### PR TITLE
[SPANISH] translate guides configuration glossary

### DIFF
--- a/content/es/guides/configuration-glossary/configuration-env.md
+++ b/content/es/guides/configuration-glossary/configuration-env.md
@@ -1,0 +1,70 @@
+---
+title: 'La propiedad env'
+description: Comparte variables de entorno entre el cliente y el servidor.
+menu: env
+category: configuration-glossary
+position: 8
+---
+
+- Tipo: `Object`
+
+> Nuxt.js te permite crear variables de entorno en el lado del cliente, y también compartirlas en el lado del servidor.
+
+La propiedad env define las variables de entorno que deben estar disponibles en el lado del cliente. Estas propiedades pueden ser asignadas usando variables de entorno del lado del servidor, las del [módulo dotenv](https://github.com/nuxt-community/dotenv-module) o similares.
+
+**Asegúrate de leer sobre `process.env` y `process.env == {}` más abajo para una mejor resolución de problemas.**
+
+```js{}[nuxt.config.js]
+export default {
+  env: {
+    baseUrl: process.env.BASE_URL || 'http://localhost:3000'
+  }
+}
+```
+
+Esto te permite crear una propiedad `baseUrl` que será igual a la variable de entorno del lado del servidor `BASE_URL`, si está disponible o definida. Si no, `baseUrl` en el lado del cliente será igual a 'http://localhost:3000'. La variable del lado del servidor `BASE_URL` es, por lo tanto, copiada en el lado del cliente a través de la propiedad `env` en `nuxt.config.js`. Como alternativa, se define el otro valor (http://localhost:3000).
+
+Entonces, puedo acceder a mi variable `baseUrl` de 2 maneras:
+
+1. A través de `process.env.baseUrl`.
+2. A través de `context.env.baseUrl`, consulta [la API de contexto](/guides/internals-glossary/context).
+
+Puedes utilizar la propiedad `env` para dar un token público, por ejemplo.
+
+Para el ejemplo anterior, podemos utilizarla para configurar [axios](https://github.com/mzabriskie/axios).
+
+```js{}[plugins/axios.js]
+import axios from 'axios'
+
+export default axios.create({
+  baseURL: process.env.baseUrl
+})
+```
+
+Entonces, en tus páginas, puedes importar axios así: `import axios from '~/plugins/axios'`
+
+## Inyección automática de variables de entorno
+
+Si defines las variables de entorno empezando con `NUXT_ENV_` en la fase de construcción (p.ej. `NUXT_ENV_COOL_WORD=freezing nuxt build`), se inyectarán automáticamente en el entorno del proceso. Ten en cuenta que potencialmente tendrán prioridad sobre las variables definidas con el mismo nombre en tu `nuxt.config.js`.
+
+## process.env == {}
+
+Ten en cuenta que Nuxt utiliza `definePlugin` de webpack para definir la variable de entorno. Esto significa que el `process` actual o `process.env` de Node.js no está disponible ni definido. Cada una de las propiedades `env` definidas en nuxt.config.js es mapeada individualmente a `process.env.xxxx` y convertida durante la compilación.
+
+Es decir, `console.log(process.env)` emitirá `{}` pero `console.log(process.env.your_var)` seguirá emitiendo tu valor. Cuando webpack compila tu código, reemplaza todas las instancias de `process.env.your_var` al valor que tú le has dado. Por ejemplo: `env.test = 'testing123'`. Si usas `process.env.test` en tu código en algún lugar, se traduce a 'testing123'.
+
+antes
+
+```js
+if (process.env.test == 'testing123')
+```
+
+después
+
+```js
+if ('testing123' == 'testing123')
+```
+
+## serverMiddleware
+
+Como [serverMiddleware](/guides/configuration-glossary/configuration-servermiddleware) está desacoplado de la construcción principal de Nuxt, las variables `env` definidas en `nuxt.config.js` no están disponibles ahí.

--- a/content/es/guides/configuration-glossary/configuration-extend-plugins.md
+++ b/content/es/guides/configuration-glossary/configuration-extend-plugins.md
@@ -1,0 +1,32 @@
+---
+title: 'La propiedad extendPlugins'
+description: La propiedad extendPlugins te permite personalizar los plugins de Nuxt.js.
+menu: extendPlugins
+category: configuration-glossary
+position: 9
+---
+
+> La propiedad extendPlugins te permite personalizar los plugins de Nuxt.js ([options.plugins](/guides/configuration-glossary/configuration-plugins)).
+
+- Tipo: `Function`
+- Por defecto: `undefined`
+
+Puede que quieras extender los plugins o cambiar el orden de los plugins creado por Nuxt.js. Esta función acepta un array de objetos [plugin](/guides/configuration-glossary/configuration-plugins) y debería devolver el array de objetos plugin.
+
+Ejemplo cambiando el orden de los plugins:
+
+```js{}[nuxt.config.js]
+export default {
+  extendPlugins(plugins) {
+    const pluginIndex = plugins.findIndex(
+      ({ src }) => src === '~/plugins/shouldBeFirst.js'
+    )
+    const shouldBeFirstPlugin = plugins[pluginIndex]
+
+    plugins.splice(pluginIndex, 1)
+    plugins.unshift(shouldBeFirstPlugin)
+
+    return plugins
+  }
+}
+```

--- a/content/es/guides/configuration-glossary/configuration-global-name.md
+++ b/content/es/guides/configuration-glossary/configuration-global-name.md
@@ -1,0 +1,42 @@
+---
+title: 'La propiedad globalName'
+description: Nuxt.js te permite personalizar el ID global utilizado en la plantilla HTML principal, así como el nombre de la instancia principal de Vue y otras opciones.
+menu: globalName
+category: configuration-glossary
+position: 11
+---
+
+> Nuxt.js te permite personalizar el ID global utilizado en la plantilla HTML principal, así como el nombre de la instancia principal de Vue y otras opciones.
+
+- Tipo: `String`
+- Por defecto: `nuxt`
+
+```js{}[nuxt.config.js]
+{
+  globalName: 'myCustomName'
+}
+```
+
+<base-alert>
+
+`globalName` debe ser un identificador válido de JavaScript, y cambiarlo puede romper el soporte de ciertos plugins que dependen de funciones con nomenclatura de Nuxt. Si estás buscando cambiar sólo el ID HTML visible `__nuxt`, entonces usa la propiedad `globals`.
+
+</base-alert>
+
+## La propiedad globals
+
+> Personaliza los nombres globales específicos basados en `globalName` por defecto.
+
+- Tipo: `Object`
+- Por defecto:
+
+```js{}[nuxt.config.js]
+globals: {
+  id: globalName => `__${globalName}`,
+  nuxt: globalName => `$${globalName}`,
+  context: globalName => `__${globalName.toUpperCase()}__`,
+  pluginPrefix: globalName => globalName,
+  readyCallback: globalName => `on${_.capitalize(globalName)}Ready`,
+  loadedCallback: globalName => `_on${_.capitalize(globalName)}Loaded`
+},
+```

--- a/content/es/guides/configuration-glossary/configuration-head.md
+++ b/content/es/guides/configuration-glossary/configuration-head.md
@@ -1,0 +1,35 @@
+---
+title: 'La propiedad head'
+description: Nuxt.js te permite definir todas las etiquetas meta por defecto de tu aplicación dentro de nuxt.config.js.
+menu: head
+category: configuration-glossary
+position: 12
+---
+
+> Nuxt.js te permite definir todas las etiquetas meta por defecto de tu aplicación dentro de `nuxt.config.js`, usando la misma propiedad `head`
+
+- Tipo: `Object` o `Function`
+
+```js{}[nuxt.config.js]
+export default {
+  head: {
+    titleTemplate: '%s - Nuxt.js',
+    meta: [
+      { charset: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+
+      // hid is used as unique identifier. Do not use `vmid` for it as it will not work
+      { hid: 'description', name: 'description', content: 'Meta description' }
+    ]
+  }
+}
+```
+Para saber la lista de opciones que puedes dar a la propiedad `head`, echa un vistazo a la [documentación de vue-meta](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
+
+También puedes usar `head` como una función en tus componentes para acceder a los datos del componente a través de `this` ([leer más](/guides/components-glossary/pages-head)).
+
+<base-alert type="info">
+
+<b>Info:</b> Para evitar la duplicación de etiquetas meta cuando se utiliza en un componente hijo, añade un identificador único con la clave `hid` para tus metas ([leer más](https://vue-meta.nuxtjs.org/api/#tagidkeyname)).
+
+</base-alert>


### PR DESCRIPTION
Pages translated to Spanish for #543 

📝 guides -> configuration-glossary

 configuration-env.md
 configuration-extend-plugins.md
 configuration-global-name.md
 configuration-head.md