### PR TITLE
translation(es-ES)/internals glossary v.2

### DIFF
--- a/content/es/guides/internals-glossary/internals-nuxt.md
+++ b/content/es/guides/internals-glossary/internals-nuxt.md
@@ -1,0 +1,28 @@
+---
+title: 'The Nuxt Class'
+description: Nuxt Core Class
+menu: Nuxt Class
+category: internals-glossary
+position: 4
+---
+
+- Source: **[core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)**
+
+This is the core container which allows all modules and classes communicate with each other. All modules have access to Nuxt instance using `this.nuxt`.
+
+## Hooks
+
+We can register hooks on certain life cycle events.
+
+```js
+nuxt.hook('ready', async nuxt => {
+  // Your custom code here
+})
+```
+
+| Plugin | Arguments | When |
+| --- | --- | --- |
+| `ready` | (nuxt) | Nuxt is ready to work (`ModuleContainer` and `Renderer` ready). |
+| `error` | (error) | An unhandled error when calling hooks. |
+| `close` | (nuxt) | Nuxt instance is gracefully closing. |
+| `listen` | (server, {host, port}) | Nuxt **internal** server starts listening. (Using `nuxt start` or `nuxt dev`). |

--- a/content/es/guides/internals-glossary/internals-nuxt.md
+++ b/content/es/guides/internals-glossary/internals-nuxt.md
@@ -1,28 +1,28 @@
 ---
-title: 'The Nuxt Class'
-description: Nuxt Core Class
-menu: Nuxt Class
+title: 'La clase Nuxt'
+description: Clase principal de Nuxt 
+menu: Clase Nuxt
 category: internals-glossary
 position: 4
 ---
 
 - Source: **[core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)**
 
-This is the core container which allows all modules and classes communicate with each other. All modules have access to Nuxt instance using `this.nuxt`.
+Este es el contenedor principal que permite que todos los módulos y clases se comuniquen entre sí. Todos los módulos tienen acceso a la instancia de Nuxt usando `this.nuxt`.
 
 ## Hooks
 
-We can register hooks on certain life cycle events.
+Podemos registrar los _hooks_ en ciertos eventos del ciclo de vida.
 
 ```js
 nuxt.hook('ready', async nuxt => {
-  // Your custom code here
+  // Tu código personalizado aquí
 })
 ```
 
-| Plugin | Arguments | When |
+| Plugin | Argumentos | Cuando |
 | --- | --- | --- |
-| `ready` | (nuxt) | Nuxt is ready to work (`ModuleContainer` and `Renderer` ready). |
-| `error` | (error) | An unhandled error when calling hooks. |
-| `close` | (nuxt) | Nuxt instance is gracefully closing. |
-| `listen` | (server, {host, port}) | Nuxt **internal** server starts listening. (Using `nuxt start` or `nuxt dev`). |
+| `ready` | (nuxt) | Nuxt está listo para trabajar (`ModuleContainer` y `Renderer` listos). |
+| `error` | (error) | Se da un error no controlado al llamar a hooks. |
+| `close` | (nuxt) | La instancia de Nuxt se está cerrando con gracia. |
+| `listen` | (server, {host, port}) | El servidor Nuxt **interno** comienza a escuchar. (Usando `nuxt start` o `nuxt dev`). |

--- a/content/es/guides/internals-glossary/internals-renderer.md
+++ b/content/es/guides/internals-glossary/internals-renderer.md
@@ -1,0 +1,26 @@
+---
+title: 'The Renderer Class'
+description: Nuxt Renderer Class
+menu: Renderer
+category: internals-glossary
+position: 5
+---
+
+- Source: **[vue-renderer/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-renderer/src/renderer.js)**
+
+This class is exporting a connect middleware which handles and serves all SSR and asset requests.
+
+## Hooks
+
+We can register hooks on certain life cycle events.
+
+| Hook | Arguments | When |
+| --- | --- | --- |
+| `render:before` | (renderer, options) | Before setting up middleware and resources for the Renderer class, useful to overload some methods or options. |
+| `render:setupMiddleware` | (app) _connect instance_ | Before Nuxt adds its middleware stack. We can use it to register custom server side middleware. |
+| `render:errorMiddleware` | (app) _connect instance_ | Before adding Nuxt error middleware, useful to add your own middleware before using Nuxt's. See the [Sentry module](https://github.com/nuxt-community/sentry-module/blob/v4.0.3/lib/module.js#L151) for more info. |
+| `render:resourcesLoaded` | (resources) | Called after resources for renderer are loaded (client manifest, server bundle, etc). |
+| `render:done` | (renderer) | SSR Middleware and all resources are ready (Renderer ready) |
+| `render:routeContext` | (context.nuxt) | _Every time a route is server-rendered and before `render:route` hook_. Called before serializing Nuxt context into `window.__NUXT__`, useful to add some data that you can fetch on client-side. |
+| `render:route` | (url, result, context) | _Every time a route is server-rendered_. Called before sending back the request to the browser. |
+| `render:routeDone` | (url, result, context) | _Every time a route is server-rendered_. Called after the response has been sent to the browser. |

