### PR TITLE
[Spanish] Translate guides configuration glossary

### DIFF
--- a/content/es/guides/configuration-glossary/configuration-target.md
+++ b/content/es/guides/configuration-glossary/configuration-target.md
@@ -1,12 +1,12 @@
 ---
 title: 'La propiedad target'
-description: Cambiar el destino por defecto de Nuxt.
+description: Cambiar el target por defecto de Nuxt.
 menu: target
 category: configuration-glossary
 position: 29
 ---
 
-Destinos de despliegue para Nuxt >= v2.13:
+Targets de despliegue para Nuxt >= v2.13:
 
 - Tipo: `string`
   - Por defecto: `server`
@@ -14,6 +14,6 @@ Destinos de despliegue para Nuxt >= v2.13:
     - `'server'`: para renderizado en el lado del servidor
     - `'static'`: para sitios estáticos
 
-> Puedes usar esta opción para cambiar el destino por defecto de Nuxt en tu proyecto, usando `nuxt.config.js`.
+> Puedes usar esta opción para cambiar el target por defecto de Nuxt en tu proyecto, usando `nuxt.config.js`.
 
-Para saber más sobre la opción target, visita la [sección de destinos de despliegue](/guides/features/deployment-targets).
+Para saber más sobre la opción target, visita la [sección de targets de despliegue](/guides/features/deployment-targets).

--- a/content/es/guides/configuration-glossary/configuration-target.md
+++ b/content/es/guides/configuration-glossary/configuration-target.md
@@ -1,0 +1,19 @@
+---
+title: 'La propiedad target'
+description: Cambiar el destino por defecto de Nuxt.
+menu: target
+category: configuration-glossary
+position: 29
+---
+
+Destinos de despliegue para Nuxt >= v2.13:
+
+- Tipo: `string`
+  - Por defecto: `server`
+  - Valores posibles:
+    - `'server'`: para renderizado en el lado del servidor
+    - `'static'`: para sitios estáticos
+
+> Puedes usar esta opción para cambiar el destino por defecto de Nuxt en tu proyecto, usando `nuxt.config.js`.
+
+Para saber más sobre la opción target, visita la [sección de destinos de despliegue](/guides/features/deployment-targets).

--- a/content/es/guides/configuration-glossary/configuration-vue-config.md
+++ b/content/es/guides/configuration-glossary/configuration-vue-config.md
@@ -1,0 +1,36 @@
+---
+title: 'La propiedad vue.config'
+description: Un objeto de configuración para Vue.config
+menu: vue.config
+category: configuration-glossary
+position: 32
+---
+
+- Tipo: `Object`
+- Por defecto: `{ silent: !isDev, performance: isDev }`
+
+> La propiedad vue.config ofrece un puente directo de configuración para `Vue.config`.
+
+**Ejemplo**
+
+```js{}[nuxt.config.js]
+export default {
+  vue: {
+    config: {
+      productionTip: true,
+      devtools: false
+    }
+  }
+}
+```
+
+Esta configuración resulta en el siguiente Vue.config:
+
+```js
+Vue.config.productionTip // true
+Vue.config.devtools // false
+Vue.config.silent // !isDev [valor por defecto]
+Vue.config.performance // isDev [valor por defecto]
+```
+
+Para saber más sobre la API de `Vue.config`, visita la [documentación oficial de Vue](https://vuejs.org/v2/api/#Global-Config)

--- a/content/es/guides/configuration-glossary/configuration-watch.md
+++ b/content/es/guides/configuration-glossary/configuration-watch.md
@@ -1,0 +1,18 @@
+---
+title: 'La propiedad watch'
+description: La propiedad watch permite observar ficheros propios para reiniciar el servidor.
+menu: watch
+category: configuration-glossary
+position: 33
+---
+
+- Tipo: `Object`
+- Por defecto: `[]`
+
+> La propiedad watch permite observar ficheros propios para reiniciar el servidor.
+
+```js
+watch: ['~/custom/*.js']
+```
+
+Usamos [chokidar](https://github.com/paulmillr/chokidar) para configurar los observadores. Para saber más sobre las opciones de plantillas de chokidar, visita la [API de chokidar](https://github.com/paulmillr/chokidar#api).

--- a/content/es/guides/configuration-glossary/configuration-watch.md
+++ b/content/es/guides/configuration-glossary/configuration-watch.md
@@ -1,6 +1,6 @@
 ---
 title: 'La propiedad watch'
-description: La propiedad watch permite observar ficheros propios para reiniciar el servidor.
+description: La propiedad watch permite observar archivos personalizados para reiniciar el servidor.
 menu: watch
 category: configuration-glossary
 position: 33
@@ -9,7 +9,7 @@ position: 33
 - Tipo: `Object`
 - Por defecto: `[]`
 
-> La propiedad watch permite observar ficheros propios para reiniciar el servidor.
+> La propiedad watch permite observar archivos personalizados para reiniciar el servidor.
 
 ```js
 watch: ['~/custom/*.js']

--- a/content/es/guides/configuration-glossary/configuration-watchers.md
+++ b/content/es/guides/configuration-glossary/configuration-watchers.md
@@ -1,0 +1,43 @@
+---
+title: 'La propiedad watchers'
+description: La propiedad watchers permite sobreescribir la configuración de los observadores.
+menu: watchers
+category: configuration-glossary
+position: 34
+---
+
+- Tipo: `Object`
+- Por defecto: `{}`
+
+> La propiedad watchers permite sobreescribir la configuración de los observadores en nuxt.config.js.
+
+## chokidar
+
+- Tipo: `Object`
+- Por defecto: `{}`
+
+Para saber más sobre las opciones de chokidar, visita la [API de chokidar](https://github.com/paulmillr/chokidar#api).
+
+## webpack
+
+- Tipo: `Object`
+- Por defecto:
+
+```js
+watchers: {
+  webpack: {
+    aggregateTimeout: 300,
+    poll: 1000
+  }
+}
+```
+
+Para saber más sobre las watchoptions de webpack, visita la [documentación de webpack](https://webpack.js.org/configuration/watch/#watchoptions).
+
+### A continuación...
+
+<base-alert type="next">
+
+Echa un vistazo al [libro Glosario de Internos](/guides/internals-glossary/$nuxt)
+
+</base-alert>


### PR DESCRIPTION
Pages translated to Spanish for #543

📝 guides -> configuration-glossary

- [x] configuration-target.md
- [x] configuration-vue-config.md
- [x] configuration-watch.md
- [x] configuration-watchers.md