### PR TITLE
docs: Add deploy to Bip tutorial

### DIFF
--- a/content/en/faq/appengine-deployment.md
+++ b/content/en/faq/appengine-deployment.md
@@ -3,7 +3,7 @@ title: How to deploy on Google App Engine?
 description: How to deploy Nuxt.js on Google App Engine?
 menu: Deploy on Google App Engine
 category: deployment
-position: 206
+position: 207
 ---
 
 Deploying to [Google App Engine](https://cloud.google.com/appengine/) is a fast and easy solution for hosting your universal Nuxt application on Google's Cloud Services.

--- a/content/en/faq/bip-deployment.md
+++ b/content/en/faq/bip-deployment.md
@@ -1,0 +1,52 @@
+---
+title: How to deploy with Bip?
+description: How to deploy a NuxtJS app with Bip?
+menu: Deploy on Bip
+category: deployment
+position: 204
+---
+
+[Bip](https://bip.sh) is a commercial hosting service which provides zero downtime deployment, a global CDN, SSL, unlimited bandwidth and more for NuxtJS static websites. Plans are available on a pay as you go, per domain basis.
+
+The following guide will show you how to deploy your NuxtJS static site to Bip in just a couple simple steps.
+
+## Prerequisites
+
+- You have [Yarn](https://yarnpkg.com/getting-started/install) installed.
+- You have the Bip CLI installed, along with a Bip account and domain ready to use. Visit the [Bip Get Started guide](https://bip.sh/getstarted) for further instructions.
+
+## Step 1: Initial setup
+
+You'll first need a NuxtJS project ready to deploy and share with the world. If you need a project, use the [create-nuxt-app](https://github.com/nuxt/create-nuxt-app):
+
+Use Yarn to create your new project:
+
+```bash
+yarn create nuxt-app <project-name>
+```
+
+Follow the prompts to setup your NuxtJS project. Ensure that when you reach the 'Deployment target' setting, select 'Static (Static/JAMStack hosting)'.
+
+Once complete, move into your new directory:
+
+```bash
+cd <project-name>
+```
+
+Next, you'll need to initialise your project with Bip. This only needs to be done once.
+
+```bash
+bip init
+```
+
+Follow the prompts, where you'll be asked which domain you'd like to deploy to. Bip will detect that you're using NuxtJS, and set project settings like the source file directory automatically.
+
+## Step 2: Deploy
+
+You're now ready to deploy your website. To do so, run:
+
+```bash
+yarn generate && bip deploy
+```
+
+That's it! After a few moments, your website will be deployed.

--- a/content/en/faq/deployment-cloud-run.md
+++ b/content/en/faq/deployment-cloud-run.md
@@ -3,7 +3,7 @@ title: How to deploy on Google Cloud Run?
 description: How to deploy NuxtJS on Google Cloud Run?
 menu: Deploy on Google Cloud Run
 category: deployment
-position: 207
+position: 208
 ---
 
 [Google Cloud Run](https://cloud.google.com/run) is a fully managed compute platform for deploying and scaling containerized applications quickly and securely.

--- a/content/en/faq/deployment-pm2.md
+++ b/content/en/faq/deployment-pm2.md
@@ -3,7 +3,7 @@ title: How to deploy using PM2 cluster mode?
 description: How to deploy Nuxt.js with PM2 cluster mode enabled?
 menu: Deploy using PM2 cluster mode
 category: deployment
-position: 212
+position: 213
 ---
 
 Deploying using [PM2](https://pm2.keymetrics.io/) (Process Manager 2) is a fast and easy solution for hosting your universal Nuxt application on your server or VM.

--- a/content/en/faq/dokku-deployment.md
+++ b/content/en/faq/dokku-deployment.md
@@ -3,7 +3,7 @@ title: How to deploy on Dokku?
 description: How to deploy a Nuxt.js application on Dokku?
 menu: Deploy on Dokku
 category: deployment
-position: 204
+position: 205
 ---
 
 We recommend to read [Dokku documentation for the setup](http://dokku.viewdocs.io/dokku/getting-started/installation/) and [Deploying a Node.js Application on Digital Ocean using Dokku](http://jakeklassen.com/post/deploying-a-node-app-on-digital-ocean-using-dokku/).

--- a/content/en/faq/github-pages.md
+++ b/content/en/faq/github-pages.md
@@ -3,7 +3,7 @@ title: How to deploy on GitHub Pages?
 description: How to deploy Nuxt.js app on GitHub Pages?
 menu: Deploy on Github
 category: deployment
-position: 205
+position: 206
 ---
 
 Nuxt.js gives you the possibility to host your web application on any static hosting like [GitHub Pages](https://pages.github.com/) for example.

--- a/content/en/faq/heroku-deployment.md
+++ b/content/en/faq/heroku-deployment.md
@@ -3,7 +3,7 @@ title: How to deploy on Heroku?
 description: How to deploy Nuxt.js on Heroku?
 menu: Deploy on Heroku
 category: deployment
-position: 208
+position: 209
 ---
 
 We recommend you read the [Heroku documentation for Node.js](https://devcenter.heroku.com/articles/nodejs-support).

--- a/content/en/faq/netlify-deployment.md
+++ b/content/en/faq/netlify-deployment.md
@@ -3,7 +3,7 @@ title: How to deploy on Netlify?
 description: How to deploy Nuxt.js on Netlify?
 menu: Deploy on Netlify
 category: deployment
-position: 209
+position: 210
 ---
 
 Deploying to [Netlify](https://www.netlify.com) is a low friction option for getting a **statically generated** Nuxt.js site online quickly.

--- a/content/en/faq/nginx-proxy.md
+++ b/content/en/faq/nginx-proxy.md
@@ -3,7 +3,7 @@ title: Using nginx as a reverse proxy
 description: How to use nginx as a reverse proxy
 menu: Using nginx as a proxy
 category: deployment
-position: 213
+position: 214
 ---
 
 ```nginx

--- a/content/en/faq/now-deployment.md
+++ b/content/en/faq/now-deployment.md
@@ -3,7 +3,7 @@ title: How to deploy with Vercel?
 description: How to deploy Nuxt.js app with Vercel?
 menu: Deploy on Vercel
 category: deployment
-position: 210
+position: 211
 ---
 
 ![nuxt-now-builder](https://user-images.githubusercontent.com/904724/61308402-7a752d00-a7f0-11e9-9502-23731ccd00fd.png)

--- a/content/en/faq/surge-deployment.md
+++ b/content/en/faq/surge-deployment.md
@@ -3,7 +3,7 @@ title: How to deploy with Surge?
 description: How to deploy Nuxt.js app with Surge?
 menu: Deploy on Surge
 category: deployment
-position: 211
+position: 212
 ---
 
 Nuxt.js gives you the possibility to host your web application on any static hosting like [Surge](https://surge.sh/) for example.


### PR DESCRIPTION
## Description

Added a short tutorial on how to deploy to [Bip](https://bip.sh). Bip contains automatic framework detection for NuxtJS, so this is reflected in the guide. 

An example NuxtJS project hosted on Bip is available at https://nuxtjsexample.bip.sh, which utilises [create-nuxt-app](https://github.com/nuxt/create-nuxt-app).