### PR TITLE
docs(fr): fix guides/get-started translations

### DIFF
--- a/content/fr/guides/get-started/conclusion.md
+++ b/content/fr/guides/get-started/conclusion.md
@@ -4,72 +4,72 @@ description: Félicitations, vous avez maintenant créé votre première applica
 position: 4
 category: get-started
 questions:
-  - question: Quel est le nom du répertoire dont vous avez besoin pour que Nuxt.js fonctionne?
+  - question: Quel est le nom du répertoire dont vous avez besoin pour que Nuxt.js fonctionne ?
     answers:
       - nuxt
       - pages
       - index
     correctAnswer: pages
-  - question: Quel est le nom de votre fichier ID de projet?
+  - question: Quel est le nom de votre fichier ID de projet ?
     answers:
       - package.vue
       - package.json
       - package.js
     correctAnswer: package.json
-  - question: Quelle est la commande que vous tapez dans le terminal pour lancer votre projet Nuxt.js?
+  - question: Quelle est la commande que vous tapez dans le terminal pour lancer votre projet Nuxt.js ?
     answers:
       - npm dev
       - npm run dev
       - nuxt dev
     correctAnswer: npm run dev
-  - question: Quelle est l'adresse dans le navigateur où vous pouvez voir votre page en mode développement?
+  - question: Quelle est l'adresse dans le navigateur où vous pouvez voir votre page en mode développement ?
     answers:
       - http://localhost:3000/
       - http://localhost:3000/project-name:3000
       - http://localhost:3000/nuxt:3000/
     correctAnswer: http://localhost:3000/
-  - question: Où mettez-vous votre configuration?
+  - question: Où mettez-vous votre configuration ?
     answers:
       - nuxt.config.json
       - config.js
       - nuxt.config.js
     correctAnswer: nuxt.config.js
-  - question: Quel répertoire ne convient pas aux fichiers `.vue`?
+  - question: Quel répertoire ne convient pas aux fichiers `.vue` ?
     answers:
       - pages
       - static
       - components
     correctAnswer: static
-  - question: Dans quel répertoire mettez-vous vos styles?
+  - question: Dans quel répertoire mettez-vous vos styles ?
     answers:
       - styles
       - components
       - assets
     correctAnswer: assets
-  - question: Dans quel répertoire mettons-nous un robots.txt ou un favicon?
+  - question: Dans quel répertoire mettons-nous un fichier robots.txt ou un favicon ?
     answers:
       - assets
       - components
       - static
     correctAnswer: static
-  - question: Quel composant utilisons-nous pour naviguer entre les pages?
+  - question: Quel composant utilisons-nous pour naviguer entre les pages ?
     answers:
       - '<Nuxt>'
       - '<RouterLink>'
       - '<NuxtLink>'
     correctAnswer: '<NuxtLink>'
-  - question: "`<NuxtLink>` est utilisé pour les liens internes appartenant à l'application Nuxt.js?"
+  - question: "`<NuxtLink>` est utilisé pour les liens internes appartenant à l'application Nuxt.js ?"
     answers:
       - True
       - False
     correctAnswer: True
 ---
 
-Félicitations! Vous avez maintenant créé votre première application Nuxt.js et vous pouvez maintenant vous considérer comme un Nuxter, mais il y a tellement plus à apprendre et tellement plus que vous pouvez faire avec Nuxt.js. Voici quelques recommandations:
+Félicitations ! Vous avez créé votre première application Nuxt.js et vous pouvez maintenant vous considérer comme un Nuxter, mais il y a tellement plus à apprendre et tellement plus à faire avec Nuxt.js. Voici quelques pistes :
 
 <base-alert type="next">
 
-Consultez le [livre de concepts](../concepts/views)
+Consulter le [guide des concepts](../concepts/views)
 
 </base-alert>
 
