### PR TITLE
[Spanish] Translate guides configuration glossary

### DIFF
--- a/content/es/guides/configuration-glossary/configuration-dev.md
+++ b/content/es/guides/configuration-glossary/configuration-dev.md
@@ -16,7 +16,7 @@ Esta propiedad es sobreescrita por los comandos nuxt:
 - `dev` es forzado a `true` con `nuxt`
 - `dev` es forzado a `false` con `nuxt build`, `nuxt start` y `nuxt generate`
 
-Esta propiedad debería usarse al utilizar [Nuxt.js programáticamente](/guides/internals-glossary/nuxt):
+Esta propiedad debería usarse al emplear [Nuxt.js programáticamente](/guides/internals-glossary/nuxt):
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/es/guides/configuration-glossary/configuration-dev.md
+++ b/content/es/guides/configuration-glossary/configuration-dev.md
@@ -1,0 +1,56 @@
+---
+title: 'La propiedad dev'
+description: Define el modo desarrollo o producción.
+menu: dev
+category: configuration-glossary
+position: 6
+---
+
+- Tipo: `Boolean`
+- Por defecto: `true`
+
+> Define el mode desarrollo o producción de Nuxt.js.
+
+Esta propiedad es sobreescrita por los comandos nuxt:
+
+- `dev` es forzado a `true` con `nuxt`
+- `dev` es forzado a `false` con `nuxt build`, `nuxt start` y `nuxt generate`
+
+Esta propiedad debería usarse al utilizar [Nuxt.js programáticamente](/guides/internals-glossary/nuxt):
+
+```js{}[nuxt.config.js]
+export default {
+  dev: process.env.NODE_ENV !== 'production'
+}
+```
+
+```js{}[server.js]
+const { Nuxt, Builder } = require('nuxt')
+const app = require('express')()
+const port = process.env.PORT || 3000
+
+// Instanciamos Nuxt.js con las opciones
+const config = require('./nuxt.config.js')
+const nuxt = new Nuxt(config)
+app.use(nuxt.render)
+
+// Build sólo en modo dev
+if (config.dev) {
+  new Builder(nuxt).build()
+}
+
+// El servidor escucha
+app.listen(port, '0.0.0.0').then(() => {
+  console.log(`El servidor está escuchando en el puerto: ${port}`)
+})
+```
+
+```json{}[package.json]
+{
+  "scripts": {
+    "dev": "node server.js",
+    "build": "nuxt build",
+    "start": "NODE_ENV=production node server.js"
+  }
+}
+```

--- a/content/es/guides/configuration-glossary/configuration-dir.md
+++ b/content/es/guides/configuration-glossary/configuration-dir.md
@@ -1,0 +1,38 @@
+---
+title: 'La propiedad dir'
+description: Define los directorios personalizados para tu aplicación Nuxt.js
+menu: dir
+category: configuration-glossary
+position: 7
+---
+
+- Tipo: `Object`
+- Por defecto:
+
+```js
+{
+  assets: 'assets',
+  app: 'app',
+  layouts: 'layouts',
+  middleware: 'middleware',
+  pages: 'pages',
+  static: 'static',
+  store: 'store'
+}
+```
+
+> Define los directorios personalizados para tu aplicación Nuxt.js
+
+```js{}[nuxt.config.js]
+export default {
+  dir: {
+    assets: 'custom-assets',
+    app: 'custom-app',
+    layouts: 'custom-layouts',
+    middleware: 'custom-middleware',
+    pages: 'custom-pages',
+    static: 'custom-static',
+    store: 'custom-store'
+  }
+}
+```

--- a/content/es/guides/configuration-glossary/configuration-modern.md
+++ b/content/es/guides/configuration-glossary/configuration-modern.md
@@ -11,14 +11,14 @@ position: 18
 - Tipo: `String` o `Boolean`
   - Por defecto: false
   - Valores posibles:
-    - `'client'`: Sirve tanto el script de paquete moderno `<script type="module">` como legacy `<script nomodule>`, además de ofrecer un `<link rel="modulepreload">` para el paquete moderno. Los navegadores que entiendan el tipo `module`, cargarán el paquete moderno, mientras que navegadores más antiguos usarán el legacy (transpiled).
-    - `'server'` or `true`: El servidor Node.js comprobará la versión del navegador a partir del user agent, y servirá el paquete moderno o legacy correspondiente.
-    - `false`: Deshabilitar build moderno.
+    - `'client'`: Sirve tanto el script de paquete moderno `<script type="module">` como _legacy_ `<script nomodule>`, además de ofrecer un `<link rel="modulepreload">` para el paquete moderno. Los navegadores que entiendan el tipo `module`, cargarán el paquete moderno, mientras que navegadores más antiguos usarán el _legacy_ (_transpiled_).
+    - `'server'` or `true`: El servidor Node.js comprobará la versión del navegador a partir del user agent, y servirá el paquete moderno o _legacy_ correspondiente.
+    - `false`: Deshabilitar el _build_ moderno.
 
 Las dos versiones de paquetes son:
 
 1. Paquete moderno: orientado a navegadores modernos que soportan módulos ES.
