### PR TITLE
Changed menu item of SSR config item

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-ssr.md
+++ b/content/en/guides/configuration-glossary/configuration-ssr.md
@@ -1,7 +1,7 @@
 ---
 title: 'The ssr Property'
 description: Change default nuxt ssr value
-menu: mode
+menu: ssr
 category: configuration-glossary
 position: 28.1
 ---


### PR DESCRIPTION
In the documentation the Configuration glossary has two "mode" properties. The second, further down in the list, was actually SSR. It was alphabetically placed where SSR should be.

This change simply changes the menu item. 

Background: I couldn't find the documentation on the SSR property of the nuxt.config file. Discovered it by accident by going to Mode and seeing a link to SSR, which linked to the second "mode" entry. 

