### PR TITLE
Update CSP Documentation

### DIFF
--- a/content/en/api/configuration-render.md
+++ b/content/en/api/configuration-render.md
@@ -178,7 +178,7 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 - Type: `Boolean` or `Object`
   - Default: `false`
 
-> Use this to configure to load external resources of Content-Security-Policy
+> Use this to configure Content-Security-Policy to load external resources
 
 Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
 

--- a/content/en/api/configuration-render.md
+++ b/content/en/api/configuration-render.md
@@ -180,6 +180,8 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 > Use this to configure Content-Security-Policy to load external resources
 
+Note that these CSP settings are only effective when using Nuxt server to serve your SSR application.
+
 Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
 
 In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with all the CSP policies you need to set `csp.addMeta` to `true`. Please note that this feature is independent from the `csp.policies` configuration, and only adds a `script-src` type policy, and only includes the calculated hashes of the generated inline `<script>` tags. The `csp.policies` are **only** added to the response HTTP headers when served using the Nuxt server.

--- a/content/en/api/configuration-render.md
+++ b/content/en/api/configuration-render.md
@@ -180,9 +180,15 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 > Use this to configure Content-Security-Policy to load external resources
 
-Note that these CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
+**Prerequisites:**
+
+These CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
+
+**Updating settings:**
 
 These settings are read by the Nuxt server directly from `nuxt.config.js`. This means changes to these settings take effect when the server is restarted. There is no need to rebuild the application to update the CSP settings.
+
+**HTML meta tag:**
 
 In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to the `<head>` you need to set `csp.addMeta` to `true`. Please note that this feature is independent of the `csp.policies` configuration:
 - it only adds a `script-src` type policy, and
@@ -193,7 +199,7 @@ When `csp.addMeta` is set to `true`, the complete set of the defined policies ar
 Note that CSP hashes will not be added as `<meta>` if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility. In that case the `<meta>` tag will still only contain the hashes of the inline `<script>` tags, and the policies defined under `csp.policies` will be used in the `Content-Security-Policy` HTTP response header.
 
 
