### PR TITLE
Fix links in mobile navigation

### DIFF
--- a/components/partials/Header.vue
+++ b/components/partials/Header.vue
@@ -43,10 +43,10 @@
     <!-- Mobile Main Navigation -->
     <nav class="header_mobile_nav block lg:hidden">
       <nui-container class="flex justify-between">
-        <a v-for="link in links" :key="link" class="block md:flex p-2 md:p-4 text-nuxt-gray hover:no-underline hover:text-nuxt-lightgreen text-center visited:text-nuxt-gray" :href="{ name: 'section-slug', params: { section: action } }" @click.prevent="$emit('change', action === link ? '' : link)">
+        <nuxt-link v-for="link in links" :key="link" class="block md:flex p-2 md:p-4 text-nuxt-gray hover:no-underline hover:text-nuxt-lightgreen text-center visited:text-nuxt-gray" :to="{ name: 'section-slug', params: { section: link } }" @click.prevent="$emit('change', action === link ? '' : link)">
           <component :is="'nui-' + link + '-icon'" class="inline-block h-5 fill-current mb-1" :class="{'text-nuxt-lightgreen': action === link}"/>
           <span class="block text-xs md:text-base md:pl-3 font-medium text-nuxt-gray">{{ $store.state.lang.links[link] || link }}</span>
-        </a>
+        </nuxt-link>
       </nui-container>
     </nav>
     <!-- Mobile Aside Navigation -->


### PR DESCRIPTION
The `<a>` tags inside of the mobile navigation were incorrectly using the `to` object syntax that only works with `<router-link>` and `<nuxt-link>`. This resulted in these links broken links leading to `[object Object]`:

![](https://user-images.githubusercontent.com/29176678/65987162-94381f00-e485-11e9-956e-10e73b98e3eb.png)

I turned the tags into `<nuxt-link>`'s and changed what was passed to `params.section` because that was also incorrect.