### PR TITLE
translated(es-ES)/configuration glossary

### DIFF
--- a/content/es/guides/configuration-glossary/configuration-builddir.md
+++ b/content/es/guides/configuration-glossary/configuration-builddir.md
@@ -1,0 +1,20 @@
+---
+title: 'The buildDir Property'
+description: Define the dist directory for your Nuxt.js application
+menu: buildDir
+category: configuration-glossary
+position: 2
+---
+
+- Type: `String`
+- Default: `.nuxt`
+
+> Define the dist directory for your Nuxt.js application
+
+```js{}[nuxt.config.js]
+export default {
+  buildDir: 'nuxt-dist'
+}
+```
+
+By default, many tools assume that `.nuxt` is a hidden directory, because its name starts with a dot. You can use this option to prevent that.

--- a/content/es/guides/configuration-glossary/configuration-builddir.md
+++ b/content/es/guides/configuration-glossary/configuration-builddir.md
@@ -1,15 +1,15 @@
 ---
-title: 'The buildDir Property'
-description: Define the dist directory for your Nuxt.js application
+title: 'La propiedad buildDir'
+description: Defina el directorio dist para su aplicación Nuxt.js
 menu: buildDir
 category: configuration-glossary
 position: 2
 ---
 
-- Type: `String`
-- Default: `.nuxt`
+- Tipo: `String`
+- Por defecto: `.nuxt`
 
-> Define the dist directory for your Nuxt.js application
+> Defina el directorio dist para su aplicación Nuxt.js
 
 ```js{}[nuxt.config.js]
 export default {
@@ -17,4 +17,4 @@ export default {
 }
 ```
 
-By default, many tools assume that `.nuxt` is a hidden directory, because its name starts with a dot. You can use this option to prevent that.
+De forma predeterminada, muchas herramientas asumen que `.nuxt` es un directorio oculto, porque su nombre comienza con un punto. Puede utilizar esta opción para evitarlo.

--- a/content/es/guides/configuration-glossary/configuration-cli.md
+++ b/content/es/guides/configuration-glossary/configuration-cli.md
@@ -1,0 +1,28 @@
+---
+title: 'The cli Property'
+description: Nuxt.js lets you customize the CLI configuration.
+menu: cli
+category: configuration-glossary
+position: 3
+---
+
+> Nuxt.js lets you customize the CLI configuration.
+
+## bannerColor
+
+- Type: `String`
+  - Default: `'green'`
+
+Change the color of the 'Nuxt.js' title in the CLI banner.
+
+**Available colors:**
+
+`black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`, `redBright`, `greenBright`, `yellowBright`, `blueBright`, `magentaBright`, `cyanBright`, `whiteBright`
+
+```js{}[nuxt.config.js]
+export default {
+  cli: {
+    bannerColor: 'yellow'
+  }
+}
+```

--- a/content/es/guides/configuration-glossary/configuration-cli.md
+++ b/content/es/guides/configuration-glossary/configuration-cli.md
@@ -1,21 +1,21 @@
 ---
-title: 'The cli Property'
-description: Nuxt.js lets you customize the CLI configuration.
+title: 'La propiedad cli'
+description: Nuxt.js le permite personalizar la configuración de CLI.
 menu: cli
 category: configuration-glossary
 position: 3
 ---
 
-> Nuxt.js lets you customize the CLI configuration.
+> Nuxt.js le permite personalizar la configuración de CLI.
 
 ## bannerColor
 
-- Type: `String`
-  - Default: `'green'`
+- Tipo: `String`
+  - Por defecto: `'green'`
 
-Change the color of the 'Nuxt.js' title in the CLI banner.
+Cambie el color del título 'Nuxt.js' en el banner de la CLI.
 
-**Available colors:**
+**Colores disponibles:**
 
 `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`, `redBright`, `greenBright`, `yellowBright`, `blueBright`, `magentaBright`, `cyanBright`, `whiteBright`
 

