### PR TITLE
Update default highlight.js CSS reference

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   css: [
     'normalize.css',
-    'highlight.js/styles/github.css',
+    'highlight.js/styles/hybrid.css',
     { src: '~assets/scss/main.scss', lang: 'scss' }
   ],
   plugins: [


### PR DESCRIPTION
The github.css option creates unreadable *.vue code in the `FilesTree` component. hybrid.css is the option used by the production site.

**Before**

<img width="891" alt="screen shot 2017-03-24 at 10 31 16 am" src="https://cloud.githubusercontent.com/assets/437535/24306408/b6c41b3e-107d-11e7-9f0b-90370d05da33.png">

**After**

<img width="884" alt="screen shot 2017-03-24 at 10 36 45 am" src="https://cloud.githubusercontent.com/assets/437535/24306442/cfac9838-107d-11e7-8584-7c5700631589.png">