### PR TITLE
refactor: tailwind config & CarbonAds.vue css

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -31,40 +31,6 @@
   margin: auto;
 }
 
-.container {
-  width: 100%;
-}
-
-/*@media (min-width: 320px){
-  .container{
-    max-width: 320px;
-  }
-}*/
-
-@media (min-width: 640px) {
-  .container {
-    max-width: 640px;
-  }
-}
-
-@media (min-width: 768px) {
-  .container {
-    max-width: 768px;
-  }
-}
-
-@media (min-width: 1024px) {
-  .container {
-    max-width: 1024px;
-  }
-}
-
-@media (min-width: 1280px) {
-  .container {
-    max-width: 1280px;
-  }
-}
-
 body {
   min-width: 320px;
 }

--- a/components/TheCookieBox.vue
+++ b/components/TheCookieBox.vue
@@ -2,7 +2,7 @@
   <VueIfBot>
     <CookieConsent
       data-cy="cookie-box"
-      class="flex justify-center items-center text-light-onSurfaceSecondary dark:text-dark-onSurfaceSecondary border border-top border-light-border dark:border-dark-border xs:flex-col xs:pt-2 md:flex-row xs:text-center"
+      class="flex justify-center items-center text-light-onSurfaceSecondary dark:text-dark-onSurfaceSecondary border border-top border-light-border dark:border-dark-border flex-col pt-2 px-2 md:pt-0 md:px-0 md:flex-row text-center"
     >
       <template slot="message">
         <p>

--- a/components/global/bases/AppModal.vue
+++ b/components/global/bases/AppModal.vue
@@ -23,7 +23,7 @@
           <div class="modal-container flex flex-col">
             <div class="w-full flex justify-end">
               <button
-                class="xs:m-2 mb-4 w-auto"
+                class="sm:m-2 mb-4 w-auto"
                 data-cy="modal-close"
                 @click="showModal = false"
               >

--- a/components/global/bases/AppModal.vue
+++ b/components/global/bases/AppModal.vue
@@ -23,7 +23,7 @@
           <div class="modal-container flex flex-col">
             <div class="w-full flex justify-end">
               <button
-                class="sm:m-2 mb-4 w-auto"
+                class="m-2 w-auto"
                 data-cy="modal-close"
                 @click="showModal = false"
               >

