### PR TITLE
Make text more readable on mobile + shape-outside for round SVG

### DIFF
--- a/components/partials/home/sponsors.vue
+++ b/components/partials/home/sponsors.vue
@@ -5,7 +5,7 @@
         Sponsors
       </h1>
       <i-sponsoring class="inline-block float-right ml-4" />
-      <div class="pt-6 pb-12 leading-loose">
+      <div class="pt-6 pb-12 leading-loose text-left">
         <p>
           NuxtJS is an MIT licensed open source project and completely free to use.
           However, the amount of effort needed to maintain and develop new features for the project is not sustainable without proper financial backing.
@@ -66,7 +66,7 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 .sponsor {
   & img {
     opacity: 0.75;

--- a/components/partials/home/sponsors.vue
+++ b/components/partials/home/sponsors.vue
@@ -1,10 +1,10 @@
 <template>
   <nui-container class="py-12 text-center">
     <section class="px-4">
-      <h1 class="text-3xl uppercase">
+      <h1 class="text-3xl uppercase mb-2 sm:mb-0">
         Sponsors
       </h1>
-      <i-sponsoring class="inline-block float-right ml-4" />
+      <i-sponsoring id="sponsor-img" class="inline-block float-right lg:ml-4" />
       <div class="pt-6 pb-12 leading-loose text-left">
         <p>
           NuxtJS is an MIT licensed open source project and completely free to use.
@@ -79,5 +79,8 @@ export default {
       filter: grayscale(0%);
     }
   }
+}
+#sponsor-img {
+  shape-outside: circle(49.5% at 90px 95px);
 }
 </style>

--- a/components/partials/home/why.vue
+++ b/components/partials/home/why.vue
@@ -10,14 +10,14 @@
           <h4 class="uppercase text-2xl py-8">
             {{ $store.state.homepage.why_modular.attrs.title }}
           </h4>
-          <p class="leading-loose text-justify" v-html="$store.state.homepage.why_modular.body" />
+          <p class="leading-loose text-left sm:text-justify" v-html="$store.state.homepage.why_modular.body" />
         </div>
         <div class="lg:w-1/3 px-4 py-8 lg:p-8 text-center">
           <i-performant class="inline-block" />
           <h4 class="uppercase text-2xl py-8">
             {{ $store.state.homepage.why_performant.attrs.title }}
           </h4>
-          <p class="leading-loose text-justify" v-html="$store.state.homepage.why_performant.body" />
+          <p class="leading-loose text-left sm:text-justify" v-html="$store.state.homepage.why_performant.body" />
         </div>
         <div class="lg:w-1/3 px-4 py-8 lg:p-8 text-center">
           <i-enjoyable class="inline-block" />


### PR DESCRIPTION
On mobile (tablet and desktop are fine), when the text is justified, it sometimes leaves big gaps:
![image](https://user-images.githubusercontent.com/1411843/66009212-61cef780-e46e-11e9-9ac7-5403ffe91555.png)

We could also center align it, but I feel that a left aligned text is more readable.

As for the text about sponsoring, I suggest having it always left aligned.

PS: I love the redesign with Tailwind 😍