-Example (`nuxt.config.js`)
+**Example:** (`nuxt.config.js`)
 
 ```js
 export default {

--- a/content/en/api/configuration-render.md
+++ b/content/en/api/configuration-render.md
@@ -182,6 +182,8 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 Note that these CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
 
+These settings are read by the Nuxt server directly from `nuxt.config.js`. This means changes to these settings take effect when the server is restarted. There is no need to rebuild the application to update the CSP settings.
+
 In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to the `<head>` you need to set `csp.addMeta` to `true`. Please note that this feature is independent of the `csp.policies` configuration:
 - it only adds a `script-src` type policy, and
 - the `script-src` policy only contains the hashes of the inline `<script>` tags.

--- a/content/en/api/configuration-render.md
+++ b/content/en/api/configuration-render.md
@@ -182,7 +182,7 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 **Prerequisites:**
 
-These CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
+These CSP settings are only effective when using Nuxt with `target: 'server'` to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
 
 **Updating settings:**
 

--- a/content/en/api/configuration-render.md
+++ b/content/en/api/configuration-render.md
@@ -180,11 +180,15 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 > Use this to configure Content-Security-Policy to load external resources
 
-Note that these CSP settings are only effective when using Nuxt server to serve your SSR application.
+Note that these CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
 
-Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
+In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to the `<head>` you need to set `csp.addMeta` to `true`. Please note that this feature is independent of the `csp.policies` configuration:
+- it only adds a `script-src` type policy, and
+- the `script-src` policy only contains the hashes of the inline `<script>` tags.
 
-In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with all the CSP policies you need to set `csp.addMeta` to `true`. Please note that this feature is independent from the `csp.policies` configuration, and only adds a `script-src` type policy, and only includes the calculated hashes of the generated inline `<script>` tags. The `csp.policies` are **only** added to the response HTTP headers when served using the Nuxt server.
+When `csp.addMeta` is set to `true`, the complete set of the defined policies are still added to the HTTP response header.
+
+Note that CSP hashes will not be added as `<meta>` if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility. In that case the `<meta>` tag will still only contain the hashes of the inline `<script>` tags, and the policies defined under `csp.policies` will be used in the `Content-Security-Policy` HTTP response header.
 
 
 Example (`nuxt.config.js`)

--- a/content/en/api/configuration-render.md
+++ b/content/en/api/configuration-render.md
@@ -182,7 +182,8 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
 
-In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with all the CSP policies you need to set `csp.addMeta` to `true`.
+In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with all the CSP policies you need to set `csp.addMeta` to `true`. Please note that this feature is independent from the `csp.policies` configuration, and only adds a `script-src` type policy, and only includes the calculated hashes of the generated inline `<script>` tags. The `csp.policies` are **only** added to the response HTTP headers when served using the Nuxt server.
+
 
 Example (`nuxt.config.js`)
 

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -180,7 +180,7 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 **Prerequisites:**
 
-These CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
+These CSP settings are only effective when using Nuxt with `target: 'server'` to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
 
 **Updating settings:**
 

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -180,6 +180,8 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 Note that these CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
 
+These settings are read by the Nuxt server directly from `nuxt.config.js`. This means changes to these settings take effect when the server is restarted. There is no need to rebuild the application to update the CSP settings.
+
 In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to the `<head>` you need to set `csp.addMeta` to `true`. Please note that this feature is independent of the `csp.policies` configuration:
 - it only adds a `script-src` type policy, and
 - the `script-src` policy only contains the hashes of the inline `<script>` tags.

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -178,9 +178,15 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 > Use this to configure Content-Security-Policy to load external resources
 
-Note that these CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
+**Prerequisites:**
+
+These CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
+
+**Updating settings:**
 
 These settings are read by the Nuxt server directly from `nuxt.config.js`. This means changes to these settings take effect when the server is restarted. There is no need to rebuild the application to update the CSP settings.
+
+**HTML meta tag:**
 
 In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to the `<head>` you need to set `csp.addMeta` to `true`. Please note that this feature is independent of the `csp.policies` configuration:
 - it only adds a `script-src` type policy, and

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -176,7 +176,7 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 - Type: `Boolean` or `Object`
   - Default: `false`
 
-> Use this to configure to load external resources of Content-Security-Policy
+> Use this to configure Content-Security-Policy to load external resources
 
 Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
 

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -180,7 +180,8 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
 
-In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with all the CSP policies you need to set `csp.addMeta` to `true`.
+In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with all the CSP policies you need to set `csp.addMeta` to `true`. Please note that this feature is independent from the `csp.policies` configuration, and only adds a `script-src` type policy, and only includes the calculated hashes of the generated inline `<script>` tags. The `csp.policies` are **only** added to the response HTTP headers when served using the Nuxt server.
+
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -178,11 +178,15 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 > Use this to configure Content-Security-Policy to load external resources
 
-Note that these CSP settings are only effective when using Nuxt server to serve your SSR application.
+Note that these CSP settings are only effective when using Nuxt server to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
 
-Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
+In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to the `<head>` you need to set `csp.addMeta` to `true`. Please note that this feature is independent of the `csp.policies` configuration:
+- it only adds a `script-src` type policy, and
+- the `script-src` policy only contains the hashes of the inline `<script>` tags.
 
-In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with all the CSP policies you need to set `csp.addMeta` to `true`. Please note that this feature is independent from the `csp.policies` configuration, and only adds a `script-src` type policy, and only includes the calculated hashes of the generated inline `<script>` tags. The `csp.policies` are **only** added to the response HTTP headers when served using the Nuxt server.
+When `csp.addMeta` is set to `true`, the complete set of the defined policies are still added to the HTTP response header.
+
+Note that CSP hashes will not be added as `<meta>` if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility. In that case the `<meta>` tag will still only contain the hashes of the inline `<script>` tags, and the policies defined under `csp.policies` will be used in the `Content-Security-Policy` HTTP response header.
 
 
 ```js{}[nuxt.config.js]

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -178,6 +178,8 @@ See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible
 
 > Use this to configure Content-Security-Policy to load external resources
 
+Note that these CSP settings are only effective when using Nuxt server to serve your SSR application.
+
 Note that CSP hashes will not be added if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility.
 
 In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with all the CSP policies you need to set `csp.addMeta` to `true`. Please note that this feature is independent from the `csp.policies` configuration, and only adds a `script-src` type policy, and only includes the calculated hashes of the generated inline `<script>` tags. The `csp.policies` are **only** added to the response HTTP headers when served using the Nuxt server.


### PR DESCRIPTION
The CSP documentation lacks some crucial information and has a confusing structure. These commits supposed to make that part of the docs more useful.