### PR TITLE
fix:  svg of 404 page is responsive now

### DIFF
--- a/pages/404.vue
+++ b/pages/404.vue
@@ -8,7 +8,7 @@
           {{ $t('common.page_not_found') }}
         </h1>
         <div class="w-full lg:w-2/3 mx-auto">
-          <LostImageIllustration />
+          <LostImageIllustration class="w-full" />
         </div>
       </div>
     </AppContainer>


### PR DESCRIPTION
While browsing the nuxtjs.org, I noticed that the 404 page was mistake ( LostImageIllustration's position).