### PR TITLE
Add dev.to link to links/follow in footer partial

### DIFF
--- a/components/partials/Footer.vue
+++ b/components/partials/Footer.vue
@@ -77,7 +77,8 @@ export default {
         follow: [
           { key: 'Github', href: 'https://github.com/nuxt/nuxt.js' },
           { key: 'Twitter', href: 'https://twitter.com/nuxt_js' },
-          { key: 'Discord', href: 'https://discord.nuxtjs.org' }
+          { key: 'Discord', href: 'https://discord.nuxtjs.org' },
+          { key: 'DEV Community', href: 'https://dev.to/t/nuxt' }
         ],
         support: [
           { key: 'Sponsor NuxtJS', to: '/sponsor-nuxtjs' },


### PR DESCRIPTION
This pull request adds a link for the Nuxt tag on DEV. DEV.to is an amazing online community for programmers and developers of all kind with close to 10 million unique monthly visitors. 
Links to the DEV Community can also be found on vuejs.org making this a perfect symbiosis.

There are new posts consistently flowing into the tag and this will help both Nuxt and the DEV Community to increase their reach and help develop both projects.

If this is not the right place for the link or the wording is not what you want, let me know what might be more appropriate. Thanks a lot!

Code for the platform can be found here:
https://github.com/thepracticaldev/dev.to