### PR TITLE
Translate guides configuration glossary pages to Spanish (es-ES)

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-rootdir.md
+++ b/content/en/guides/configuration-glossary/configuration-rootdir.md
@@ -11,10 +11,10 @@ position: 23
 
 > Define the workspace directory of your Nuxt.js application.
 
-This property will be overwritten by the nuxt commands(nuxt start, nuxt build etc) if an argument is passed to them. Eg running `nuxt ./my-app/` will set the `rootDir` to the absolute path of `./my-app/` from the current/working directory
+This property will be overwritten by the nuxt commands(nuxt start, nuxt build etc) if an argument is passed to them. Eg running `nuxt ./my-app/` will set the `rootDir` to the absolute path of `./my-app/` from the current/working directory.
 
 Because of that its normally not needed to configure this option unless you will use [Nuxt.js programmatically](/guides/internals-glossary/nuxt).
 
-<base-alert type="info"> Both `rootDir` as the package root containing the `node_modules` directory need to be within the same directory tree to be able to <NuxtLink to="https://nodejs.org/api/modules.html#modules_all_together">resolve dependencies.</NuxtLink> See the <NuxtLink to="/guides/configuration-glossary/configuration-srcdir">`srcDir` option</NuxtLink> for examples of directory structure when thats not the case
+<base-alert type="info"> Both `rootDir` as the package root containing the `node_modules` directory need to be within the same directory tree to be able to <NuxtLink to="https://nodejs.org/api/modules.html#modules_all_together">resolve dependencies.</NuxtLink> See the <NuxtLink to="/guides/configuration-glossary/configuration-srcdir">`srcDir` option</NuxtLink> for examples of directory structure when that is not the case.
 
 </base-alert>

--- a/content/en/guides/configuration-glossary/configuration-srcdir.md
+++ b/content/en/guides/configuration-glossary/configuration-srcdir.md
@@ -11,7 +11,7 @@ position: 28
 
 > Define the source directory of your Nuxt.js application
 
-If a relative path is specified it will be relative to the rootDir
+If a relative path is specified it will be relative to the `rootDir`.
 
 Example 1: Prerequisites:
 