--- a/components/partials/ads/CarbonAds.vue
+++ b/components/partials/ads/CarbonAds.vue
@@ -46,50 +46,41 @@ export default {
 }
 
 .Carbon {
-  @apply p-4 flex flex-col ml-auto mt-4;
-
-  max-width: 100%;
+  @apply p-4 flex flex-col ml-auto mt-4 max-w-full;
 
   @screen sm {
-    max-width: 320px;
+    @apply max-w-xs;
   }
 
   @screen lg {
     @apply mt-0 mx-auto;
-
     max-width: 160px;
   }
 
   #carbonads span {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    @apply flex flex-col justify-between;
 
     .carbon-wrap {
-      display: flex;
+      @apply flex flex-col;
       flex: 1;
-      flex-direction: column;
 
-      @screen xs {
-        flex-direction: row;
+      @media (min-width: 320px) {
+        @apply flex-row;
       }
 
       @screen lg {
-        flex-direction: column;
+        @apply flex-col;
       }
 
       .carbon-img {
-        align-items: flex-start;
-        display: flex;
-        justify-content: center;
-        margin-bottom: 1rem;
+        @apply flex items-start justify-center mb-4;
 
-        @screen xs {
-          margin-bottom: 0;
+        @media (min-width: 320px) {
+          @apply mb-0;
         }
 
         @screen lg {
-          margin-bottom: 1rem;
+          @apply mb-4;
         }
       }
 
@@ -100,12 +91,12 @@ export default {
           @apply no-underline;
         }
 
-        @screen xs {
-          margin-left: 1rem;
+        @media (min-width: 320px) {
+          @apply ml-4;
         }
 
         @screen lg {
-          margin-left: 0;
+          @apply ml-0;
         }
       }
     }
@@ -120,25 +111,6 @@ export default {
 
     &:hover {
       @apply no-underline text-gray-500;
-    }
-  }
-
-  @media (max-width: 1023px) {
-    // margin: 1rem 0;
-    & .carbon-img {
-      // float: left;
-      display: block;
-    }
-
-    & .carbon-text {
-      display: block;
-      width: 150px;
-    }
-
-    & .carbon-poweredby {
-      display: block;
-      // float: right;
-      text-align: right;
     }
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,10 +3,6 @@ const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
   theme: {
-    screens: {
-      xs: '320px',
-      ...defaultTheme.screens
-    },
     extend: {
       fontFamily: {
         sans: [
@@ -109,9 +105,6 @@ module.exports = {
       'dark:hover',
       'light:hover'
     ]
-  },
-  corePlugins: {
-    container: false
   },
   plugins: [
     plugin(function ({ addVariant, theme, e, prefix, config }) {


### PR DESCRIPTION
## Context

I noticed there are css definitions for `.container` class and various breakpoints in the `assets/css/tailwind.css` file, as seen here:

https://github.com/nuxt/nuxtjs.org/blob/39c564e9b162efcc42300c1b9c56ec6aa308d7de/assets/css/tailwind.css#L34-L66

However Tailwind CSS already comes with `.container` utility class that has these exact same css definitions with the same breakpoints, as seen in the Tailwind CSS docs over here: https://tailwindcss.com/docs/container

Just to be sure, I've also checked the CDN file for Tailwind CSS and here is a screenshot of the resulting `.container` utility class and breakpoints in it:
![chrome_p0DlGwUX2S](https://user-images.githubusercontent.com/42867097/93710067-3315c980-fb76-11ea-82c1-4d7043c57d07.png)

Which confirms that it is the exact same, except for the `320px` breakpoint, but the `320px` breakpoint is commented out already so this begs the question why we are disabling the out-of-the-box `.container` class and redoing it ourselves? 

Code block where the original `.container` class is turned off ([reference](https://tailwindcss.com/docs/container#disabling-entirely)):
https://github.com/nuxt/nuxtjs.org/blob/39c564e9b162efcc42300c1b9c56ec6aa308d7de/tailwind.config.js#L113-L115

## Assumption on why this approach was taken

Since the `xs` or `320px` breakpoint was defined and added to the existing breakpoints over here:
https://github.com/nuxt/nuxtjs.org/blob/39c564e9b162efcc42300c1b9c56ec6aa308d7de/tailwind.config.js#L6-L9

This made the Tailwind CSS `.container` class to detect that new breakpoint and caused every html tag using it to shrink to `320px` when it's less than the `sm` or `640px` width, like so:

![chrome_1m3ABRJnJw](https://user-images.githubusercontent.com/42867097/93710331-622d3a80-fb78-11ea-8a12-18731ba39f95.png)

which is not what the current intended behaviour, thus prompting us to override the container class ourselves and comment out the `320px` breakpoint.

## Analysis

This then leads to why are we defining `xs` screen breakpoint if it's not what we want? Apparently it is being used ONLY in the `components/partials/ads/CarbonAds.vue` component over here (there are several more lines further down in the code):
https://github.com/nuxt/nuxtjs.org/blob/39c564e9b162efcc42300c1b9c56ec6aa308d7de/components/partials/ads/CarbonAds.vue#L73

If we look at this section of the Tailwind CSS docs: https://tailwindcss.com/docs/functions-and-directives#screen, we can see `@screen xs` is a directive or shorthand for `@media (min-width: 320px)`. Since we are just using this in the CarbonAds.vue file, so I think we shouldn't create a new breakpoint & override the `.container` class just for it.

## Solution

I've removed the `xs` breakpoint and re-enable the original `.container` class via changes in `tailwind.config.js`, then I removed the redundant classes/breakpoints in the `tailwind.css` file. Now every `.container` class usage in all the pages are back to the same behaviour.

As for the broken one, I then proceed to change `@screen xs` to `@media (min-width: 320px)` in the `CarbonAds.vue` file to fix it. I've also noticed that there are already some usage of `@apply` directive by Tailwind, so I just changed almost all of the CSS styles into their equivalent ones in Tailwind, for example `max-width: 100%` to `max-w-full`, `flex-direction: column` to `flex-col` etc to make the file leaner in lines of code.

I've also noticed there is a block of `@media (max-width: 1023px)` CSS styles which are just applying the same style for width more than 1023px, so I removed it since it is redundant. Here are screenshots to explain the redundancy:

 `max-width: 1023px` means any width from 0 to 1023px, it will be applied. like so:
![chrome_ZE1wJR08E0](https://user-images.githubusercontent.com/42867097/93710605-91dd4200-fb7a-11ea-8dec-5de101bc3a18.png)

but as we can see, we are overriding `display: block` with the same `display: block`, and same for text-align. So I think this `@media (max-width: 1023px)` code block might be used in older iterations, but not now anymore.

---

**EDIT:** Noticed that `xs:` is used in the cookies message section and a button, so I added another commit to fix them. Modified the paddings for the cookies box to only appear when shrinked below `md` so they won't touch the side of the screen. 

~~As for the button in AppModal, is the change acceptable? I can't seem to pin point where it's being used atm, so I can't view it.~~ Found it. It seemed like the original `xs:m-2` was already overriding the margins so `mb-4` never works unless it's below 320px in width. In that case, I think we should just remove the `mb-4` and make it `m-2` for all width. to avoid it being at the edge for <320px.

| Original | Fix |
|---|---|
| ![chrome_E7ozsLWDVq](https://user-images.githubusercontent.com/42867097/93711458-1b900e00-fb81-11ea-9ab0-5926e305c9cb.png) | ![chrome_z64f7jXRQy](https://user-images.githubusercontent.com/42867097/93711465-22b71c00-fb81-11ea-9551-2ba5f51a9632.png) |