### PR TITLE
Fixed formatting of the trailingSlash section

### DIFF
--- a/content/en/guides/features/file-system-routing.md
+++ b/content/en/guides/features/file-system-routing.md
@@ -476,7 +476,9 @@ The `scrollBehavior` option lets you define a custom behavior for the scroll p
 
 <base-alert type="next">
 
-To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html). </base-alert>
+To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+
+</base-alert>
 
 Available since:v2.9.0:
 


### PR DESCRIPTION
Fixed formatting of the last two sections in the page. The trailingSlash section appears in the alert from scrollBehavior