--- a/content/es/guides/internals-glossary/internals-renderer.md
+++ b/content/es/guides/internals-glossary/internals-renderer.md
@@ -1,6 +1,6 @@
 ---
-title: 'The Renderer Class'
-description: Nuxt Renderer Class
+title: 'La clase Renderer'
+description: Clase Renderer de Nuxt
 menu: Renderer
 category: internals-glossary
 position: 5
@@ -8,19 +8,19 @@ position: 5
 
 - Source: **[vue-renderer/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-renderer/src/renderer.js)**
 
-This class is exporting a connect middleware which handles and serves all SSR and asset requests.
+Esta clase está exportando un middleware de conexión que maneja y sirve todas las solicitudes de activos y SSR.
 
 ## Hooks
 
-We can register hooks on certain life cycle events.
+Podemos registrar los _hooks_ en ciertos eventos del ciclo de vida.
 
-| Hook | Arguments | When |
+| Hook | Argumentos | Cuando |
 | --- | --- | --- |
-| `render:before` | (renderer, options) | Before setting up middleware and resources for the Renderer class, useful to overload some methods or options. |
-| `render:setupMiddleware` | (app) _connect instance_ | Before Nuxt adds its middleware stack. We can use it to register custom server side middleware. |
-| `render:errorMiddleware` | (app) _connect instance_ | Before adding Nuxt error middleware, useful to add your own middleware before using Nuxt's. See the [Sentry module](https://github.com/nuxt-community/sentry-module/blob/v4.0.3/lib/module.js#L151) for more info. |
-| `render:resourcesLoaded` | (resources) | Called after resources for renderer are loaded (client manifest, server bundle, etc). |
-| `render:done` | (renderer) | SSR Middleware and all resources are ready (Renderer ready) |
-| `render:routeContext` | (context.nuxt) | _Every time a route is server-rendered and before `render:route` hook_. Called before serializing Nuxt context into `window.__NUXT__`, useful to add some data that you can fetch on client-side. |
-| `render:route` | (url, result, context) | _Every time a route is server-rendered_. Called before sending back the request to the browser. |
-| `render:routeDone` | (url, result, context) | _Every time a route is server-rendered_. Called after the response has been sent to the browser. |
+| `render:before` | (renderer, options) | Antes de configurar el middleware y los recursos para la clase Renderer, útil para sobrecargar algunos métodos u opciones. |
+| `render:setupMiddleware` | (app) _connect instance_ | Antes de que Nuxt agregue su pila de middleware. Podemos usarlo para registrar un middleware del lado del servidor personalizado. |
+| `render:errorMiddleware` | (app) _connect instance_ | Antes de agregar el middleware de errores de Nuxt, es útil agregar tu propio middleware antes de usar Nuxt. Ver el [módulo Sentry](https://github.com/nuxt-community/sentry-module/blob/v4.0.3/lib/module.js#L151) para más información. |
+| `render:resourcesLoaded` | (resources) | Se llama después de que se cargan los recursos para el renderizador (manifiesto del cliente, paquete del servidor, etc.). |
+| `render:done` | (renderer) | Middleware para SSR y todos los recursos están listos (Renderer listo) |
+| `render:routeContext` | (context.nuxt) | _Cada vez que una ruta es renderizada por el servidor y antes de `render:route` hook_. Se llama antes de serializar el contexto de Nuxt en `window.__NUXT__`, útil para agregar algunos datos y obtenerlos en el lado del cliente. |
+| `render:route` | (url, result, context) | _Cada vez que se procesa una ruta en el servidor_. Se llama antes de devolver la solicitud al navegador. |
+| `render:routeDone` | (url, result, context) | _Cada vez que se procesa una ruta en el servidor_. Llamado después de que la respuesta se haya enviado al navegador. |

--- a/content/es/guides/internals-glossary/nuxt-render-and-get-window.md
+++ b/content/es/guides/internals-glossary/nuxt-render-and-get-window.md
@@ -1,0 +1,45 @@
+---
+title: 'nuxt.renderAndGetWindow(url, options)'
+description: Get the `window` from a given URL of a Nuxt.js Application.
+menu: renderAndGetWindow
+category: internals-glossary
+position: 12
+---
+
+- Type: `Function`
+- Argument: `String`
+  1. `String`: URL to render
+  2. _Optional_, `Object`: options
+  - virtualConsole: `Boolean` (default: `true`)
+- Returns: `Promise`
+  - Returns: `window`
+
+> Get the window from a given url of a Nuxt.js application.
+
+<base-alert>
+
+This method is made for test purposes.
+
+</base-alert>
+
+To use this function, you have to install `jsdom`:
+
+```bash
+npm install --save-dev jsdom
+```
+
+Example:
+
+```js
+const { Nuxt, Builder } = require('nuxt')
+
+const config = require('./nuxt.config.js')
+config.dev = false
+
+const nuxt = new Nuxt(config)
+
+nuxt.renderAndGetWindow('http://localhost:3000').then(window => {
+  // Display the head `<title>`
+  console.log(window.document.title)
+})
+```

--- a/content/es/guides/internals-glossary/nuxt-render-and-get-window.md
+++ b/content/es/guides/internals-glossary/nuxt-render-and-get-window.md
@@ -1,34 +1,34 @@
 ---
 title: 'nuxt.renderAndGetWindow(url, options)'
-description: Get the `window` from a given URL of a Nuxt.js Application.
+description: Obtener `window` de una URL determinada de una aplicación Nuxt.js.
 menu: renderAndGetWindow
 category: internals-glossary
 position: 12
 ---
 
-- Type: `Function`
-- Argument: `String`
-  1. `String`: URL to render
-  2. _Optional_, `Object`: options
-  - virtualConsole: `Boolean` (default: `true`)
-- Returns: `Promise`
-  - Returns: `window`
+- Tipo: `Function`
+- Argumento: `String`
+  1. `String`: URL para renderizar
+  2. _Optional_, `Object`: opciones
+  - virtualConsole: `Boolean` (por defecto: `true`)
+- Devulve: `Promise`
+  - Devuelve: `window`
 
-> Get the window from a given url of a Nuxt.js application.
+> Obtenga la ventana de una URL determinada de una aplicación Nuxt.js.
 
 <base-alert>
 
-This method is made for test purposes.
+Este método está hecho para propósitos de prueba.
 
 </base-alert>
 
-To use this function, you have to install `jsdom`:
+Para usar esta función debes instalar `jsdom`:
 
 ```bash
 npm install --save-dev jsdom
 ```
 
-Example:
+Ejemplo:
 
 ```js
 const { Nuxt, Builder } = require('nuxt')
@@ -39,7 +39,7 @@ config.dev = false
 const nuxt = new Nuxt(config)
 
 nuxt.renderAndGetWindow('http://localhost:3000').then(window => {
-  // Display the head `<title>`
+  // Muestra `<title>` en head
   console.log(window.document.title)
 })
 ```

--- a/content/es/guides/internals-glossary/nuxt-render-route.md
+++ b/content/es/guides/internals-glossary/nuxt-render-route.md
@@ -1,0 +1,56 @@
+---
+title: 'nuxt.renderRoute(route, context)'
+description: Render a specific route with a given context.
+menu: renderRoute
+category: internals-glossary
+position: 11
+---
+
+- Type: `Function`
+- Arguments:
+  1. `String` : route to render
+  2. _Optional_, `Object`, context given, available keys: `req` & `res`
+- Returns: `Promise`
+  - `html`: `String`
+  - `error`: `null` or `Object`
+  - `redirected`: `false` or `Object`
+
+> Render a specific route with a given context.
+
+This method should be used mostly for test purposes as well as with [`nuxt.renderAndGetWindow`](/guides/internals-glossary/nuxt-render-and-get-window).
+
+<base-alert>
+
+`nuxt.renderRoute` should be executed after the build process in production mode.
+
+</base-alert>
+
+```js
+const { loadNuxt, build } = require('nuxt')
+
+async function start() {
+  // Get nuxt instance for start (production mode)
+  // Make sure to have run `nuxt build` before running this script
+  const nuxt = await loadNuxt({ for: 'start' })
+
+  const { html, error, redirected } = await nuxt.renderRoute('/')
+
+  // `html` will always be a string
+
+  // `error` not null when the error layout is displayed, the error format is:
+  // { statusCode: 500, message: 'My error message' }
+
+  // `redirected` is not `false` when `redirect()` has been used in `asyncData()` or `fetch()`
+  // { path: '/other-path', query: {}, status: 302 }
+}
+
+start()
+```
+
+### What's next
+
+<base-alert type="next">
+
+Check out the the [Components Glossary book](/guides/components-glossary/pages-fetch)
+
+</base-alert>

--- a/content/es/guides/internals-glossary/nuxt-render-route.md
+++ b/content/es/guides/internals-glossary/nuxt-render-route.md
@@ -1,27 +1,27 @@
 ---
 title: 'nuxt.renderRoute(route, context)'
-description: Render a specific route with a given context.
+description: Renderiza una ruta específica con un contexto dado.
 menu: renderRoute
 category: internals-glossary
 position: 11
 ---
 
-- Type: `Function`
-- Arguments:
-  1. `String` : route to render
-  2. _Optional_, `Object`, context given, available keys: `req` & `res`
-- Returns: `Promise`
+- Tipo: `Function`
+- Argumentos:
+  1. `String` : Ruta a renderizar
+  2. _Optional_, `Object`, contexto dado, llaves disponibles: `req` y `res`
+- Devuelve: `Promise`
   - `html`: `String`
-  - `error`: `null` or `Object`
-  - `redirected`: `false` or `Object`
+  - `error`: `null` o `Object`
+  - `redirected`: `false` o `Object`
 
-> Render a specific route with a given context.
+> Renderiza una ruta específica con un contexto dado.
 
-This method should be used mostly for test purposes as well as with [`nuxt.renderAndGetWindow`](/guides/internals-glossary/nuxt-render-and-get-window).
+Este método se debe utilizar principalmente con fines de prueba, así como con [`nuxt.renderAndGetWindow`](/guides/internals-glossary/nuxt-render-and-get-window).
 
 <base-alert>
 
-`nuxt.renderRoute` should be executed after the build process in production mode.
+`nuxt.renderRoute` debe ejecutarse después del proceso de construcción en modo de producción.
 
 </base-alert>
 
@@ -29,28 +29,28 @@ This method should be used mostly for test purposes as well as with [`nuxt.rende
 const { loadNuxt, build } = require('nuxt')
 
 async function start() {
-  // Get nuxt instance for start (production mode)
-  // Make sure to have run `nuxt build` before running this script
+  // Obtener la instancia de nuxt para iniciar (modo de producción)
+  // Asegúrese de haber ejecutado `nuxt build` antes de ejecutar este script
   const nuxt = await loadNuxt({ for: 'start' })
 
   const { html, error, redirected } = await nuxt.renderRoute('/')
 
-  // `html` will always be a string
+  // `html` siempre será un string
 
-  // `error` not null when the error layout is displayed, the error format is:
+  // `error` no es nulo cuando se muestra el diseño de error, el formato de error es:
   // { statusCode: 500, message: 'My error message' }
 
-  // `redirected` is not `false` when `redirect()` has been used in `asyncData()` or `fetch()`
+  // `redirected` no es `false` cuando `redirect()` ha sido usado en `asyncData()` o `fetch()`
   // { path: '/other-path', query: {}, status: 302 }
 }
 
 start()
 ```
 
-### What's next
+### Que sigue
 
 <base-alert type="next">
 
-Check out the the [Components Glossary book](/guides/components-glossary/pages-fetch)
+Consulte el [glosario de componentes](/guides/components-glossary/pages-fetch)
 
 </base-alert>

--- a/content/es/guides/internals-glossary/nuxt-render.md
+++ b/content/es/guides/internals-glossary/nuxt-render.md
@@ -1,0 +1,49 @@
+---
+title: 'nuxt.render(req, res)'
+description: You can use Nuxt.js as a middleware for your Node.js server.
+menu: render
+category: internals-glossary
+position: 10
+---
+
+- Type: `Function`
+- Arguments:
+  1. [Request](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
+  2. [Response](https://nodejs.org/api/http.html#http_class_http_serverresponse)
+- Returns: `Promise`
+
+> You can use Nuxt.js as a middleware with `nuxt.render` for your node.js server.
+
+Example with [Express](https://github.com/expressjs/express):
+
+```js
+const { loadNuxt, build } = require('nuxt')
+
+const app = require('express')()
+const isDev = process.env.NODE_ENV !== 'production'
+const port = process.env.PORT || 3000
+
+async function start() {
+  // We get Nuxt instance
+  const nuxt = await loadNuxt(isDev ? 'dev' : 'start')
+
+  // Render every route with Nuxt.js
+  app.use(nuxt.render)
+
+  // Build only in dev mode with hot-reloading
+  if (isDev) {
+    build(nuxt)
+  }
+  // Listen the server
+  app.listen(port, '0.0.0.0')
+  console.log('Server listening on `localhost:' + port + '`.')
+}
+
+start()
+```
+
+<div class="Alert">
+
+It's recommended to call `nuxt.render` at the end of your middlewares since it will handle the rendering of your web application and won't call `next()`
+
+</div>

--- a/content/es/guides/internals-glossary/nuxt-render.md
+++ b/content/es/guides/internals-glossary/nuxt-render.md
@@ -1,20 +1,20 @@
 ---
 title: 'nuxt.render(req, res)'
-description: You can use Nuxt.js as a middleware for your Node.js server.
+description: Puedes usar Nuxt.js como middleware para tu servidor Node.js.
 menu: render
 category: internals-glossary
 position: 10
 ---
 
-- Type: `Function`
-- Arguments:
+- Tipo: `Function`
+- Argumentos:
   1. [Request](https://nodejs.org/api/http.html#http_class_http_incomingmessage)
   2. [Response](https://nodejs.org/api/http.html#http_class_http_serverresponse)
-- Returns: `Promise`
+- Devuelve: `Promise`
 
-> You can use Nuxt.js as a middleware with `nuxt.render` for your node.js server.
+> Puedes usar Nuxt.js como middleware con `nuxt.render` para tu servidor de node.js.
 
-Example with [Express](https://github.com/expressjs/express):
+Ejemplo con [Express](https://github.com/expressjs/express):
 
 ```js
 const { loadNuxt, build } = require('nuxt')
@@ -24,19 +24,19 @@ const isDev = process.env.NODE_ENV !== 'production'
 const port = process.env.PORT || 3000
 
 async function start() {
-  // We get Nuxt instance
+  // Obtenemos la instancia de Nuxt
   const nuxt = await loadNuxt(isDev ? 'dev' : 'start')
 
-  // Render every route with Nuxt.js
+  // Renderizamos cada ruta con Nuxt.js
   app.use(nuxt.render)
 
-  // Build only in dev mode with hot-reloading
+  // Compila solo en modo dev con recarga en caliente
   if (isDev) {
     build(nuxt)
   }
-  // Listen the server
+  // Escucha el servidor
   app.listen(port, '0.0.0.0')
-  console.log('Server listening on `localhost:' + port + '`.')
+  console.log('Servidor escuchando en `localhost:' + port + '`.')
 }
 
 start()
@@ -44,6 +44,6 @@ start()
 
 <div class="Alert">
 
-It's recommended to call `nuxt.render` at the end of your middlewares since it will handle the rendering of your web application and won't call `next()`
+Se recomienda llamar a `nuxt.render` al final de sus middlewares ya que manejará la representación de su aplicación web y no llamará a` next () `
 
 </div>

--- a/content/es/guides/internals-glossary/nuxt.md
+++ b/content/es/guides/internals-glossary/nuxt.md
@@ -1,0 +1,40 @@
+---
+title: 'Using Nuxt.js Programmatically'
+description: You can use Nuxt.js programmatically to use it as a middleware giving you the freedom of creating your own server for rendering your web applications.
+menu: Using Nuxt Programmatically
+category: internals-glossary
+position: 9
+---
+
+You might want to use your own server with your middleware and your API. That's why you can use Nuxt.js programmatically.
+
+## Nuxt Constructor
+
+To see the list of options to give to Nuxt.js, see the configuration section.
+
+```js
+const { loadNuxt, build } = require('nuxt')
+
+// Check if we need to run Nuxt in development mode
+const isDev = process.env.NODE_ENV !== 'production'
+
+// Get a ready to use Nuxt instance
+const nuxt = await loadNuxt(isDev ? 'dev' : 'start')
+
+// Enable live build & reloading on dev
+if (isDev) {
+  build(nuxt)
+}
+
+// We can use `nuxt.render(req, res)` or `nuxt.renderRoute(route, context)`
+```
+
+You can take a look at the [nuxt-express](https://github.com/nuxt/express) and [adonuxt](https://github.com/nuxt/adonuxt) starters to get started quickly.
+
+### Debug logs
+
+If you want to display Nuxt.js logs, you can add the following to the top of your file:
+
+```js
+process.env.DEBUG = 'nuxt:*'
+```

--- a/content/es/guides/internals-glossary/nuxt.md
+++ b/content/es/guides/internals-glossary/nuxt.md
@@ -1,39 +1,39 @@
 ---
-title: 'Using Nuxt.js Programmatically'
-description: You can use Nuxt.js programmatically to use it as a middleware giving you the freedom of creating your own server for rendering your web applications.
-menu: Using Nuxt Programmatically
+title: 'Usando Nuxt.js mediante programación'
+description: Puedes usar Nuxt.js mediante programación para usarlo como middleware, lo que le brinda la libertad de crear su propio servidor para representar sus aplicaciones web.
+menu: Usando Nuxt.js mediante programación
 category: internals-glossary
 position: 9
 ---
 
-You might want to use your own server with your middleware and your API. That's why you can use Nuxt.js programmatically.
+Es posible que desee utilizar su propio servidor con su middleware y su API. Es por eso que puede usar Nuxt.js mediante programación.
 
-## Nuxt Constructor
+## Constructor Nuxt
 
-To see the list of options to give to Nuxt.js, see the configuration section.
+Para ver la lista de opciones para dar a Nuxt.js, consulte la sección de configuración.
 
 ```js
 const { loadNuxt, build } = require('nuxt')
 
-// Check if we need to run Nuxt in development mode
+// Compruebe si necesitamos ejecutar Nuxt en modo de desarrollo
 const isDev = process.env.NODE_ENV !== 'production'
 
-// Get a ready to use Nuxt instance
+// Prepara una instancia de Nuxt lista para usar
 const nuxt = await loadNuxt(isDev ? 'dev' : 'start')
 
-// Enable live build & reloading on dev
+// Habilita la compilación y recarga en vivo en el desarrollador
 if (isDev) {
   build(nuxt)
 }
 
-// We can use `nuxt.render(req, res)` or `nuxt.renderRoute(route, context)`
+// Podemos usar `nuxt.render(req, res)` o `nuxt.renderRoute(route, context)`
 ```
 
-You can take a look at the [nuxt-express](https://github.com/nuxt/express) and [adonuxt](https://github.com/nuxt/adonuxt) starters to get started quickly.
+Puedes echar un vistazo a las guías de inico rapido de [nuxt-express](https://github.com/nuxt/express) y [adonuxt](https://github.com/nuxt/adonuxt).
 
-### Debug logs
+### Registros de depuración
 
-If you want to display Nuxt.js logs, you can add the following to the top of your file:
+Si desea mostrar los registros de Nuxt.js, puede agregar lo siguiente en la parte superior de su archivo:
 
 ```js
 process.env.DEBUG = 'nuxt:*'


### PR DESCRIPTION
## Translated(es-ES) @ Internals glossary

📝 Finished the missing translations for the internals glossary:

- [x] internals-nuxt.md
- [x] internals-renderer.md
- [x] nuxt.md
- [x] nuxt-render.md
- [x] nuxt-render-and-get-window.md
- [x] nuxt-render-route.md