@@ -47,7 +47,7 @@ works with the following folder structure (note that nuxt.config is listed in th
 
 Example 2:
 
-Instead of example 1 you can also move the nuxt.config into your src folder. In this case you only need to specify client as the rootDir and you can leave srcDir empty:
+Instead of example 1 you can also move the nuxt.config into your `src` folder. In this case you only need to specify client as the `rootDir` and you can leave `srcDir` empty:
 
 Prerequisites:
 

--- a/content/es/guides/configuration-glossary/configuration-rootdir.md
+++ b/content/es/guides/configuration-glossary/configuration-rootdir.md
@@ -1,0 +1,19 @@
+---
+title: 'La propiedad rootDir'
+description: Define el espacio de trabajo de la aplicación Nuxt.js
+menu: rootDir
+category: configuration-glossary
+position: 23
+---
+
+- Tipo: `String`
+- Por defecto: `process.cwd()`
+
+> Define el directorio del espacio de trabajo de tu aplicación Nuxt.js.
+
+Esta propiedad será sobrescrita por los comandos de nuxt (nuxt start, nuxt build etc) si se les pasa un argumento. Por ejemplo, ejecutar `nuxt ./my-app/` establecerá el `rootDir` a la ruta absoluta de `./my-app/` desde el directorio de trabajo actual.
+
+Por eso, normalmente no es necesario configurar esta opción a menos que utilice [Nuxt.js mediante programación](/guides/internals-glossary/nuxt).
+
+<base-alert type="info"> Tanto `rootDir` como la raíz del paquete que contiene el directorio `node_modules` deben estar dentro del mismo árbol de directorios para poder <NuxtLink to="https://nodejs.org/api/modules.html#modules_all_together">resolver las dependencias</NuxtLink>. Consulta la <NuxtLink to="/guides/configuration-glossary/configuration-srcdir">opción `srcDir`</NuxtLink> para ejemplos de estructura de directorios cuando ese no es el caso.
+</base-alert>

--- a/content/es/guides/configuration-glossary/configuration-runtime-config.md
+++ b/content/es/guides/configuration-glossary/configuration-runtime-config.md
@@ -6,7 +6,7 @@ category: configuration-glossary
 position: 25
 ---
 
-La configuración en tiempo de ejecución permite pasar variables dinámicas de configuración y de entorno al contexto nuxt. Para más información de uso, consulta [runtime config guide](/guide/runtime-config).
+La configuración en tiempo de ejecución permite pasar variables dinámicas de configuración y de entorno al contexto de nuxt. Para más información de uso, consulta [runtime config guide](/guide/runtime-config).
 
 ## `publicRuntimeConfig`
 

--- a/content/es/guides/configuration-glossary/configuration-runtime-config.md
+++ b/content/es/guides/configuration-glossary/configuration-runtime-config.md
@@ -1,0 +1,21 @@
+---
+title: 'Propiedades RuntimeConfig'
+description: RuntimeConfig permite pasar variables dinámicas de configuración y de entorno al contexto nuxt
+menu: runtimeConfig
+category: configuration-glossary
+position: 25
+---
+
+La configuración en tiempo de ejecución permite pasar variables dinámicas de configuración y de entorno al contexto nuxt. Para más información de uso, consulta [runtime config guide](/guide/runtime-config).
+
+## `publicRuntimeConfig`
+
+- Tipo: `Object`
+
+El valor de este objeto es **accesible tanto desde el cliente como desde el servidor** usando `$config`.
+
+## `privateRuntimeConfig`
+
+- Tipo: `Object`
+
+El valor de este objeto es accesible **solo desde el servidor** usando `$config`. Anula `publicRuntimeConfig` para el servidor.

--- a/content/es/guides/configuration-glossary/configuration-srcdir.md
+++ b/content/es/guides/configuration-glossary/configuration-srcdir.md
@@ -1,0 +1,82 @@
+---
+title: 'La propiedad srcDir'
+description: Defina el directorio de origen de tu aplicación Nuxt.js
+menu: srcDir
+category: configuration-glossary
+position: 28
+---
+
+- Tipo: `String`
+- Por defecto: [rootDir value](/guides/configuration-glossary/configuration-rootdir)
+
+> Define el directorio de origen de tu aplicación Nuxt.js
+
+Si se especifica una ruta relativa, será relativa al `rootDir`.
+
+Ejemplo 1: Prerrequisitos:
+
+```js{}[nuxt.config.js]
+export default {
+  srcDir: 'client/'
+}
+```
+
+```js{}[package.json]
+  "script": {
+    "dev": "yarn nuxt"
+  }
+```
+
+funciona con la siguiente estructura de carpetas (ten en cuenta que nuxt.config aparece en el directorio de la aplicación)
+
+```bash
+-| app/
+---| node_modules/
+---| nuxt.config.js
+---| package.json
+---| client/
+------| assets/
+------| components/
+------| layouts/
+------| middleware/
+------| pages/
+------| plugins/
+------| static/
+------| store/
+```
+
+Ejemplo 2:
+
+En lugar del ejemplo 1, también puedes mover nuxt.config a tu carpeta `src`. En este caso solo necesitas especificar el cliente como el `rootDir` y puedes dejar el `srcDir` vacío:
+
+Prerrequisitos:
+
+```js{}[nuxt.config.js]
+export default {
+  srcDir: '' // o simplemente quítalo
+}
+```
+
+```js{}[package.json]
+  "script": {
+    "dev": "yarn nuxt client" // Esto establece al cliente como rootDir
+  }
+```
+
+funciona con la siguiente estructura de carpetas (ten en cuenta que nuxt.config aparece en el directorio del cliente)
+
+```bash
+-| app/
+---| node_modules/
+---| package.json
+---| client/
+------| nuxt.config.js
+------| assets/
+------| components/
+------| layouts/
+------| middleware/
+------| pages/
+------| plugins/
+------| static/
+------| store/
+```


### PR DESCRIPTION
## Related to #543

Add the Spanish translation of the following pages.

📝 guides -> configuration glossary
- [x] configuration-rootdir.md
- [x] configuration-runtime-config.md
- [x] configuration-srcdir.md