### PR TITLE
fix: correct github spelling

### DIFF
--- a/components/partials/Footer.vue
+++ b/components/partials/Footer.vue
@@ -75,7 +75,7 @@ export default {
           { key: 'A worldwide team', to: '/team' }
         ],
         follow: [
-          { key: 'Github', href: 'https://github.com/nuxt/nuxt.js' },
+          { key: 'GitHub', href: 'https://github.com/nuxt/nuxt.js' },
           { key: 'Twitter', href: 'https://twitter.com/nuxt_js' },
           { key: 'Discord', href: 'https://discord.nuxtjs.org' }
         ],


### PR DESCRIPTION
This pull requests changes `Github` to `GitHub` in footer to match the official spelling and the way it's written in other parts of the website.