### PR TITLE
Fix: Missing hyphen in getting started using NPX.

### DIFF
--- a/content/en/guides/get-started/installation.md
+++ b/content/en/guides/get-started/installation.md
@@ -206,7 +206,7 @@ yarn create nuxt-app <project-name>
   <code-block label="NPX">
 
 ```bash
-npx create nuxt-app <project-name>
+npx create-nuxt-app <project-name>
 ```
 
   </code-block>


### PR DESCRIPTION
In installation guide, under Using create-nuxt-app, in NPX command, hyphen was missing between create and nuxt.

https://nuxtjs.org/guides/get-started/installation#using-create-nuxt-app