### PR TITLE
Convert schemas to SVGs

### DIFF
--- a/static/nuxt-schema.svg
+++ b/static/nuxt-schema.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="460" height="600" version="1" viewBox="0 0 460 600">
+  <g fill="none" fill-rule="evenodd" font-family="Source Sans Pro, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif" text-anchor="middle">
+    <path stroke="#737373" stroke-linecap="square" stroke-width="2" d="M365 250H260m105 0v122"/>
+    <path fill="#737373" d="M250 250l15-4v8z"/>
+    <path stroke="#737373" stroke-linecap="square" stroke-width="2" d="M365 555H249m116-124v124"/>
+    <path stroke="#9B9B9B" stroke-linecap="square" stroke-width="2" d="M149 69v21"/>
+    <path fill="#9B9B9B" d="M149 100l-4-11h8z"/>
+    <path stroke="#9B9B9B" stroke-linecap="square" stroke-width="2" d="M149 169v21"/>
+    <path fill="#9B9B9B" d="M149 200l-4-11h8z"/>
+    <path stroke="#9B9B9B" stroke-linecap="square" stroke-width="2" d="M149 299v21"/>
+    <path fill="#9B9B9B" d="M149 330l-4-11h8z"/>
+    <path stroke="#9B9B9B" stroke-linecap="square" stroke-width="2" d="M149 399v21"/>
+    <path fill="#9B9B9B" d="M149 430l-4-11h8z"/>
+    <path stroke="#9B9B9B" stroke-linecap="square" stroke-width="2" d="M149 499v21"/>
+    <path fill="#9B9B9B" d="M149 530l-4-11h8z"/>
+    <g transform="translate(50 20)" letter-spacing="0.05rem">
+      <rect width="198" height="48" x="1" y="1" stroke="#05668D" stroke-width="2" rx="20"/>
+      <text x="100" y="31" fill="#00658F" font-size="19" font-weight="500">
+        Incoming
+      </text>
+    </g>
+    <g transform="translate(50 100)" fill="#FFF" letter-spacing="0.05rem">
+      <rect width="200" height="70" fill="#05668D" rx="20"/>
+      <text x="100" y="31" font-size="19" font-weight="500">
+        nuxtServerInit
+      </text>
+      <text x="100" y="52" font-size="14" font-weight="300">
+        Store action
+      </text>
+    </g>
+    <g transform="translate(50 200)" fill="#FFF">
+      <rect width="200" height="100" fill="#028090" rx="20"/>
+      <text x="100" y="31" font-size="19" font-weight="500" letter-spacing="0.05rem">
+        middleware
+      </text>
+      <text font-size="14" font-weight="300" text-anchor="start">
+        <tspan x="18" y="52">1. nuxt.config.js</tspan>
+        <tspan x="18" y="68">2. matching layout</tspan>
+        <tspan x="18" y="84">3. matching page &amp; children</tspan>
+      </text>
+    </g>
+    <g transform="translate(50 330)" letter-spacing="0.05rem" fill="#FFF">
+      <rect width="200" height="70" fill="#00A896" rx="20"/>
+      <text x="100" y="31" font-size="19" font-weight="500">
+        validate()
+      </text>
+      <text x="100" y="52" font-size="14" font-weight="300">
+        Pages &amp; children
+      </text>
+    </g>
+    <g transform="translate(50 430)" fill="#FFF" letter-spacing="0.05rem">
+      <rect width="200" height="70" fill="#02C39A" rx="20"/>
+      <text x="101" y="31" font-size="18" font-weight="500">
+        asyncData() &amp; fetch()
+      </text>
+      <text x="100" y="52" font-size="14" font-weight="300">
+        Pages &amp; children
+      </text>
+    </g>
+    <g transform="translate(50 530)" letter-spacing="0.05rem">
+      <rect width="198" height="48" x="1" y="1" stroke="#5CA4A9" stroke-width="2" rx="20"/>
+      <text x="100" y="31" fill="#5CA4A9" font-size="19" font-weight="500">
+        Render
+      </text>
+    </g>
+    <g transform="translate(301 372)" letter-spacing="0.05rem">
+      <rect width="128" height="58" x="1" y="1" stroke="#737373" stroke-width="2" rx="20"/>
+      <text x="65" y="28" fill="#737373" font-size="17" font-weight="500">
+        Navigate
+      </text>
+      <text x="65" y="45" fill="#737373" font-size="14" font-weight="300">
+        &lt;nuxt-link&gt;
+      </text>
+    </g>
+  </g>
+</svg>

--- a/static/nuxt-schema.svg
+++ b/static/nuxt-schema.svg
@@ -16,7 +16,7 @@
     <g transform="translate(50 20)" letter-spacing="0.05rem">
       <rect width="198" height="48" x="1" y="1" stroke="#05668D" stroke-width="2" rx="20"/>
       <text x="100" y="31" fill="#00658F" font-size="19" font-weight="500">