@@ -81,13 +81,13 @@ Travailler avec [asyncData](/guides/features/data-fetching#async-data)
 
 <base-alert type="next">
 
-Choix entre les différents [Modes de rendu](/guides/features/rendering-modes)
+Choisir entre les différents [modes de rendu](/guides/features/rendering-modes)
 
 </base-alert>
 
 <base-alert type="star">
 
-Avez-vous aimé Nuxt.js jusqu'à présent? N'oubliez pas de [mettre en favoris notre projet](https://github.com/nuxt/nuxt.js) sur GitHub
+Vous aimez Nuxt.js jusqu'à présent ? N'oubliez pas de [mettre en favoris notre projet](https://github.com/nuxt/nuxt.js) sur GitHub
 
 </base-alert>
 

--- a/content/fr/guides/get-started/directory-structure.md
+++ b/content/fr/guides/get-started/directory-structure.md
@@ -1,14 +1,14 @@
 ---
 title: Structure des répertoires
-description: La structure d'application par défaut Nuxt.js est destinée à fournir un excellent point de départ pour les applications petites comme grandes. Vous êtes libre d'organiser votre application comme vous le souhaitez et pouvez créer d'autres répertoires au fur et à mesure que vous en avez besoin.
+description: La structure par défaut d'une application Nuxt.js est destinée à fournir un excellent point de départ pour les applications plus ou moins grandes. Vous êtes libre d'organiser votre application comme vous le souhaitez et pouvez créer d'autres répertoires au fur et à mesure que vous en avez besoin.
 position: 3
 category: get-started
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/03_directory_structure?fontsize=14&hidenavigation=1&theme=dark
 ---
 
-La structure d'application par défaut Nuxt.js est destinée à fournir un excellent point de départ pour les applications petites et grandes. Vous êtes libre d'organiser votre application comme vous le souhaitez et pouvez créer d'autres répertoires au fur et à mesure que vous en avez besoin.
+La structure par défaut d'une application Nuxt.js est destinée à fournir un excellent point de départ pour les applications plus ou moins grandes. Vous êtes libre d'organiser votre application comme vous le souhaitez et pouvez créer d'autres répertoires au fur et à mesure que vous en avez besoin.
 
-Créons les répertoires et les fichiers qui n'existent pas encore dans notre projet.
+Créons les répertoires et les fichiers qui n'existent pas encore dans notre projet :
 
 ```bash
 mkdir components assets static
@@ -27,7 +27,7 @@ La création de répertoires avec ces noms active les fonctionnalités de votre 
 
 ### Le répertoire pages
 
-Le répertoire `pages` contient les vues et les itinéraires de votre application. Comme vous l'avez appris dans le dernier chapitre, Nuxt.js lit tous les fichiers `.vue` dans ce répertoire et les utilise pour créer le routeur d'application.
+Le répertoire `pages` contient les vues et les routes de votre application. Comme vous l'avez appris dans [l'étape précédente](/guides/get-started/routing), Nuxt.js lit tous les fichiers `.vue` dans ce répertoire et les utilise pour créer le routeur de l'application.
 
 <base-alert type="next">
 
@@ -39,7 +39,7 @@ En savoir plus sur le [répertoire pages](/guides/directory-structure/pages)
 
 Le répertoire `components` est l'endroit où vous placez tous vos composants Vue.js qui sont ensuite importés dans vos pages.
 
-Avec Nuxt.js, vous pouvez créer vos composants et les importer automatiquement dans vos fichiers .vue, ce qui signifie qu'il n'est pas nécessaire de les importer manuellement dans la section script. Nuxt.js les analysera et les importera automatiquement pour vous une fois que vous aurez défini les composants sur true.
+Avec Nuxt.js, vous pouvez créer vos composants et les importer automatiquement dans vos fichiers `.vue`, ce qui signifie qu'il n'est pas nécessaire de les importer manuellement dans la section script. Nuxt.js les analysera et les importera automatiquement pour vous une fois que vous aurez activé cette fonctionnalié dans votre fichier de configuration.
 
 <base-alert type="next">
 
@@ -59,17 +59,17 @@ En savoir plus sur le [répertoire assets](/guides/directory-structure/assets)
 
 ### Le répertoire static
 
-Le répertoire `static` est directement mappé à la racine du serveur et contient des fichiers qui doivent conserver leur nom (par exemple, `robots.txt`) _ou_ ne changera probablement pas (par exemple le favicon)
+Le répertoire `static` est directement servi à la racine du serveur et contient des fichiers qui doivent conserver leur nom (comme `robots.txt`) _ou_ qui ne changeront probablement pas (comme le favicon).
 
 <base-alert type="next">
 
-En savoir plus sur le [répertoire des static](/guides/directory-structure/static)
+En savoir plus sur le [répertoire static](/guides/directory-structure/static)
 
 </base-alert>
 
 ### Le fichier nuxt.config.js
 
-Le fichier `nuxt.config.js` est le point unique de configuration pour Nuxt.js. Si vous souhaitez ajouter des modules ou remplacer les paramètres par défaut, c'est l'endroit où appliquer les modifications.
+Le fichier `nuxt.config.js` est le point unique de configuration pour Nuxt.js. Si vous souhaitez ajouter des modules ou remplacer les paramètres par défaut, c'est ce fichier qu'il faudra modifier.
 
 <base-alert type="next">
 
@@ -85,12 +85,12 @@ Le fichier `package.json` contient toutes les dépendances et scripts de votre a
   <code-sandbox  :src="csb_link"></code-sandbox>
 </app-modal>
 
-## En savoir plus sur les structures du projet
+## En savoir plus sur la structure du projet
 
-Il existe des répertoires et fichiers plus utiles, notamment  [content](/guides/directory-structure/content), [layouts](/guides/directory-structure/layouts), [middleware](/guides/directory-structure/middleware), [modules](/guides/directory-structure/modules), [plugins](/guides/directory-structure/plugins) and [store](/guides/directory-structure/store) . Comme ils ne sont pas nécessaires pour les petites applications, ils ne sont pas traités ici.
+Il existe d'autres répertoires et fichiers utiles, comme [content](/guides/directory-structure/content), [layouts](/guides/directory-structure/layouts), [middleware](/guides/directory-structure/middleware), [modules](/guides/directory-structure/modules), [plugins](/guides/directory-structure/plugins) et [store](/guides/directory-structure/store). Comme ils ne sont pas nécessaires pour les petites applications, ils ne sont pas traités ici.
 
 <base-alert type="next">
 
-Pour en savoir plus sur tous les répertoires en détail, n'hésitez pas à lire le [Livre sur la structure des répertoires](/guides/directory-structure/nuxt).
+Pour en savoir plus sur tous les répertoires en détail, n'hésitez pas à lire le [guide sur la structure des répertoires](/guides/directory-structure/nuxt).
 
 </base-alert>

--- a/content/fr/guides/get-started/upgrading.md
+++ b/content/fr/guides/get-started/upgrading.md
@@ -7,7 +7,7 @@ category: get-started
 
 > La mise à jour de Nuxt.js est rapide, mais plus complexe que celle de votre package.json
 
-Si vous effectuez une mise à niveau vers Nuxt v2.14 et que vous souhaitez utiliser un hébergement statique, vous devrez ajouter [target:static](/guides/features/deployment-targets#static-hosting) dans votre fichier nuxt.config.js pour que la commande generate fonctionne correctement.
+Si vous effectuez une mise à niveau vers Nuxt v2.14 et que vous souhaitez utiliser un hébergement statique, vous devrez ajouter [target:static](/guides/features/deployment-targets#static-hosting) dans votre fichier nuxt.config.js pour que la commande `generate` fonctionne correctement.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -17,21 +17,21 @@ export default {
 
 ## Commencer
 
-1. Vérifier la [note de release](/guide/release-notes) pour la version que vous souhaitez mettre à niveau pour savoir s'il existe des instructions supplémentaires pour cette version particulière.
+1. Vérifiez les [notes de publication](/guide/release-notes) pour la version que vous souhaitez mettre à niveau pour savoir s'il existe des instructions supplémentaires pour cette version en particulier.
 2. Mettez à jour la version spécifiée pour le package `nuxt` dans votre fichier `package.json`.
 
-Après cette étape, les instructions varient selon que vous utilisez Yarn ou NPM. _[Yarn](https://yarnpkg.com/en/docs/usage) est le gestionnaire de paquets préféré pour travailler avec Nuxt car c'est l'outil de développement sur lequel les tests ont été écrits._
+Après cette étape, les instructions varient en fonction de votre gestionnaire de paquets (Yarn ou NPM). _[Yarn](https://yarnpkg.com/en/docs/usage) est l'outil de développement préféré pour travailler avec Nuxt car c'est celui qui a été utilisé lors de l'écriture des tests._
 
 ## Yarn
 
-3. Supprimer le fichier `yarn.lock`
-4. Supprimer le dossier `node_modules`
-5. Lancer la commande `yarn`
-6. Une fois l'installation terminée et les tests exécutés, envisagez également de mettre à niveau d'autres dépendances. La commande `yarn outdated` peut être utilisée.
+3. Supprimez le fichier `yarn.lock`
+4. Supprimez le dossier `node_modules`
+5. Lancez la commande `yarn`
+6. Une fois l'installation terminée et les tests exécutés, vous devriez également envisager de mettre à jour d'autres dépendances. La commande `yarn outdated` peut être utilisée.
 
 ## NPM
 
-3. Supprimer le fichier `package-lock.json`
-4. Supprimer le dossier `node_modules`
-5. Lancer la commande `npm install`
-6. Une fois l'installation terminée et les tests exécutés, envisagez également de mettre à niveau d'autres dépendances. La commande `npm outdated` peut être utilisée.
+3. Supprimez le fichier `package-lock.json`
+4. Supprimez le dossier `node_modules`
+5. Lancez la commande `npm install`
+6. Une fois l'installation terminée et les tests exécutés, vous devriez également envisager de mettre à jour d'autres dépendances. La commande `npm outdated` peut être utilisée.


### PR DESCRIPTION
Fix french translation (typos, grammar and some rewrites) for guides/get-started pages:
- guides/get-started/directory-structure
- guides/get-started/conclusion
- guides/get-started/upgrading