### PR TITLE
fix link to cached-components in the aside nav

### DIFF
--- a/content/en/faq/cached-components.md
+++ b/content/en/faq/cached-components.md
@@ -1,7 +1,7 @@
 ---
 title: How to cache Vue components?
 description: How to cache Vue components in NuxtJS?
-menu: Using nginx as a proxy
+menu: How to cache Vue components?
 category: configuration
 position: 8
 ---

--- a/content/fr/faq/cached-components.md
+++ b/content/fr/faq/cached-components.md
@@ -1,7 +1,7 @@
 ---
 title: Mettre en cache les composants
 description: Comment mettre en cache des composants avec NuxtJS ?
-menu: Using nginx as a proxy
+menu: Mettre en cache les composants
 category: configuration
 position: 8
 ---

--- a/content/id/faq/cached-components.md
+++ b/content/id/faq/cached-components.md
@@ -1,7 +1,7 @@
 ---
 title: Komponen Caching
 description: Bagaimana cara men-cache sebuah komponen?
-menu: Using nginx as a proxy
+menu: Komponen Caching
 category: configuration
 position: 8
 ---

--- a/content/ja/faq/cached-components.md
+++ b/content/ja/faq/cached-components.md
@@ -1,7 +1,7 @@
 ---
 title: Vue コンポーネントをキャッシュするには？
 description: NuxtJS で Vue コンポーネントをキャッシュするには？
-menu: Using nginx as a proxy
+menu: Vue コンポーネントをキャッシュするには？
 category: configuration
 position: 8
 ---

--- a/content/zh/faq/cached-components.md
+++ b/content/zh/faq/cached-components.md
@@ -1,7 +1,7 @@
 ---
 title: Caching Components
 description: 如何使用 cache 组件？
-menu: Using nginx as a proxy
+menu: 如何使用 cache 组件？
 category: configuration
 position: 8
 ---


### PR DESCRIPTION
Hello, 
I realized the sidebar on the current doc shows an item "Using nginx as a proxy" that links to the "How to cache Vue components?" page. This PR corrects it.