### PR TITLE
Using mousetrap to focus on search input field via '/' #233

### DIFF
--- a/components/partials/Search.vue
+++ b/components/partials/Search.vue
@@ -30,6 +30,12 @@ export default {
     }
   },
   mounted () {
+    const mousetrap = require('mousetrap')
+    mousetrap.bind('/', function (e) {
+      e.preventDefault()
+      document.getElementById('algolia').focus()
+    })
+
     onScriptLoaded(() => this.addInstantSearch())
     if (scriptInjected) { return }
     // Load JS

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.15",
     "marked": "^0.7.0",
     "micro": "^9.3.4",
+    "mousetrap": "^1.6.3",
     "node-fetch": "^2.6.0",
     "normalize.css": "^8.0.1",
     "nuxt": "^2.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5606,6 +5606,11 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mousetrap@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.3.tgz#80fee49665fd478bccf072c9d46bdf1bfed3558a"
+  integrity sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
Added mousetrap via yarn (`yarn add mousetrap`). 
Bound `/` to focus on the text field.
Tested in chrome, firefox and safari.

---

How should I go about changing the seach text? I see that they are in a separate repo
https://github.com/nuxt/docs

Shall I send a PR for that? How should translations be handled?