### PR TITLE
docs(eslint-loader): use cache

### DIFF
--- a/content/en/guide/development-tools.md
+++ b/content/en/guide/development-tools.md
@@ -201,7 +201,10 @@ It is also recommended to enable ESLint hot reloading mode via webpack. This way
           enforce: "pre",
           test: /\.(js|vue)$/,
           loader: "eslint-loader",
-          exclude: /(node_modules)/
+          exclude: /(node_modules)/,
+          options: {
+            cache: true
+          }
         })
       }
     }


### PR DESCRIPTION
This will fix performance in very large projects. For example, in our project, the `dev` mode (`yarn dev`) was launched without this for **30 minutes**, and after using the cache, for **50 seconds**!!! 

New version of https://github.com/nuxt/docs/pull/1846