### PR TITLE
Fixed displaying translations of each country on dev mode.

### DIFF
--- a/plugins/init.js
+++ b/plugins/init.js
@@ -14,6 +14,10 @@ export default async function ({ isDev, env, req, store: { commit, state }, redi
     // If url like ja.nuxtjs.org
     if (hostParts.length === 2) {
       if (hostParts[0] === 'www') return redirect(301, 'https://nuxtjs.org' + req.url)
+
+      if (isDev) {
+        commit('setLocale', hostParts[0])
+      }
     }
   } else {
     // Used with nuxt generate


### PR DESCRIPTION
Hi nuxtjs.org authors.

First, thank you for awesome documents.

When I ran this codes as dev mode(`npm run dev`), I coundn't watch the japanese transations. So I fixed the codes.

Since `dev mode` is `SSR`,  `setLocale` is never called.

Please feel free to merge it.
Thx :)
