### PR TITLE
Fix typo: create nuxt-app -> create-nuxt-app

### DIFF
--- a/content/en/guides/get-started/installation.md
+++ b/content/en/guides/get-started/installation.md
@@ -199,14 +199,14 @@ Make sure you have npx installed (npx is shipped by default since NPM 5.2.0) or 
   <code-block label="Yarn" active>
 
 ```bash
-yarn create nuxt-app <project-name>
+yarn create-nuxt-app <project-name>
 ```
 
   </code-block>
   <code-block label="NPX">
 
 ```bash
-npx create nuxt-app <project-name>
+npx create-nuxt-app <project-name>
 ```
 
   </code-block>


### PR DESCRIPTION
The command was misspelled and caused an error.