### PR TITLE
Fix cwd of watch directory in 'docs' module

### DIFF
--- a/modules/docs/server.js
+++ b/modules/docs/server.js
@@ -37,7 +37,7 @@ class DocsServer {
     ])
 
     if (this.watch) {
-      this.watchFiles()
+      this.watchFiles(this.docsDir)
     }
   }
 


### PR DESCRIPTION
When setting up as README says and running `yarn dev`, an initial build works but errors are reported on update/add documents.

```
 ERROR  ENOENT: no such file or directory, open '/path/to/nuxtjs.org/docs/docs/en/api/pages-watchquery.md'
```

As the error message says, it's looking for a wrong file path.

```
Expected: /path/to/nuxtjs.org/docs/en/api/pages-watchquery.md
Actual:   /path/to/nuxtjs.org/docs/docs/en/api/pages-watchquery.md
```

You can see `docs` is duplicated.

After some investigation, I found that the [`cwd`](https://github.com/nuxt/nuxtjs.org/blob/master/modules/docs/server.js#L237-L241) parameter is not used in `watchFiles()`. I guess it should watch files in the document directory?

I confirmed build and watch work fine with the fix, in my local machine.