--- a/content/es/guides/configuration-glossary/configuration-components.md
+++ b/content/es/guides/configuration-glossary/configuration-components.md
@@ -1,0 +1,20 @@
+---
+title: 'The components Property'
+description: 'Nuxt.js 2.13+ can scan and auto import your components using @nuxt/components module'
+menu: components
+category: configuration-glossary
+position: 5
+---
+
+> Nuxt.js 2.13+ can scan and auto import your components.
+
+- Type: `Boolean` or `Object`
+- Default: `false`
+
+When set to `true` or using an object, it will include the [nuxt/components](https://github.com/nuxt/components) dependencies and auto import your components (defined in `~/components`) when you use them in your templates.
+
+<base-alert type="info">
+
+Please refer to [nuxt/components](https://github.com/nuxt/components) repository for usage and options.
+
+</base-alert>

--- a/content/es/guides/configuration-glossary/configuration-components.md
+++ b/content/es/guides/configuration-glossary/configuration-components.md
@@ -1,20 +1,20 @@
 ---
-title: 'The components Property'
-description: 'Nuxt.js 2.13+ can scan and auto import your components using @nuxt/components module'
+title: 'La propiedad components'
+description: 'Nuxt.js 2.13+ puede escanear e importar automáticamente sus componentes usando el módulo @nuxt/components'
 menu: components
 category: configuration-glossary
 position: 5
 ---
 
-> Nuxt.js 2.13+ can scan and auto import your components.
+> Nuxt.js 2.13+ puede escanear e importar automáticamente sus componentes.
 
-- Type: `Boolean` or `Object`
-- Default: `false`
+- Tipo: `Boolean` o `Object`
+- Por defecto: `false`
 
-When set to `true` or using an object, it will include the [nuxt/components](https://github.com/nuxt/components) dependencies and auto import your components (defined in `~/components`) when you use them in your templates.
+Cuando se establece en `true` o se usa un objeto, incluirá las dependencias de [nuxt/components](https://github.com/nuxt/components) e importará automáticamente sus componentes (definidos en "~/components") cuando los utilíces en tus templates.
 
 <base-alert type="info">
 
-Please refer to [nuxt/components](https://github.com/nuxt/components) repository for usage and options.
+Consulte el repositorio de [nuxt/components](https://github.com/nuxt/components) para conocer el uso y las opciones.
 
 </base-alert>

--- a/content/es/guides/configuration-glossary/configuration-css.md
+++ b/content/es/guides/configuration-glossary/configuration-css.md
@@ -1,0 +1,51 @@
+---
+title: 'The css Property'
+description: Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every page).
+menu: css
+category: configuration-glossary
+position: 4
+---
+
+> Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every page).
+
+In case you want to use `sass` make sure that you have installed `node-sass` and `sass-loader` packages. If you didn't just
+
+```sh
+npm install --save-dev node-sass sass-loader
+```
+
+- Type: `Array`
+  - Items: `string`
+
+```js{}[nuxt.config.js]
+export default {
+  css: [
+    // Load a Node.js module directly (here it's a Sass file)
+    'bulma',
+    // CSS file in the project
+    '@/assets/css/main.css',
+    // SCSS file in the project
+    '@/assets/css/main.scss'
+  ]
+}
+```
+
+Nuxt.js will automatically guess the file type by its extension and use the appropriate pre-processor loader for webpack. You will still need to install the required loader if you need to use them.
+
+### Style Extensions
+
+You can omit the file extension for CSS/SCSS/Postcss/Less/Stylus/... files listed in the css array in your nuxt config file.
+
+```js{}[nuxt.config.js]
+export default {
+  css: ['~/assets/css/main', '~/assets/css/animations']
+}
+```
+
+<base-alert>
+
+If you have two files with the same name eg. `main.scss` and `main.css`, and don't specify an extension in the css array entry, eg. `css: ['~/assets/css/main']`, then only one file will be loaded depending on the order of `styleExtensions`. In this case only the `css` file will be loaded and the `scss` file will be ignored because `css` comes first in the default `styleExtension` array.
+
+</base-alert>
+
+Default order: `['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']`

--- a/content/es/guides/configuration-glossary/configuration-css.md
+++ b/content/es/guides/configuration-glossary/configuration-css.md
@@ -1,40 +1,40 @@
 ---
-title: 'The css Property'
-description: Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every page).
+title: 'La propiedad css'
+description: Nuxt.js te permite definir los archivos/módulos/bibliotecas CSS que desea configurar globalmente (incluidos en cada página).
 menu: css
 category: configuration-glossary
 position: 4
 ---
 
-> Nuxt.js lets you define the CSS files/modules/libraries you want to set globally (included in every page).
+> Nuxt.js te permite definir los archivos/módulos/bibliotecas CSS que desea configurar globalmente (incluidos en cada página).
 
-In case you want to use `sass` make sure that you have installed `node-sass` and `sass-loader` packages. If you didn't just
+En caso de que desee utilizar `sass` asegúrese de haber instalado los paquetes `node-sass` y `sass-loader`. Si no solo
 
 ```sh
 npm install --save-dev node-sass sass-loader
 ```
 
-- Type: `Array`
+- Tipo: `Array`
   - Items: `string`
 
 ```js{}[nuxt.config.js]
 export default {
   css: [
-    // Load a Node.js module directly (here it's a Sass file)
+    // Cargue un módulo Node.js directamente (aquí es un archivo Sass)
     'bulma',
-    // CSS file in the project
+    // Archivo CSS en el proyecto
     '@/assets/css/main.css',
-    // SCSS file in the project
+    // Archivo SCSS en el proyecto
     '@/assets/css/main.scss'
   ]
 }
 ```
 
-Nuxt.js will automatically guess the file type by its extension and use the appropriate pre-processor loader for webpack. You will still need to install the required loader if you need to use them.
+Nuxt.js adivinará automáticamente el tipo de archivo por su extensión y usará el cargador de preprocesador apropiado para webpack. Aún necesitará instalar el cargador requerido si necesita usarlos.
 
-### Style Extensions
+### Extensiones de estilo
 
-You can omit the file extension for CSS/SCSS/Postcss/Less/Stylus/... files listed in the css array in your nuxt config file.
+Puede omitir la extensión de archivo para los archivos CSS/SCSS/Postcss/Less/Stylus/... enumerados en el array css en su archivo de configuración nuxt.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -44,8 +44,8 @@ export default {
 
 <base-alert>
 
-If you have two files with the same name eg. `main.scss` and `main.css`, and don't specify an extension in the css array entry, eg. `css: ['~/assets/css/main']`, then only one file will be loaded depending on the order of `styleExtensions`. In this case only the `css` file will be loaded and the `scss` file will be ignored because `css` comes first in the default `styleExtension` array.
+Si tiene dos archivos con el mismo nombre, por ejemplo. `main.scss` y `main.css`, y no especifique una extensión en la entrada del array css, por ejemplo. `css: ['~/assets/css/main']`, entonces solo se cargará un archivo dependiendo del orden de `styleExtensions`. En este caso, solo se cargará el archivo `css` y se ignorará el archivo `scss` porque `css` es lo primero en el array `styleExtension` predeterminado.
 
 </base-alert>
 
-Default order: `['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']`
+Orden predeterminado: `['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']`

--- a/content/es/guides/configuration-glossary/configuration-transition.md
+++ b/content/es/guides/configuration-glossary/configuration-transition.md
@@ -1,0 +1,77 @@
+---
+title: 'transition Properties'
+description: Set the default properties of the page and layout transitions.
+menu: transition
+category: configuration-glossary
+position: 31
+---
+
+## The pageTransition Property
+
+> Nuxt v2.7.0 introduces key "pageTransition" in favor of the "transition" key to consolidate the naming with layout transition keys.
+
+- Type: `String` or `Object`
+
+> Used to set the default properties of the page transitions.
+
+Default:
+
+```js
+{
+  name: 'page',
+  mode: 'out-in'
+}
+```
+
+```js{}[nuxt.config.js]
+export default {
+  pageTransition: 'page'
+  // or
+  pageTransition: {
+    name: 'page',
+    mode: 'out-in',
+    beforeEnter (el) {
+      console.log('Before enter...');
+    }
+  }
+}
+```
+
+The transition key in `nuxt.config.js` is used to set the default properties for the page transitions. To learn more about the available keys when the `transition` key is an object, see the [pages transition property](/guides/features/transitions).
+
+## The layoutTransition Property
+
+- Type: `String` or `Object`
+
+> Used to set the default properties of the layout transitions. The value provided in the `name` option is configured to work with the name provided in `layout` from your `layouts` folder.
+
+Default:
+
+```js
+{
+  name: 'layout',
+  mode: 'out-in'
+}
+```
+
+```js{}[nuxt.config.js]
+export default {
+  layoutTransition: 'layout'
+  // or
+  layoutTransition: {
+    name: 'layout',
+    mode: 'out-in'
+  }
+}
+```
+
+```css{}[assets/main.css]
+.layout-enter-active,
+.layout-leave-active {
+  transition: opacity 0.5s;
+}
+.layout-enter,
+.layout-leave-active {
+  opacity: 0;
+}
+```

--- a/content/es/guides/configuration-glossary/configuration-transition.md
+++ b/content/es/guides/configuration-glossary/configuration-transition.md
@@ -1,20 +1,20 @@
 ---
-title: 'transition Properties'
-description: Set the default properties of the page and layout transitions.
-menu: transition
+title: 'Propiedades de transición'
+description: Establezca las propiedades predeterminadas de la página y las transiciones de diseño.
+menu: transición
 category: configuration-glossary
 position: 31
 ---
 
-## The pageTransition Property
+## La propiedad pageTransition
 
-> Nuxt v2.7.0 introduces key "pageTransition" in favor of the "transition" key to consolidate the naming with layout transition keys.
+> Nuxt v2.7.0 introduce la clave "pageTransition" a favor de la clave "transition" para consolidar el nombre con claves de transición de diseño.
 
-- Type: `String` or `Object`
+- Tipo: `String` o `Object`
 
-> Used to set the default properties of the page transitions.
+> Se utiliza para establecer las propiedades predeterminadas de las transiciones de página.
 
-Default:
+Por defecto:
 
 ```js
 {
@@ -26,7 +26,7 @@ Default:
 ```js{}[nuxt.config.js]
 export default {
   pageTransition: 'page'
-  // or
+  // o
   pageTransition: {
     name: 'page',
     mode: 'out-in',
@@ -37,15 +37,15 @@ export default {
 }
 ```
 
-The transition key in `nuxt.config.js` is used to set the default properties for the page transitions. To learn more about the available keys when the `transition` key is an object, see the [pages transition property](/guides/features/transitions).
+La clave de transición en `nuxt.config.js` se usa para establecer las propiedades predeterminadas para las transiciones de página. Para obtener más información sobre las claves disponibles cuando la clave `transition` es un objeto, consulte la [propiedad de transición de páginas](/guides/features/transitions).
 
-## The layoutTransition Property
+## La propiedad layoutTransition
 
-- Type: `String` or `Object`
+- Tipo: `String` o `Object`
 
-> Used to set the default properties of the layout transitions. The value provided in the `name` option is configured to work with the name provided in `layout` from your `layouts` folder.
+> Se utiliza para establecer las propiedades predeterminadas de las transiciones de diseño. El valor proporcionado en la opción `name` está configurado para trabajar con el nombre proporcionado en `layout` de la carpeta `layouts`.
 
-Default:
+Por defecto:
 
 ```js
 {
@@ -57,7 +57,7 @@ Default:
 ```js{}[nuxt.config.js]
 export default {
   layoutTransition: 'layout'
-  // or
+  // o
   layoutTransition: {
     name: 'layout',
     mode: 'out-in'


### PR DESCRIPTION
## Translated(es-ES) @ configuration glossary

Added more Spanish translations for (#543):

📝 guides -> configuration glossary

- [x]  configuration-transition.md
- [x]  configuration-builddir.md
- [x]  configuration-cli.md
- [x]  configuration-components.md
- [x]  configuration-css.md