### PR TITLE
Fix: heading underlines

### DIFF
--- a/assets/css/themes/light/headings.css
+++ b/assets/css/themes/light/headings.css
@@ -18,24 +18,18 @@ body {
     }
     & h1 {
       @apply text-nuxt-gray relative text-3xl inline-block mb-8;
-      &::before {
+      &::after {
         content: " ";
         width: 80%;
-        height: 4px;
-        top: 3.25rem;
-        left: 0;
-        @apply rounded absolute bg-nuxt-lightgreen;
+        @apply block border-2 border-nuxt-lightgreen my-2 rounded;
       }
     }
     & h2 {
       @apply text-nuxt-gray relative text-2xl inline-block my-8;
-      &::before {
+      &::after {
         content: " ";
         width: 80%;
-        height: 4px;
-        top: 3rem;
-        left: 0;
-        @apply rounded absolute bg-nuxt-green;
+        @apply block border-2 border-nuxt-green my-2 rounded;
       }
       & code {
         @apply text-xl;
@@ -46,13 +40,10 @@ body {
     }
     & h3 {
       @apply text-nuxt-gray relative text-xl inline-block my-8;
-      &::before {
+      &::after {
         content: " ";
         width: 80%;
-        height: 4px;
-        top: 2.5rem;
-        left: 0;
-        @apply rounded absolute bg-gray-600;
+        @apply block border-2 border-gray-600 my-2 rounded;
       }
       & code {
         @apply text-lg;


### PR DESCRIPTION
### Context:
The horizontal lines below headings in the docs are floating in the middle of the text if the headings span multiple lines:

![nuxtjs_headings_issue](https://user-images.githubusercontent.com/15672948/65915035-da807600-e3d2-11e9-9443-af7c909f73e0.png)
 

### Change(s):

I've changed the `::before` pseudo-element added to each heading level to be `::after` and made it a block element with a border colour matching the background colour it had before. It will now always be below the text

![nuxtjs_headings_fix](https://user-images.githubusercontent.com/15672948/65915211-44991b00-e3d3-11e9-8c51-afb454cbcf49.png)

