### PR TITLE
en: add extra options example for extractCSS

### DIFF
--- a/content/en/api/configuration-build.md
+++ b/content/en/api/configuration-build.md
@@ -201,10 +201,24 @@ export default {
 
 > Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://ssr.vuejs.org/en/css.html).
 
-- Type: `Boolean`
+- Type: `Boolean` or `Object`
 - Default: `false`
 
 Using [`extract-css-chunks-webpack-plugin`](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/) under the hood, all your CSS will be extracted into separate files, usually one per component. This allows caching your CSS and JavaScript separately and is worth a try in case you have a lot of global or shared CSS.
+
+Example (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    extractCSS: true,
+    // or
+    extractCSS: {
+      ignoreOrder: true
+    }
+  }
+}
+```
 
 <div class="Alert Alert--teal">
 

--- a/content/en/guides/configuration-glossary/configuration-build.md
+++ b/content/en/guides/configuration-glossary/configuration-build.md
@@ -196,10 +196,24 @@ export default {
 
 > Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://ssr.vuejs.org/en/css.html).
 
-- Type: `Boolean`
+- Type: `Boolean` or `Object`
 - Default: `false`
 
 Using [`extract-css-chunks-webpack-plugin`](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/) under the hood, all your CSS will be extracted into separate files, usually one per component. This allows caching your CSS and JavaScript separately and is worth a try in case you have a lot of global or shared CSS.
+
+Example (`nuxt.config.js`):
+
+```js
+export default {
+  build: {
+    extractCSS: true,
+    // or
+    extractCSS: {
+      ignoreOrder: true
+    }
+  }
+}
+```
 
 <base-alert type="info">
 


### PR DESCRIPTION
When using `extractCSS`, we also can pass `extract-css-chunks-webpack-plugin` options. Which is supported in https://github.com/nuxt/nuxt.js/blob/15bc5b06e69e08a2dea325dac18cac0dde6d9ca5/packages/webpack/src/config/base.js#L385

This is helpful as a lot users like me got `Conflicting order` warnings from `extract-css-chunks-webpack-plugin`. See issue https://github.com/nuxt/nuxt.js/issues/4885#issuecomment-533015230