### PR TITLE
fix small syntax error in plugin docs

### DIFF
--- a/content/en/guide/plugins.md
+++ b/content/en/guide/plugins.md
@@ -119,7 +119,7 @@ export default {
     this.$hello('mounted')
     // will console.log 'Hello mounted!'
   },
-  asyncData ({ $hello ) {
+  asyncData ({ $hello }) {
     $hello('asyncData')
   }
 }


### PR DESCRIPTION
just noticed a small syntax error in the `https://nuxtjs.org/guide/plugins/` docs

```
asyncData ({ $hello ) {
  $hello('asyncData')
}
```

i just added a extra `}` to

```
asyncData ({ $hello }) {
  $hello('asyncData')
}
```