### PR TITLE
Fix mobile aside navigation

### DIFF
--- a/components/partials/Header.vue
+++ b/components/partials/Header.vue
@@ -43,7 +43,7 @@
     <!-- Mobile Main Navigation -->
     <nav class="header_mobile_nav block lg:hidden">
       <nui-container class="flex justify-between">
-        <nuxt-link v-for="link in links" :key="link" class="block md:flex p-2 md:p-4 text-nuxt-gray hover:no-underline hover:text-nuxt-lightgreen text-center visited:text-nuxt-gray" :to="{ name: 'section-slug', params: { section: link } }" @click.prevent="$emit('change', action === link ? '' : link)">
+        <nuxt-link v-for="link in links" :key="link" class="block md:flex p-2 md:p-4 text-nuxt-gray hover:no-underline hover:text-nuxt-lightgreen text-center visited:text-nuxt-gray" :to="{ name: 'section-slug', params: { section: link } }" @click.prevent.native="$emit('change', action === link ? '' : ($route.params.section !== link ? '' : link))">
           <component :is="'nui-' + link + '-icon'" class="inline-block h-5 fill-current mb-1" :class="{'text-nuxt-lightgreen': action === link}"/>
           <span class="block text-xs md:text-base md:pl-3 font-medium text-nuxt-gray">{{ $store.state.lang.links[link] || link }}</span>
         </nuxt-link>


### PR DESCRIPTION
There was a conflict between `nuxt-link` and the `click` event that prevented the event to be fired.
I added the `native` modifier to fix that.
I also made sure that the action to open the aside navigation is not triggered if we are changing pages.

Closes #253 
