### PR TITLE
Improve menu on iPhone X / 11

### DIFF
--- a/components/partials/MobileMainNavigation.vue
+++ b/components/partials/MobileMainNavigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="fixed h-16 bg-light-elevatedSurface dark:bg-dark-elevatedSurface border-t left-0 bottom-0 right-0 z-30 border-light-border dark:border-dark-border block lg:hidden transition-colors duration-300 ease-linear">
+  <nav class="fixed bg-light-elevatedSurface dark:bg-dark-elevatedSurface border-t left-0 bottom-0 right-0 z-30 border-light-border dark:border-dark-border block lg:hidden transition-colors duration-300 ease-linear">
     <div class="flex justify-between items-center h-full">
       <template v-for="link in headerLinks">
         <nuxt-link v-if="link.type === 'dynamic'" :key="link.slug" class="block md:flex md:justify-center w-full p-2 md:p-4 text-light-onSurfacePrimary dark:text-dark-onSurfacePrimary hover:no-underline hover:text-primary-base dark:hover:text-primary-base text-center visited:text-nuxt-gray transition-colors duration-300 ease-linear" :to="{ name: link.routeName, params: { section: link.slug } }">
@@ -48,4 +48,9 @@ export default {
 /*.header_mobile_nav a {
   padding-bottom: max(0.5rem,env(safe-area-inset-bottom));
 }*/
+
+nav {
+  padding-bottom: constant(safe-area-inset-bottom);
+  padding-bottom: env(safe-area-inset-bottom);
+}
 </style>

--- a/components/partials/MobileMainNavigation.vue
+++ b/components/partials/MobileMainNavigation.vue
@@ -45,10 +45,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-/*.header_mobile_nav a {
-  padding-bottom: max(0.5rem,env(safe-area-inset-bottom));
-}*/
-
 nav {
   padding-bottom: constant(safe-area-inset-bottom);
   padding-bottom: env(safe-area-inset-bottom);

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -5,7 +5,7 @@ export default {
   head: {
     meta: [
       { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1' }
+      { name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' }
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },


### PR DESCRIPTION
By removing the fixed height of the nav element and adding padding-bottom via constant/env values we have correct functioning spacing on iPhone X / 11 after scroll. 
Adding the 'viewport-fit=cover' value to the viewport meta tag makes the padding work.