### PR TITLE
Removed link to the Medium blog

### DIFF
--- a/components/HeaderNavMenuDropdown.vue
+++ b/components/HeaderNavMenuDropdown.vue
@@ -34,11 +34,6 @@ export default {
           target: '_blank'
         },
         {
-          name: this.$store.state.lang.links.blog,
-          path: 'https://medium.com/@nuxt_js',
-          target: '_blank'
-        },
-        {
           name: this.$store.state.lang.links.chat,
           path: 'https://gitter.im/nuxt/nuxt.js',
           target: '_blank'


### PR DESCRIPTION
I think that we no longer need it since when going to the URL, there appears message: "The user deleted their Medium account" ;)