### PR TITLE
Add missing 'render' subkey in CSP-docs.

### DIFF
--- a/content/en/api/configuration-render.md
+++ b/content/en/api/configuration-render.md
@@ -223,31 +223,33 @@ export default {
 */
 const PRIMARY_HOSTS = `loc.example-website.com`
 export default {
-  csp: {
-    reportOnly: true,
-    hashAlgorithm: 'sha256',
-    policies: {
-      'default-src': ["'self'"],
-      'img-src': ['https:', '*.google-analytics.com'],
-      'worker-src': ["'self'", `blob:`, PRIMARY_HOSTS, '*.logrocket.io'],
-      'style-src': ["'self'", "'unsafe-inline'", PRIMARY_HOSTS],
-      'script-src': [
-        "'self'",
-        "'unsafe-inline'",
-        PRIMARY_HOSTS,
-        'sentry.io',
-        '*.sentry-cdn.com',
-        '*.google-analytics.com',
-        '*.logrocket.io'
-      ],
-      'connect-src': [PRIMARY_HOSTS, 'sentry.io', '*.google-analytics.com'],
-      'form-action': ["'self'"],
-      'frame-ancestors': ["'none'"],
-      'object-src': ["'none'"],
-      'base-uri': [PRIMARY_HOSTS],
-      'report-uri': [
-        `https://sentry.io/api/<project>/security/?sentry_key=<key>`
-      ]
+  render: {
+    csp: {
+      reportOnly: true,
+      hashAlgorithm: 'sha256',
+      policies: {
+        'default-src': ["'self'"],
+        'img-src': ['https:', '*.google-analytics.com'],
+        'worker-src': ["'self'", `blob:`, PRIMARY_HOSTS, '*.logrocket.io'],
+        'style-src': ["'self'", "'unsafe-inline'", PRIMARY_HOSTS],
+        'script-src': [
+          "'self'",
+          "'unsafe-inline'",
+          PRIMARY_HOSTS,
+          'sentry.io',
+          '*.sentry-cdn.com',
+          '*.google-analytics.com',
+          '*.logrocket.io'
+        ],
+        'connect-src': [PRIMARY_HOSTS, 'sentry.io', '*.google-analytics.com'],
+        'form-action': ["'self'"],
+        'frame-ancestors': ["'none'"],
+        'object-src': ["'none'"],
+        'base-uri': [PRIMARY_HOSTS],
+        'report-uri': [
+          `https://sentry.io/api/<project>/security/?sentry_key=<key>`
+        ]
+      }
     }
   }
 }

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -219,31 +219,33 @@ export default {
 */
 const PRIMARY_HOSTS = `loc.example-website.com`
 export default {
-  csp: {
-    reportOnly: true,
-    hashAlgorithm: 'sha256',
-    policies: {
-      'default-src': ["'self'"],
-      'img-src': ['https:', '*.google-analytics.com'],
-      'worker-src': ["'self'", `blob:`, PRIMARY_HOSTS, '*.logrocket.io'],
-      'style-src': ["'self'", "'unsafe-inline'", PRIMARY_HOSTS],
-      'script-src': [
-        "'self'",
-        "'unsafe-inline'",
-        PRIMARY_HOSTS,
-        'sentry.io',
-        '*.sentry-cdn.com',
-        '*.google-analytics.com',
-        '*.logrocket.io'
-      ],
-      'connect-src': [PRIMARY_HOSTS, 'sentry.io', '*.google-analytics.com'],
-      'form-action': ["'self'"],
-      'frame-ancestors': ["'none'"],
-      'object-src': ["'none'"],
-      'base-uri': [PRIMARY_HOSTS],
-      'report-uri': [
-        `https://sentry.io/api/<project>/security/?sentry_key=<key>`
-      ]
+  render: {
+    csp: {
+      reportOnly: true,
+      hashAlgorithm: 'sha256',
+      policies: {
+        'default-src': ["'self'"],
+        'img-src': ['https:', '*.google-analytics.com'],
+        'worker-src': ["'self'", `blob:`, PRIMARY_HOSTS, '*.logrocket.io'],
+        'style-src': ["'self'", "'unsafe-inline'", PRIMARY_HOSTS],
+        'script-src': [
+          "'self'",
+          "'unsafe-inline'",
+          PRIMARY_HOSTS,
+          'sentry.io',
+          '*.sentry-cdn.com',
+          '*.google-analytics.com',
+          '*.logrocket.io'
+        ],
+        'connect-src': [PRIMARY_HOSTS, 'sentry.io', '*.google-analytics.com'],
+        'form-action': ["'self'"],
+        'frame-ancestors': ["'none'"],
+        'object-src': ["'none'"],
+        'base-uri': [PRIMARY_HOSTS],
+        'report-uri': [
+          `https://sentry.io/api/<project>/security/?sentry_key=<key>`
+        ]
+      }
     }
   }
 }

--- a/content/ja/api/configuration-render.md
+++ b/content/ja/api/configuration-render.md
@@ -214,31 +214,33 @@ export default {
 */
 const PRIMARY_HOSTS = `loc.example-website.com`
 export default {
-  csp: {
-    reportOnly: true,
-    hashAlgorithm: 'sha256',
-    policies: {
-      'default-src': ["'self'"],
-      'img-src': ['https:', '*.google-analytics.com'],
-      'worker-src': ["'self'", `blob:`, PRIMARY_HOSTS, '*.logrocket.io'],
-      'style-src': ["'self'", "'unsafe-inline'", PRIMARY_HOSTS],
-      'script-src': [
-        "'self'",
-        "'unsafe-inline'",
-        PRIMARY_HOSTS,
-        'sentry.io',
-        '*.sentry-cdn.com',
-        '*.google-analytics.com',
-        '*.logrocket.io'
-      ],
-      'connect-src': [PRIMARY_HOSTS, 'sentry.io', '*.google-analytics.com'],
-      'form-action': ["'self'"],
-      'frame-ancestors': ["'none'"],
-      'object-src': ["'none'"],
-      'base-uri': [PRIMARY_HOSTS],
-      'report-uri': [
-        `https://sentry.io/api/<project>/security/?sentry_key=<key>`
-      ]
+  render: {
+    csp: {
+      reportOnly: true,
+      hashAlgorithm: 'sha256',
+      policies: {
+        'default-src': ["'self'"],
+        'img-src': ['https:', '*.google-analytics.com'],
+        'worker-src': ["'self'", `blob:`, PRIMARY_HOSTS, '*.logrocket.io'],
+        'style-src': ["'self'", "'unsafe-inline'", PRIMARY_HOSTS],
+        'script-src': [
+          "'self'",
+          "'unsafe-inline'",
+          PRIMARY_HOSTS,
+          'sentry.io',
+          '*.sentry-cdn.com',
+          '*.google-analytics.com',
+          '*.logrocket.io'
+        ],
+        'connect-src': [PRIMARY_HOSTS, 'sentry.io', '*.google-analytics.com'],
+        'form-action': ["'self'"],
+        'frame-ancestors': ["'none'"],
+        'object-src': ["'none'"],
+        'base-uri': [PRIMARY_HOSTS],
+        'report-uri': [
+          `https://sentry.io/api/<project>/security/?sentry_key=<key>`
+        ]
+      }
     }
   }
 }

--- a/content/ko/api/configuration-render.md
+++ b/content/ko/api/configuration-render.md
@@ -211,31 +211,33 @@ export default {
 */
 const PRIMARY_HOSTS = `loc.example-website.com`
 export default {
-  csp: {
-    reportOnly: true,
-    hashAlgorithm: 'sha256',
-    policies: {
-      'default-src': ["'self'"],
-      'img-src': ['https:', '*.google-analytics.com'],
-      'worker-src': ["'self'", `blob:`, PRIMARY_HOSTS, '*.logrocket.io'],
-      'style-src': ["'self'", "'unsafe-inline'", PRIMARY_HOSTS],
-      'script-src': [
-        "'self'",
-        "'unsafe-inline'",
-        PRIMARY_HOSTS,
-        'sentry.io',
-        '*.sentry-cdn.com',
-        '*.google-analytics.com',
-        '*.logrocket.io'
-      ],
-      'connect-src': [PRIMARY_HOSTS, 'sentry.io', '*.google-analytics.com'],
-      'form-action': ["'self'"],
-      'frame-ancestors': ["'none'"],
-      'object-src': ["'none'"],
-      'base-uri': [PRIMARY_HOSTS],
-      'report-uri': [
-        `https://sentry.io/api/<project>/security/?sentry_key=<key>`
-      ]
+  render: {
+    csp: {
+      reportOnly: true,
+      hashAlgorithm: 'sha256',
+      policies: {
+        'default-src': ["'self'"],
+        'img-src': ['https:', '*.google-analytics.com'],
+        'worker-src': ["'self'", `blob:`, PRIMARY_HOSTS, '*.logrocket.io'],
+        'style-src': ["'self'", "'unsafe-inline'", PRIMARY_HOSTS],
+        'script-src': [
+          "'self'",
+          "'unsafe-inline'",
+          PRIMARY_HOSTS,
+          'sentry.io',
+          '*.sentry-cdn.com',
+          '*.google-analytics.com',
+          '*.logrocket.io'
+        ],
+        'connect-src': [PRIMARY_HOSTS, 'sentry.io', '*.google-analytics.com'],
+        'form-action': ["'self'"],
+        'frame-ancestors': ["'none'"],
+        'object-src': ["'none'"],
+        'base-uri': [PRIMARY_HOSTS],
+        'report-uri': [
+          `https://sentry.io/api/<project>/security/?sentry_key=<key>`
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
The `render` subkey is missing in the docs.

This is a follow-up from nuxt/docs#2095
/cc @debs-obrien 