### PR TITLE
On mobile, align paragraphs to the left

### DIFF
--- a/components/partials/home/modes.vue
+++ b/components/partials/home/modes.vue
@@ -10,21 +10,21 @@
           <h4 class="text-center uppercase text-2xl pt-8 pb-4">
             {{ $store.state.homepage.modes_server_side_rendering.attrs.content_title }}
           </h4>
-          <p class="leading-loose text-justify" v-html="$store.state.homepage.modes_server_side_rendering.body" />
+          <p class="leading-loose text-left sm:text-justify" v-html="$store.state.homepage.modes_server_side_rendering.body" />
         </div>
         <div class="lg:w-1/2 p-4 lg:p-8">
           <i-snow class="mx-auto my-8 w-32"/>
           <h4 class="text-center uppercase text-2xl pt-8 pb-4">
             {{ $store.state.homepage.modes_statically_generated.attrs.content_title }}
           </h4>
-          <p class="leading-loose text-justify" v-html="$store.state.homepage.modes_statically_generated.body" />
+          <p class="leading-loose text-left sm:text-justify" v-html="$store.state.homepage.modes_statically_generated.body" />
         </div>
       </div>
       <div class="px-4 lg:p-8">
         <h4 class="uppercase text-2xl pt-8 pb-4">
           {{ $store.state.homepage.modes_single_page_app.attrs.content_title }}
         </h4>
-        <p class="leading-loose text-justify" v-html="$store.state.homepage.modes_single_page_app.body" />
+        <p class="leading-loose text-left sm:text-justify" v-html="$store.state.homepage.modes_single_page_app.body" />
       </div>
     </section>
   </nui-container>

--- a/components/partials/home/why.vue
+++ b/components/partials/home/why.vue
@@ -24,7 +24,7 @@
           <h4 class="uppercase text-2xl py-8">
             {{ $store.state.homepage.why_enjoyable.attrs.title }}
           </h4>
-          <p class="leading-loose text-justify" v-html="$store.state.homepage.why_enjoyable.body" />
+          <p class="leading-loose text-left sm:text-justify" v-html="$store.state.homepage.why_enjoyable.body" />
         </div>
       </div>
       <div class="text-center">


### PR DESCRIPTION
In my previous pull request (https://github.com/nuxt/nuxtjs.org/pull/244), I missed a few paragraphs.