### PR TITLE
Add Vue School Video Links

### DIFF
--- a/content/en/guides/concepts/static-site-generation.md
+++ b/content/en/guides/concepts/static-site-generation.md
@@ -36,6 +36,17 @@ questions:
 
 With static site generation you can render your application during the build phase and deploy it to any static hosting services such as Netlify, Github pages, Vercel etc. This means that no server is needed in order to deploy your application.
 
+<div>
+  <a href="https://vueschool.io/courses/static-site-generation-with-nuxtjs?friend=nuxt" target="_blank" class="Promote">
+    <img src="/static-site-generation-with-nuxtjs.png" alt="Static Site Generation with Nuxt.js by vueschool"/>
+    <div class="Promote__Content">
+      <h4 class="Promote__Content__Title">Static Site Generation with Nuxt.js</h4>
+      <p class="Promote__Content__Description">Learn how to generate static websites (pre rendering) to improve both performance and SEO while eliminating hosting costs.</p>
+      <p class="Promote__Content__Signature">Video courses made by VueSchool to support Nuxt.js development.</p>
+    </div>
+  </a>
+</div>
+
 ### Generating your site
 
 When deploying your site in with [target:static](/guides/features/deployment-targets#static-hosting) all your `.vue` pages will be generated into HTML and JavaScript files. All calls to APIs will be made and cached in a folder called static inside your generated content so that no calls to your API need to be made on client side navigation.

--- a/content/en/guides/directory-structure/pages.md
+++ b/content/en/guides/directory-structure/pages.md
@@ -74,6 +74,10 @@ You can also create routes with .js files and .ts files
 
 Every Page component is a Vue component but Nuxt.js adds special attributes and functions to make the development of your universal application as easy as possible.
 
+<base-alert type="star">
+    Watch a free lesson about <a href="https://vueschool.io/lessons/nuxtjs-page-components?friend=nuxt" target="_blank"><strong>Nuxt.js Page Components</strong> on Vue School</a>
+</base-alert>
+
 ```html{}[pages
 <template>
   <h1 class="red">Hello {{ name }}!</h1>

--- a/content/en/guides/directory-structure/store.md
+++ b/content/en/guides/directory-structure/store.md
@@ -64,6 +64,10 @@ _This directory cannot be renamed without extra configuration._
 
 Using a store to manage the state is important for every big application. That's why Nuxt.js implements Vuex in its core.
 
+<base-alert type="star">
+ Watch a free lesson about <a href="https://vueschool.io/lessons/utilising-the-vuex-store-nuxtjs?friend=nuxt" target="_blank"><strong>Nuxt.js and Vuex</strong></a> on Vue School
+</base-alert>
+
 ## Activate the Store
 
 Nuxt.js will look for the `store` directory, if it exists, it will:

--- a/content/en/guides/features/data-fetching.md
+++ b/content/en/guides/features/data-fetching.md
@@ -65,6 +65,17 @@ questions:
 
 In Nuxt.js we have 2 ways of getting data from an api. We can use the fetch method or the asyncData method.
 
+<div>
+  <a href="https://vueschool.io/courses/async-data-with-nuxtjs?friend=nuxt" target="_blank" class="Promote">
+    <img src="/async-data-with-nuxtjs.png" srcset="/async-data-with-nuxtjs-2x.png 2x" alt="AsyncData by vueschool"/>
+    <div class="Promote__Content">
+      <h4 class="Promote__Content__Title">Async Data with Nuxt.js</h4>
+      <p class="Promote__Content__Description">Learn how to manage asynchronous data with Nuxt.js.</p>
+      <p class="Promote__Content__Signature">Video courses made by VueSchool to support Nuxt.js development.</p>
+    </div>
+  </a>
+</div>
+
 ## The fetch hook
 
 <base-alert type="info">

--- a/content/en/guides/get-started/directory-structure.md
+++ b/content/en/guides/get-started/directory-structure.md
@@ -8,6 +8,10 @@ csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/
 
 The default Nuxt.js application structure is intended to provide a great starting point for both small and large applications. You are free to organize your application however you like and can create other directories as and when you need them.
 
+<base-alert type="star">
+ Watch a free lesson about  <a href="https://vueschool.io/lessons/guided-nuxtjs-project-tour?friend=nuxt" target="_blank"><strong>the Nuxt.js directory structure</strong></a> on Vue School
+</base-alert>
+
 Let's create the directories and files that do not exist in our project yet.
 
 ```bash

--- a/content/en/guides/get-started/installation.md
+++ b/content/en/guides/get-started/installation.md
@@ -6,6 +6,17 @@ category: get-started
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/01_installation?fontsize=14&hidenavigation=1&theme=dark
 ---
 
+<div>
+  <a href="https://vueschool.io/courses/nuxtjs-fundamentals/?friend=nuxt" target="_blank" class="Promote">
+    <img src="/nuxt-fundamentals.png" srcset="/nuxt-fundamentals-2x.png 2x" alt="Nuxt Fundamentals by vueschool"/>
+    <div class="Promote__Content">
+      <h4 class="Promote__Content__Title">Nuxt.js Fundamentals</h4>
+      <p class="Promote__Content__Description">Learn how to get started quickly with Nuxt.js in videos.</p>
+      <p class="Promote__Content__Signature">Video courses made by VueSchool to support Nuxt.js developpement.</p>
+    </div>
+  </a>
+</div>
+
 ## Prerequisites
 
 Here, you will find information on setting up and running a Nuxt.js project in 4 steps.
@@ -15,6 +26,8 @@ Here, you will find information on setting up and running a Nuxt.js project in 4
 Another way to get started with Nuxt.js is to use [CodeSandbox](https://template.nuxtjs.org) which is a great way for quickly playing around with Nuxt.js and/or sharing your code with other people.
 
 </base-alert>
+
+
 
 ### Node
 


### PR DESCRIPTION
This PR adds the video links that already exist in the old docs to the new guides.

**The following resources have been linked:**
- [Nuxt.js Fundamentals course](https://vueschool.io/courses/nuxtjs-fundamentals)
- [Async Data with Nuxt.js course](https://vueschool.io/courses/async-data-with-nuxtjs)
- [Static Site Generation with Nuxt.js course](https://vueschool.io/courses/static-site-generation-with-nuxtjs)
- [Directory structure lesson](https://vueschool.io/lessons/guided-nuxtjs-project-tour)
- [Nuxt + Vuex lesson](https://vueschool.io/lessons/utilising-the-vuex-store-nuxtjs)
- [Nuxt Page Components lesson](https://vueschool.io/lessons/nuxtjs-page-components)

[Visuals can be seen here](https://imgur.com/a/KvAjGtD)