-        Incoming
+        Incoming Request
       </text>
     </g>
     <g transform="translate(50 100)" fill="#FFF" letter-spacing="0.05rem">

--- a/static/nuxt-views-schema.svg
+++ b/static/nuxt-views-schema.svg
@@ -44,10 +44,10 @@
       </g>
       <g transform="translate(45 0)">
         <text>
-          <tspan x="175" y="293">Optional - Page Child</tspan>
+          <tspan x="175" y="287">Optional - Page Child</tspan>
         </text>
         <text font-size="15">
-          <tspan x="175" y="314">Vue component supercharges with Nuxt options</tspan>
+          <tspan x="175" y="312">Vue component supercharges with Nuxt options</tspan>
         </text>
       </g>
       <text x="580" y="270">

--- a/static/nuxt-views-schema.svg
+++ b/static/nuxt-views-schema.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <g fill="none" fill-rule="evenodd" font-family="Source Sans Pro, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, sans-serif" font-size="21" font-weight="300" text-anchor="middle">
+    <rect width="800" height="400" fill="#41B883"/>
+    <rect width="770" height="335" x="15" y="50" fill="#3B8070"/>
+    <rect width="740" height="270" x="30" y="100" fill="#35495E"/>
+    <rect width="350" height="120" x="45" y="235" fill="#495B6E"/>
+    <rect width="350" height="55" x="405" y="300" fill="#495B6E"/>
+    <rect width="350" height="55" x="405" y="235" fill="#495B6E"/>
+    <g fill="#EEF0F1">
+      <text x="400" y="32">
+        <tspan>Document - </tspan> <tspan font-size="19">HTML file</tspan>
+      </text>
+      <text x="400" y="82">
+        <tspan>Layout - </tspan> <tspan font-size="17">Vue component + Nuxt options: middleware and head</tspan>
+      </text>
+      <text x="400" y="132">
+        <tspan>Page - </tspan> <tspan font-size="17">Vue component supercharges with Nuxt options</tspan>
+      </text>
+      <g text-anchor="start">
+        <text>
+          <tspan x="56" y="178">• </tspan> <tspan x="79" y="178" font-size="17">asyncData</tspan>
+        </text>
+        <text>
+          <tspan x="56" y="200">• </tspan> <tspan x="79" y="200" font-size="17">middleware</tspan>
+        </text>
+        <text>
+          <tspan x="231" y="178">• </tspan> <tspan x="254" y="178" font-size="17">fetch</tspan>
+        </text>
+        <text>
+          <tspan x="231" y="200">• </tspan> <tspan x="254" y="200" font-size="17">scrollToTop</tspan>
+        </text>
+        <text>
+          <tspan x="410" y="178">• </tspan> <tspan x="433" y="178" font-size="17">head</tspan>
+        </text>
+        <text>
+          <tspan x="410" y="200">• </tspan> <tspan x="433" y="200" font-size="17">transition</tspan>
+        </text>
+        <text>
+          <tspan x="589" y="178">• </tspan> <tspan x="612" y="178" font-size="17">layout</tspan>
+        </text>
+        <text>
+          <tspan x="589" y="200">• </tspan> <tspan x="612" y="200" font-size="17">validate</tspan>
+        </text>
+      </g>
+      <g transform="translate(45 0)">
+        <text>
+          <tspan x="175" y="293">Optional - Page Child</tspan>
+        </text>
+        <text font-size="15">
+          <tspan x="175" y="314">Vue component supercharges with Nuxt options</tspan>
+        </text>
+      </g>
+      <text x="580" y="270">
+        <tspan>Optional - </tspan> <tspan font-size="15">Vue Component + Nuxt option: head</tspan>
+      </text>
+      <text x="580" y="335">
+        <tspan>Optional - </tspan> <tspan font-size="15">Vue Component + Nuxt option: head</tspan>
+      </text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This PR includes two changes:

1. Converted [nuxt-schema.svg](https://github.com/patrickdaze/nuxtjs.org/blob/convert-to-svg/static/nuxt-schema.svg). It can be found on this page: https://nuxtjs.org/guide
2. Converted [nuxt-views-schema.svg](https://github.com/patrickdaze/nuxtjs.org/blob/convert-to-svg/static/nuxt-views-schema.svg). It can be found on this page: https://nuxtjs.org/guide/views

This PR does not update the text/content of the schemas. It only tries to replicate the same style and text as the original PNGs. The fonts used are the same as in [_document.scss](https://github.com/nuxt/nuxtjs.org/blob/master/assets/scss/base/_document.scss#L15).

Next Step: Once the PR is pulled-in and deployed, I'll create another PR on the nuxt-docs repo to update image links: [I started that here](https://github.com/nuxt/docs/compare/master...patrickdaze:convert-to-svg). I might also have to do a PR to individual translation repos (will investigate).

---

See Issue #104 or https://cmty.app/nuxt/nuxtjs.org/issues/c99