### PR TITLE
Fix Nuxtjs.org page broken layout

### DIFF
--- a/components/global/bases/AppModal.vue
+++ b/components/global/bases/AppModal.vue
@@ -81,7 +81,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .svg {
   width: 20px;
   color: black;

--- a/components/global/bases/BaseAlert.vue
+++ b/components/global/bases/BaseAlert.vue
@@ -25,7 +25,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .alert p {
   @apply m-0 !important;
 }


### PR DESCRIPTION
## When I open the Nuxtjs.org page on Chrome, it looks like this and I figured out the reason. ##
![image](https://user-images.githubusercontent.com/32301380/91999436-561f3b80-ed77-11ea-922a-47ed15fb38ad.png)

## ```svg``` class is added globally so that the width is limited to 20px. ##
![image](https://user-images.githubusercontent.com/32301380/91999543-7b13ae80-ed77-11ea-9895-b55a5a93e11a.png)

Styles in ```AppModal.vue``` and ```BaseAlert.vue``` are added globally. I think there is no reason they have to be added globally because **the classes in those files are not used in other components at all.**
### So I think it is better to limit their styles to be scoped and it will fix the broken layout issue. ###
Thanks.
