### PR TITLE
docs: add hint to mode doc in ssr property

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-ssr.md
+++ b/content/en/guides/configuration-glossary/configuration-ssr.md
@@ -18,3 +18,9 @@ export default {
   ssr: false // for SPA's
 }
 ```
+
+<base-alert type="next">
+
+Previously, `mode` was used to disable or enable server-side rendering. Here is the [`mode` documentation](/guides/configuration-glossary/configuration-mode).
+
+</base-alert>


### PR DESCRIPTION
Felt that it would be a nice idea to include a link to the deprecated "mode" property here so people understand the connection between the two attributes.