-1. Paquete legacy: orientado a navegadores más antiguos, basado en config de babel (compatible con IE9 por defecto).
+1. Paquete _legacy_: orientado a navegadores más antiguos, basado en config de babel (compatible con IE9 por defecto).
 
 **Info:**
 
@@ -35,7 +35,7 @@ Las dos versiones de paquetes son:
 
 **Nota sobre _nuxt generate_:** La propiedad `modern` también funciona con el comando `nuxt generate`, pero en este caso, sólo se admite la opción `client`, y ésta será seleccionada automáticamente al ejecutar el comando `nuxt generate --modern` sin especificar ningún valor.
 
-- Nuxt detectará automáticamente `modern` build en `nuxt start` cuando `modern` no esté definido, modo auto-detectado es:
+- Nuxt detectará automáticamente el _build_ `modern` en `nuxt start` cuando `modern` no esté definido, modo auto-detectado es:
 
 | Modo      | Modo moderno |
 | --------- | :---------: |

--- a/content/es/guides/configuration-glossary/configuration-modern.md
+++ b/content/es/guides/configuration-glossary/configuration-modern.md
@@ -45,4 +45,4 @@ Las dos versiones de paquetes son:
 - El modo moderno para `nuxt generate` sólo puede ser `client`
 - Utiliza [`render.crossorigin`](/guides/configuration-glossary/configuration-render#crossorigin) para definir el atributo `crossorigin` en `<link>` y `<script>`
 
-> Por favor, visita el [excelente post de Phillip Walton](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) para más información sobre builds modernos.
+> Por favor, visita este [excelente post de Phillip Walton](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) para más información sobre _builds_ modernos.

--- a/content/es/guides/configuration-glossary/configuration-modern.md
+++ b/content/es/guides/configuration-glossary/configuration-modern.md
@@ -1,0 +1,48 @@
+---
+title: 'La propiedad modern'
+description: Construye y sirve un paquete moderno
+menu: modern
+category: configuration-glossary
+position: 18
+---
+
+> Esta funcionalidad está inspirada por [vue-cli modern mode](https://cli.vuejs.org/guide/browser-compatibility.html#modern-mode)
+
+- Tipo: `String` o `Boolean`
+  - Por defecto: false
+  - Valores posibles:
+    - `'client'`: Sirve tanto el script de paquete moderno `<script type="module">` como legacy `<script nomodule>`, además de ofrecer un `<link rel="modulepreload">` para el paquete moderno. Los navegadores que entiendan el tipo `module`, cargarán el paquete moderno, mientras que navegadores más antiguos usarán el legacy (transpiled).
+    - `'server'` or `true`: El servidor Node.js comprobará la versión del navegador a partir del user agent, y servirá el paquete moderno o legacy correspondiente.
+    - `false`: Deshabilitar build moderno.
+
+Las dos versiones de paquetes son:
+
+1. Paquete moderno: orientado a navegadores modernos que soportan módulos ES.
+1. Paquete legacy: orientado a navegadores más antiguos, basado en config de babel (compatible con IE9 por defecto).
+
+**Info:**
+
+- Usa la opción `[--modern | -m]=[mode]` para construir/iniciar paquetes modernos:
+
+```json{}[package.json]
+{
+  "scripts": {
+    "build:modern": "nuxt build --modern=server",
+    "start:modern": "nuxt start --modern=server"
+  }
+}
+```
+
+**Nota sobre _nuxt generate_:** La propiedad `modern` también funciona con el comando `nuxt generate`, pero en este caso, sólo se admite la opción `client`, y ésta será seleccionada automáticamente al ejecutar el comando `nuxt generate --modern` sin especificar ningún valor.
+
+- Nuxt detectará automáticamente `modern` build en `nuxt start` cuando `modern` no esté definido, modo auto-detectado es:
+
+| Modo      | Modo moderno |
+| --------- | :---------: |
+| universal |   server    |
+| spa       |   client    |
+
+- El modo moderno para `nuxt generate` sólo puede ser `client`
+- Utiliza [`render.crossorigin`](/guides/configuration-glossary/configuration-render#crossorigin) para definir el atributo `crossorigin` en `<link>` y `<script>`
+
+> Por favor, visita el [excelente post de Phillip Walton](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) para más información sobre builds modernos.


### PR DESCRIPTION
Pages translated to Spanish for #543

📝 guides -> configuration-glossary

- [x] configuration-dev.md
- [x] configuration-dir.md
- [x] configuration-modern.md