### PR TITLE
added 'Edit this page on Github' to blog pages.

### DIFF
--- a/components/common/AppContribute.vue
+++ b/components/common/AppContribute.vue
@@ -38,6 +38,7 @@ export default {
       return '/' + this.$route.params.section
     },
     list () {
+      if (!this.$route.params.section) { return [] }
       return this.$store.state.menu[this.$route.params.section].reduce((links, section) => links.concat(section.links), [])
     },
     lastPathPart () {

--- a/pages/blog/_slug.vue
+++ b/pages/blog/_slug.vue
@@ -10,6 +10,7 @@
       </NuxtLink>
       <BlogpostItem :post="post" />
       <BlogpostNavigationLinks :links="post.links" />
+      <AppContribute :doc-link="docLink" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
1) Added 'Edit this page on Github' on blog pages.
2) The AppContribute comp should probably be tweaked long-term as it contains things like page links that seem to make it less reusable.
3) The phrase 'want to contribute to the documentation' is a little weird for blog pages, but 'meh' for now.