### PR TITLE
Make anchor icon visible on focus

### DIFF
--- a/assets/scss/theme/_content.scss
+++ b/assets/scss/theme/_content.scss
@@ -26,6 +26,11 @@
         vertical-align: middle;
         visibility: hidden;
       }
+      &:focus {
+        svg {
+          visibility: visible;
+        }
+      }
     }
     &:hover {
       a.anchor svg {


### PR DESCRIPTION
Just a small accessibility fix to add visibility to the anchor icon on `:focus`. 

Before:
![image](https://user-images.githubusercontent.com/1131579/58938308-d326c400-8774-11e9-84f7-9085397f845b.png)


After:
![image](https://user-images.githubusercontent.com/1131579/58938209-a2468f00-8774-11e9-9351-efacdaaead9a.png)
