### PR TITLE
Footer appearance

### DIFF
--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -34,7 +34,9 @@ export default {
 <style lang="scss" scoped>
 .Landscape
 {
-  min-height: 100vh;
+  $footer-height: 50px;
+
+  min-height: calc(100vh - #{$footer-height});
   background-color: #fff;
   padding: 50px 15px;
   padding-top: 120px;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -61,7 +61,9 @@ export default {
 <style lang="scss" scoped>
 .Landscape
 {
-  min-height: 100vh;
+  $footer-height: 50px;
+
+  min-height: calc(100vh - #{$footer-height});
   background-color: #fff;
   padding: 70px 15px;
   padding-top: 100px;


### PR DESCRIPTION
# Footer appearance

## Brief
I've noticed that on an _index_ and _error_ pages you can't see a footer, although there is still plenty of room to show it. 

## Links to reproduce a bug
- https://nuxtjs.org
- https://nuxtjs.org/error

## Changes
Fixed footer appearance on `index` and `error` pages