### PR TITLE
fix: styling for version number on homepage

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -127,6 +127,7 @@ export default {
       padding-bottom: 0;
       span {
         font-weight: 400;
+        width: auto;
       }
     }
   }


### PR DESCRIPTION
Version number on Github link is improperly styled. Updated scoped CSS with `width: auto`.