### PR TITLE
Optimize english documentation

### DIFF
--- a/content/en/guides/get-started/conclusion.md
+++ b/content/en/guides/get-started/conclusion.md
@@ -65,7 +65,7 @@ questions:
     correctAnswer: True
 ---
 
-Congratulations you have now created your first Nuxt.js app and you may now consider yourself a Nuxter. But there is so much more to learn and so much more you can do with Nuxt.js. Here are a few recommendations.
+Congratulations! You have now created your first Nuxt.js app and you may now consider yourself a Nuxter, but there is so much more to learn and so much more you can do with Nuxt.js. Here are a few recommendations:
 
 <base-alert type="next">
 

--- a/content/en/guides/get-started/installation.md
+++ b/content/en/guides/get-started/installation.md
@@ -83,3 +83,162 @@ Once the `package.json` has been created, add `nuxt` to your project via `npm` o
 ```bash
 yarn add nuxt
 ```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+npm install nuxt
+```
+
+  </code-block>
+</code-group>
+
+This command will add `nuxt` as a dependency to your project and it will add it to your `package.json` automatically. The `node_modules` directory will also be created which is where all your installed packages and their dependencies are stored.
+
+<base-alert type="info">
+
+A `yarn.lock` or `package-lock.json` is also created which ensures a consistent install and compatible dependencies of your packages installed in your project.
+
+</base-alert>
+
+### Create your first page
+
+Nuxt.js transforms every `*.vue` file inside the `pages` directory as a route for the application.
+
+Create the `pages` directory in your project:
+
+```bash
+mkdir pages
+```
+
+Then, create an `index.vue` file in the `pages` directory:
+
+```bash
+touch pages/index.vue
+```
+
+It is important that this page is called `index.vue` as this will be the default page Nuxt shows when the application opens. It is the home page and it must be called index.
+
+Open the `index.vue` file in your editor and add the following content:
+
+```html{}[pages/index.vue]
+<template>
+  <h1>Hello world!</h1>
+</template>
+```
+
+### Start the project
+
+Run your project by typing one of the following commands below in your terminal:
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn dev
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+npm run dev
+```
+
+  </code-block>
+</code-group>
+
+<base-alert type="info">
+
+We use the the dev command when running our application in development mode.
+
+</base-alert>
+
+The application is now running on **[http://localhost:3000](http://localhost:3000/).**
+
+Open it in your browser by clicking the link in your terminal and you should see the text "Hello World" we copied in the previous step.
+
+<base-alert type="info">
+
+When launching Nuxt.js in development mode, it will listen for file changes in most directories, so there is no need to restart the application when e.g. adding new pages
+
+</base-alert>
+
+<base-alert type="warning">
+
+When you run the dev command it will create .nuxt folder. This folder should be ignored from version control. You can ignore files by creating a .gitignore file at the root level and adding .nuxt.
+
+</base-alert>
+
+### Bonus step
+
+Create a page named `fun.vue` in the `pages` directory.
+
+Add a `<template></template>` and include a heading with a funny sentence inside.
+
+Then, go to your browser and see your new page on **[http://localhost:3000/fun](http://localhost:3000/fun).**
+
+<base-alert type="info">
+
+Create a directory name `more-fun` and put an `index.vue` file inside. This will give the same result as creating a `more-fun.vue` file
+
+</base-alert>
+
+<app-modal>
+  <code-sandbox  :src="csb_link"></code-sandbox>
+</app-modal>
+
+## Using create-nuxt-app
+
+To get started quickly you can use the [create-nuxt-app](https://github.com/nuxt/create-nuxt-app).
+
+Make sure you have npx installed (npx is shipped by default since NPM 5.2.0) or npm v6.1 or yarn.
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn create nuxt-app <project-name>
+```
+
+  </code-block>
+  <code-block label="NPX">
+
+```bash
+npx create-nuxt-app <project-name>
+```
+
+  </code-block>
+    <code-block label="NPM">
+
+```bash
+npm init nuxt-app <project-name>
+```
+
+  </code-block>
+
+</code-group>
+
+It will ask you some questions (name, Nuxt options, UI framework, TypeScript, linter, testing framework, etc.), when answered, it will install all the dependencies. The next step is to navigate to the project folder and launch it:
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+cd <project-name>
+yarn dev
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+cd <project-name>
+npm run dev
+```
+
+  </code-block>
+</code-group>
+
+The application is now running on [http://localhost:3000](http://localhost:3000). Well done!

--- a/content/en/guides/get-started/installation.md
+++ b/content/en/guides/get-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: There is not much you need in order to get started with Nuxt.js. Below you will find a few recommendations and then we will walk you through the 4 steps so you can have your first Nuxt.js project up and and running in no time.
+description: Here, you will find information on setting up and running a Nuxt.js project in 4 steps.
 position: 1
 category: get-started
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/01_installation?fontsize=14&hidenavigation=1&theme=dark
@@ -8,11 +8,11 @@ csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/
 
 ## Prerequisites
 
-There is not much you need in order to get started with Nuxt.js. Below you will find a few recommendations. Then we will walk you through the 4 steps so you can have your first Nuxt.js project up and and running in no time.
+Here, you will find information on setting up and running a Nuxt.js project in 4 steps.
 
 <base-alert type="info">
 
-Another way to get started with Nuxt.js is to use [CodeSandbox](https://template.nuxtjs.org) which is a great way for quickly playing around with Nuxt.js or sharing your code with other people.
+Another way to get started with Nuxt.js is to use [CodeSandbox](https://template.nuxtjs.org) which is a great way for quickly playing around with Nuxt.js and/or sharing your code with other people.
 
 </base-alert>
 
@@ -24,28 +24,28 @@ _We recommend you have the latest version installed._
 
 ### Text editor
 
-Use whatever you like, but we recommend [VSCode](https://code.visualstudio.com/) and further examples will be shown with it.
+Use whatever you like, but we recommend [VSCode](https://code.visualstudio.com/).
 
 ### Terminal
 
-Use whatever you like, but we recommend to use the VSCode terminal and further examples will be shown with it.
+Use whatever you like, but we recommend using VSCode's [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal).
 
 ## Starting from scratch
 
 Creating a Nuxt.js project from scratch only requires one file and one directory.
 
-In this example we will use the terminal to create the directories and files but feel free to create them using your editor if you prefer.
+In this particular example, we will use the terminal to create the directories and files, but feel free to create them using your editor of choice.
 
 ### Set up your project
 
-To get started create an empty directory with the name of your project and navigate into it:
+To get started, create an empty directory with the name of your project and navigate into it:
 
 ```bash
 mkdir <project-name>
 cd <project-name>
 ```
 
-_Replace `<project-name>` with the name of your project._
+_Replace `<project-name>` with the name of your project._
 
 Then create a file named `package.json`:
 
@@ -67,7 +67,7 @@ Open the package.json file in your favorite code editor and fill it with this JS
 }
 ```
 
-`scripts` define Nuxt.js commands that will be launched with the command `npm run <command>`.
+`scripts` define Nuxt.js commands that will be launched with the command `npm run <command>`.
 
 #### **What is a package.json file?**
 
@@ -75,7 +75,7 @@ The `package.json` is like the ID card of your project. If you don't know what t
 
 ### Install nuxt
 
-Once the `package.json` has been created, you need to add `nuxt` to your project via the NPM or Yarn command below:
+Once the `package.json` has been created, add `nuxt` to your project via `npm` or `yarn` like so below:
 
 <code-group>
   <code-block label="Yarn" active>
@@ -83,162 +83,3 @@ Once the `package.json` has been created, you need to add `nuxt` to your pro
 ```bash
 yarn add nuxt
 ```
-
-  </code-block>
-  <code-block label="NPM">
-
-```bash
-npm install nuxt
-```
-
-  </code-block>
-</code-group>
-
-This command will add `nuxt` as a dependency to your project and it will add it to your `package.json` automatically. The `node_modules` directory will also be created which is where all your installed packages and their dependencies are stored.
-
-<base-alert type="info">
-
-A `yarn.lock` or `package-lock.json` is also created which ensures a consistent install and compatible dependencies of your packages installed in your project.
-
-</base-alert>
-
-### Create your first page
-
-Nuxt.js transforms every `*.vue` file inside the `pages` directory as a route for the application.
-
-Create the `pages` directory in your project:
-
-```bash
-mkdir pages
-```
-
-Then, create an `index.vue` file in the `pages` directory:
-
-```bash
-touch pages/index.vue
-```
-
-It is important that this page is called `index.vue` as this will be the default page Nuxt shows when the application opens. It is the home page and it must be called index.
-
-Open the `index.vue` file in your editor and add the following content:
-
-```html{}[pages/index.vue]
-<template>
-  <h1>Hello world!</h1>
-</template>
-```
-
-### Start the project
-
-Run your project by typing the NPM command below in your terminal:
-
-<code-group>
-  <code-block label="Yarn" active>
-
-```bash
-yarn dev
-```
-
-  </code-block>
-  <code-block label="NPM">
-
-```bash
-npm run dev
-```
-
-  </code-block>
-</code-group>
-
-<base-alert type="info">
-
-We use the the dev command because we are running our application in development mode.
-
-</base-alert>
-
-The application is now running on **[http://localhost:3000](http://localhost:3000/).**
-
-Open it in your browser by clicking the link in your terminal and you should see the text "Hello World" we copied in the previous step.
-
-<base-alert type="info">
-
-When launching Nuxt.js in development mode, it will listen for file changes in most directories, so there is no need to restart the application when e.g. adding new pages
-
-</base-alert>
-
-<base-alert type="warning">
-
-When you run the dev command it will create .nuxt folder. This folder should be ignored from version control. You can ignore files by creating a .gitignore file at the root level and adding .nuxt.
-
-</base-alert>
-
-### Bonus step
-
-Create a page named `fun.vue` in the `pages` directory.
-
-Add a `<template></template>` and include a heading with a funny sentence inside.
-
-Then, go to your browser and see your new page on **[http://localhost:3000/fun](http://localhost:3000/fun).**
-
-<base-alert type="info">
-
-Create a directory name `more-fun` and put an `index.vue` file inside. This will give the same result as creating a `more-fun.vue` file
-
-</base-alert>
-
-<app-modal>
-  <code-sandbox  :src="csb_link"></code-sandbox>
-</app-modal>
-
-## Using create-nuxt-app
-
-To get started quickly you can use the [create-nuxt-app](https://github.com/nuxt/create-nuxt-app).
-
-Make sure you have npx installed (npx is shipped by default since NPM 5.2.0) or npm v6.1 or yarn.
-
-<code-group>
-  <code-block label="Yarn" active>
-
-```bash
-yarn create nuxt-app <project-name>
-```
-
-  </code-block>
-  <code-block label="NPX">
-
-```bash
-npx create nuxt-app <project-name>
-```
-
-  </code-block>
-    <code-block label="NPM">
-
-```bash
-npm init nuxt-app <project-name>
-```
-
-  </code-block>
-
-</code-group>
-
-It will ask you some questions (name, Nuxt options, UI framework, TypeScript, linter, testing framework, etc.), when answered, it will install all the dependencies so the next step is to navigate to the project folder and launch it with:
-
-<code-group>
-  <code-block label="Yarn" active>
-
-```bash
-cd <project-name>
-Yarn dev
-```
-
-  </code-block>
-  <code-block label="NPM">
-
-```bash
-cd <project-name>
-npm run dev
-```
-
-  </code-block>
-</code-group>
-
-The application is now running on [http://localhost:3000](http://localhost:3000).

--- a/content/en/guides/get-started/routing.md
+++ b/content/en/guides/get-started/routing.md
@@ -8,7 +8,7 @@ csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/
 
 ## Automatic Routes
 
-Most websites have more than one page. For example a home page, about page, contact page etc. In order to show these pages we need a Router. That's where `vue-router` comes in. When working with vue application you have to set up a configuration file and add all your routes manually to it. Nuxt.js automatically generates the `vue-router` configuration for you, based on your provided Vue files inside the `pages` directory. That means you never have to write a router config again! Nuxt.js also gives you automatic code splitting for all your routes.
+Most websites will have more than one page (i.e. a home page, about page, contact page etc.). In order to show these pages, we need a Router. That's where `vue-router` comes in. When working with Vue application, you have to set up a configuration file (i.e. `router.js`) and add all your routes manually to it. Nuxt.js automatically generates the `vue-router` configuration for you, based on your provided Vue files inside the `pages` directory. That means you never have to write a router config again! Nuxt.js also gives you automatic code splitting for all your routes.
 
 In other words, all you have to do to have routing in your application is to create `.vue` files in the `pages` folder.
 
@@ -20,7 +20,13 @@ Learn more about [Routing](/guides/features/file-system-routing)
 
 ## Navigation
 
-To navigate between pages of your app, you should use the [NuxtLink](/guides/features/nuxt-components#the-nuxtlink-component) component. This component is included with Nuxt.js and therefore you don't have to import it like you do with other components. It is similar to the HTML `<a>` tag except that instead of using a `href="/about"` we use `to="/about"`. If you have used `vue-router` before, you can think of the `<NuxtLink>` as a replacement for `<RouterLink>`
+To navigate between pages of your app, you should use the [NuxtLink](/guides/features/nuxt-components#the-nuxtlink-component) component. This component is included with Nuxt.js and therefore you don't have to import it like you do with other components. It is similar to the HTML `<a>` tag, except that instead of using a `href="/about"` we use `to="/about"`. If you have used `vue-router` before, you can think of the `<NuxtLink>` as a replacement for `<RouterLink>`
+
+<base-alert type="info">
+
+Keep in mind, as you insert `<NuxtLink>` in your template, you may spell it out either as `<NuxtLink>` or `<nuxt-link>`
+
+</base-alert>
 
 A simple link to the `index.vue` page in your `pages` folder:
 
@@ -36,20 +42,20 @@ The `<NuxtLink>` component should be used for all internal links. That means for
 <template>
   <main>
     <h1>Home page</h1>
-    <NuxtLink to="/about"
-      >About (internal link that belongs to the Nuxt App)</NuxtLink
-    >
+    <NuxtLink to="/about">
+      About (internal link that belongs to the Nuxt App)
+    </NuxtLink>
     <a href="https://nuxtjs.org">External Link to another page</a>
   </main>
 </template>
 ```
 
 <app-modal>
-  <code-sandbox  :src="csb_link"></code-sandbox>
+  <code-sandbox :src="csb_link" />
 </app-modal>
 
 <base-alert type="next">
 
-Learn more about the [NuxtLink component](/guides/features/nuxt-components#the-nuxtlink-component)
+Learn more about the [NuxtLink component](/guides/features/nuxt-components#the-nuxtlink-component).
 
 </base-alert>

--- a/content/en/guides/get-started/routing.md
+++ b/content/en/guides/get-started/routing.md
@@ -22,12 +22,6 @@ Learn more about [Routing](/guides/features/file-system-routing)
 
 To navigate between pages of your app, you should use the [NuxtLink](/guides/features/nuxt-components#the-nuxtlink-component) component. This component is included with Nuxt.js and therefore you don't have to import it like you do with other components. It is similar to the HTML `<a>` tag, except that instead of using a `href="/about"` we use `to="/about"`. If you have used `vue-router` before, you can think of the `<NuxtLink>` as a replacement for `<RouterLink>`
 
-<base-alert type="info">
-
-Keep in mind, as you insert `<NuxtLink>` in your template, you may spell it out either as `<NuxtLink>` or `<nuxt-link>`
-
-</base-alert>
-
 A simple link to the `index.vue` page in your `pages` folder:
 
 ```html{}[pages/index.vue]
@@ -36,7 +30,7 @@ A simple link to the `index.vue` page in your `pages` folder:
 </template>
 ```
 
-The `<NuxtLink>` component should be used for all internal links. That means for all links to the pages within your site you should use `<NuxtLink>`. The `<a>` tag should be used for all external links. That means if you have links to other websites you should use the `<a>` tag for those.
+For all links to pages within your site, use `<NuxtLink>`. If you have links to other websites you should use the `<a>` tag. See below for an example:
 
 ```html{}[pages/index.vue]
 <template>
@@ -51,7 +45,7 @@ The `<NuxtLink>` component should be used for all internal links. That means for
 ```
 
 <app-modal>
-  <code-sandbox :src="csb_link" />
+  <code-sandbox :src="csb_link"></code-sandbox>
 </app-modal>
 
 <base-alert type="next">


### PR DESCRIPTION
I was reading the Nuxt.js documentation under the "Guides" section, thought there were a few fixes I could help with:

**Installation.md**

- one of the `create-nuxt-app` commands was misspelled.
- changed some wording to have more actionable verbiage
- changed wording so it was editor-agnostic; I think beginners will choose whatever editor they want to choose, so rather, the code  should reflect the inherent idea behind the example.

**Routing.md**

- used Vetur practices on some of the code examples
- `<NuxtLink>` can also be converted to `<nuxt-link>`

**Conclusion.md**

- made sentencing more actionable (i.e. less passive tense)