### PR TITLE
Fix Exit Button Visibility In Dark Mode

### DIFF
--- a/components/global/bases/AppModal.vue
+++ b/components/global/bases/AppModal.vue
@@ -84,6 +84,7 @@ export default {
 <style>
 .svg {
   width: 20px;
+  color: black;
 }
 
 .modal-mask {


### PR DESCRIPTION
When using dark mode it was hard for me to find the exit button, and I had to refresh the page to exit the image. I added a simple css fix that I checked across multiple images in the new docs. 

This PR is a fix for issue [411](https://github.com/nuxt/nuxtjs.org/issues/411)