### PR TITLE
Fix README start command to use `yarn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Update your `/etc/hosts` to have the following lines:
 Then on another tab, start a dev server on `http://nuxt:3000`
 
 ```bash
-npm install
-npm run dev
+yarn install
+yarn run dev
 ```


### PR DESCRIPTION
Because there is a `yarn.lock` file.