### PR TITLE
Fixes horizontal stacking of headings (h1-3) in body of guide articles

### DIFF
--- a/assets/css/themes/light/headings.css
+++ b/assets/css/themes/light/headings.css
@@ -17,7 +17,7 @@ body {
       }
     }
     & h1 {
-      @apply text-nuxt-gray relative text-3xl inline-block mb-8;
+      @apply text-nuxt-gray relative text-3xl table mb-8;
       &::after {
         content: " ";
         width: 80%;
@@ -25,7 +25,7 @@ body {
       }
     }
     & h2 {
-      @apply text-nuxt-gray relative text-2xl inline-block my-8;
+      @apply text-nuxt-gray relative text-2xl table my-8;
       &::after {
         content: " ";
         width: 80%;
@@ -39,7 +39,7 @@ body {
       }
     }
     & h3 {
-      @apply text-nuxt-gray relative text-xl inline-block my-8;
+      @apply text-nuxt-gray relative text-xl table my-8;
       &::after {
         content: " ";
         width: 80%;

--- a/assets/css/themes/light/headings.css
+++ b/assets/css/themes/light/headings.css
@@ -21,7 +21,7 @@ body {
       &::after {
         content: " ";
         width: 80%;
-        @apply block border-2 border-nuxt-lightgreen my-2 rounded;
+        @apply block border-2 border-nuxt-lightgreen mt-2 mb-1 rounded;
       }
     }
     & h2 {
@@ -29,7 +29,7 @@ body {
       &::after {
         content: " ";
         width: 80%;
-        @apply block border-2 border-nuxt-green my-2 rounded;
+        @apply block border-2 border-nuxt-green mt-2 mb-1 rounded;
       }
       & code {
         @apply text-xl;
@@ -43,7 +43,7 @@ body {
       &::after {
         content: " ";
         width: 80%;
-        @apply block border-2 border-gray-600 my-2 rounded;
+        @apply block border-2 border-gray-600 mt-2 mb-1 rounded;
       }
       & code {
         @apply text-lg;


### PR DESCRIPTION
#267 

Simply setting headings from `display: inline-block` to `display: table` fixes the issue. I can't test on Safari, but latest Firefox/Chrome/Edge/IE seem OK.

I am new contributor so I am not sure if such styling is used anywhere else.