### PR TITLE
refactor: move icons to a reusable icon component

### DIFF
--- a/components/TheAsideNavNewDocs.vue
+++ b/components/TheAsideNavNewDocs.vue
@@ -24,11 +24,12 @@
               'font-bold': $route.params.book === group
             }"
           >
-            <ChevronDownIcon
+            <AppIcon
               v-if="$route.params.book === group"
+              name="chevronDown"
               class="w-4 h-4 mr-2"
             />
-            <ChevronRightIcon v-else class="w-4 h-4 mr-2" />
+            <AppIcon v-else name="chevronRight" class="w-4 h-4 mr-2" />
             <span>{{ $t(`content.guides.${group}`) }}</span>
           </component>
           <ul v-if="$route.params.book === group" class="pb-8 pl-2">
@@ -70,14 +71,8 @@
 
 <script>
 import sortBy from 'lodash.sortby'
-import ChevronDownIcon from '~/assets/icons/chevron-down.svg?inline'
-import ChevronRightIcon from '~/assets/icons/chevron-right.svg?inline'
 
 export default {
-  components: {
-    ChevronDownIcon,
-    ChevronRightIcon
-  },
   props: {
     links: {
       type: Object,

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -77,7 +77,7 @@
               label="Select language"
             >
               <template v-slot:icon>
-                <GlobeIcon />
+                <AppIcon name="globe" />
               </template>
             </AppLangSelect>
           </div>
@@ -88,12 +88,10 @@
 </template>
 
 <script>
-import GlobeIcon from '~/assets/icons/globe.svg?inline'
 import SmallNuxtLogo from '~/assets/images/logo-small.svg?inline'
 
 export default {
   components: {
-    GlobeIcon,
     SmallNuxtLogo
   },
   data() {

--- a/components/TheMobileAsideNav.vue
+++ b/components/TheMobileAsideNav.vue
@@ -39,7 +39,8 @@
           class="inner-button sm:hidden absolute h-10 w-10 flex items-center justify-center text-nuxt-gray bg-gray-200 dark:bg-dark-elevatedSurface dark:text-dark-onSurfaceSecondary transition-colors duration-300 ease-linear"
           @click="show = false"
         >
-          <TimesIcon
+          <AppIcon
+            name="times"
             class="block h-5 fill-current transition-colors duration-300 ease-linear"
           />
         </button>
@@ -53,8 +54,9 @@
           v-if="!show"
           class="block text-nuxt-gray dark:text-dark-onSurfaceSecondary stroke-current transition-colors duration-300 ease-linear"
         />
-        <TimesIcon
+        <AppIcon
           v-else
+          name="times"
           class="block h-5 fill-current transition-colors duration-300 ease-linear"
         />
       </button>
@@ -66,12 +68,10 @@
 import sortBy from 'lodash.sortby'
 
 import ListIcon from '~/assets/images/list.svg?inline'
-import TimesIcon from '~/assets/icons/times.svg?inline'
 
 export default {
   components: {
-    ListIcon,
-    TimesIcon
+    ListIcon
   },
   props: {
     links: {

--- a/components/TheMobileAsideNavNewDocs.vue
+++ b/components/TheMobileAsideNavNewDocs.vue
@@ -30,11 +30,12 @@
                 'font-bold': $route.params.book === group
               }"
             >
-              <ChevronDownIcon
+              <AppIcon
                 v-if="$route.params.book === group"
+                name="chevronDown"
                 class="w-4 h-4 mr-2"
               />
-              <ChevronRightIcon v-else class="w-4 h-4 mr-2" />
+              <AppIcon v-else name="chevronRight" class="w-4 h-4 mr-2" />
               <span>{{ $t(`content.guides.${group}`) }}</span>
             </component>
             <ul
@@ -59,7 +60,8 @@
           class="inner-button sm:hidden absolute h-10 w-10 flex items-center justify-center text-nuxt-gray bg-gray-200 dark:bg-dark-elevatedSurface dark:text-dark-onSurfaceSecondary transition-colors duration-300 ease-linear"
           @click="show = false"
         >
-          <TimesIcon
+          <AppIcon
+            name="times"
             class="block h-5 fill-current transition-colors duration-300 ease-linear"
           />
         </button>
@@ -73,8 +75,9 @@
           v-if="!show"
           class="block text-nuxt-gray dark:text-dark-onSurfaceSecondary stroke-current transition-colors duration-300 ease-linear"
         />
-        <TimesIcon
+        <AppIcon
           v-else
+          name="times"
           class="block h-5 fill-current transition-colors duration-300 ease-linear"
         />
       </button>
@@ -86,16 +89,10 @@
 import sortBy from 'lodash.sortby'
 
 import ListIcon from '~/assets/images/list.svg?inline'
-import TimesIcon from '~/assets/icons/times.svg?inline'
-import ChevronDownIcon from '~/assets/icons/chevron-down.svg?inline'
-import ChevronRightIcon from '~/assets/icons/chevron-right.svg?inline'
 
 export default {
   components: {
-    ListIcon,
-    TimesIcon,
-    ChevronDownIcon,
-    ChevronRightIcon
+    ListIcon
   },
   props: {
     links: {

--- a/components/TheMobileBottomNav.vue
+++ b/components/TheMobileBottomNav.vue
@@ -12,8 +12,8 @@
             localePath({ name: link.routeName, params: { section: link.slug } })
           "
         >
-          <component
-            :is="link.slug + '-icon'"
+          <AppIcon
+            :name="link.slug"
             class="inline-block h-5 fill-current mb-1"
             :class="{
               'text-nuxt-lightgreen': $route.params.section === link.slug
@@ -31,8 +31,8 @@
           class="block md:flex md:justify-center w-full p-2 md:p-4 text-light-onSurfacePrimary dark:text-dark-onSurfacePrimary hover:no-underline hover:text-primary-base dark:hover:text-primary-base text-center visited:text-nuxt-gray transition-colors duration-300 ease-linear"
           :to="localePath({ name: link.slug })"
         >
-          <component
-            :is="link.slug + '-icon'"
+          <AppIcon
+            :name="link.slug"
             class="inline-block h-5 fill-current mb-1"
             :class="{
               'text-nuxt-lightgreen': $route.params.section === link.slug
@@ -55,26 +55,6 @@
     </div>
   </nav>
 </template>
-
-<script>
-import ExamplesIcon from '~/assets/icons/code.svg?inline'
-import GuideIcon from '~/assets/icons/books.svg?inline'
-import ApiIcon from '~/assets/icons/list.svg?inline'
-import FaqIcon from '~/assets/icons/faq.svg?inline'
-import ResourcesIcon from '~/assets/icons/resources.svg?inline'
-import BlogIcon from '~/assets/icons/blog.svg?inline'
-
-export default {
-  components: {
-    ExamplesIcon,
-    GuideIcon,
-    ApiIcon,
-    FaqIcon,
-    ResourcesIcon,
-    BlogIcon
-  }
-}
-</script>
 
 <style lang="scss" scoped>
 nav {

--- a/components/common/AppIcon.vue
+++ b/components/common/AppIcon.vue
@@ -1,0 +1,58 @@
+<template>
+  <component :is="iconComponent" />
+</template>
+
+<script>
+const icons = {
+  angleDoubleRight: require('~/assets/icons/angle-double-right.svg?inline'),
+  api: require('~/assets/icons/list.svg?inline'),
+  arrowLeft: require('~/assets/icons/arrow-left.svg?inline'),
+  arrowRight: require('~/assets/icons/arrow-right.svg?inline'),
+  bch: require('~/assets/icons/bch.svg?inline'),
+  blog: require('~/assets/icons/blog.svg?inline'),
+  btc: require('~/assets/icons/btc.svg?inline'),
+  caretDown: require('~/assets/icons/caret-down.svg?inline'),
+  chevronDown: require('~/assets/icons/chevron-down.svg?inline'),
+  chevronRight: require('~/assets/icons/chevron-right.svg?inline'),
+  comments: require('~/assets/icons/comments.svg?inline'),
+  eth: require('~/assets/icons/eth.svg?inline'),
+  examples: require('~/assets/icons/code.svg?inline'),
+  faq: require('~/assets/icons/faq.svg?inline'),
+  fire: require('~/assets/icons/fire.svg?inline'),
+  github: require('~/assets/icons/github.svg?inline'),
+  globe: require('~/assets/icons/globe.svg?inline'),
+  guide: require('~/assets/icons/books.svg?inline'),
+  ltc: require('~/assets/icons/ltc.svg?inline'),
+  inboxIn: require('~/assets/icons/inbox-in.svg?inline'),
+  meteor: require('~/assets/icons/meteor.svg?inline'),
+  moon: require('~/assets/icons/moon.svg?inline'),
+  openCollective: require('~/assets/icons/open-collective.svg?inline'),
+  playCircle: require('~/assets/icons/play-circle.svg?inline'),
+  resources: require('~/assets/icons/resources.svg?inline'),
+  search: require('~/assets/icons/search.svg?inline'),
+  snow: require('~/assets/icons/snow.svg?inline'),
+  sun: require('~/assets/icons/sun.svg?inline'),
+  system: require('~/assets/icons/system.svg?inline'),
+  times: require('~/assets/icons/times.svg?inline'),
+  twitter: require('~/assets/icons/twitter.svg?inline'),
+  website: require('~/assets/icons/link.svg?inline'),
+  xmarkCircle: require('~/assets/icons/xmark-circle.svg?inline')
+}
+
+export default {
+  props: {
+    name: {
+      type: String,
+      required: true,
+      validator(value) {
+        return Object.prototype.hasOwnProperty.call(icons, value)
+      }
+    }
+  },
+  computed: {
+    iconComponent() {
+      return icons[this.name]
+    }
+  }
+}
+</script>

--- a/components/common/AppLangSelect.vue
+++ b/components/common/AppLangSelect.vue
@@ -21,24 +21,19 @@
             {{ getLocaleDescription(locale) }}
           </option>
         </select>
-        <CaretDownIcon class="-ml-4" />
+        <AppIcon name="caretDown" class="-ml-4" />
       </template>
     </div>
   </div>
 </template>
 
 <script>
-import CaretDownIcon from '~/assets/icons/caret-down.svg?inline'
-
 const Modes = Object.freeze({
   SLIM: 'slim',
   NORMAL: 'normal'
 })
 
 export default {
-  components: {
-    CaretDownIcon
-  },
   props: {
     mode: {
       type: String,

--- a/components/global/bases/AppModal.vue
+++ b/components/global/bases/AppModal.vue
@@ -27,7 +27,7 @@
                 data-cy="modal-close"
                 @click="showModal = false"
               >
-                <XmarkCircleIcon class="svg" />
+                <AppIcon name="xmarkCircle" class="svg" />
               </button>
             </div>
             <div class="modal-body flex-1" :class="{ 'overflow-scroll': src }">
@@ -42,11 +42,7 @@
 </template>
 
 <script>
-import XmarkCircleIcon from '~/assets/icons/xmark-circle.svg?inline'
 export default {
-  components: {
-    XmarkCircleIcon
-  },
   props: {
     src: {
       type: String,

--- a/components/partials/AlgoliaSearch.vue
+++ b/components/partials/AlgoliaSearch.vue
@@ -6,7 +6,7 @@
       aria-label="Search"
       @click="showMobile = true"
     >
-      <SearchIcon class="block h-5 fill-current" />
+      <AppIcon name="search" class="block h-5 fill-current" />
     </button>
     <AlgoliaSearchInput
       class="hidden md:inline-block align-middle"
@@ -30,12 +30,7 @@
 </template>
 
 <script>
-import SearchIcon from '~/assets/icons/search.svg?inline'
-
 export default {
-  components: {
-    SearchIcon
-  },
   props: [],
   data() {
     return {

--- a/components/partials/AlgoliaSearchInput.vue
+++ b/components/partials/AlgoliaSearchInput.vue
@@ -3,7 +3,8 @@
     class="algolia-wrapper relative"
     :class="[focused ? 'focused' : 'blurred', !q && 'blurred', appearance]"
   >
-    <SearchIcon
+    <AppIcon
+      name="search"
       class="block absolute z-10 h-4 mt-3 ml-3 fill-current text-light-onSurfaceSecondary dark:text-dark-onSurfaceSecondary transition-colors duration-300 ease-linear"
     />
     <input
@@ -23,7 +24,8 @@
       aria-label="Clear input"
       @click="handleCloseClick"
     >
-      <TimesIcon
+      <AppIcon
+        name="times"
         class="block h-5 fill-current transition-colors duration-300 ease-linear"
       />
     </button>
@@ -31,13 +33,7 @@
 </template>
 
 <script>
-import SearchIcon from '~/assets/icons/search.svg?inline'
-import TimesIcon from '~/assets/icons/times.svg?inline'
 export default {
-  components: {
-    SearchIcon,
-    TimesIcon
-  },
   props: {
     appearance: {
       type: String,

--- a/components/partials/DarkModeToggle.vue
+++ b/components/partials/DarkModeToggle.vue
@@ -6,15 +6,18 @@
     <span
       class="relative mr-2 overflow-hidden inline-block w-5 h-5 flex items-center justify-center"
     >
-      <MoonIcon
+      <AppIcon
+        name="moon"
         class="w-5 h-5 absolute"
         :class="$colorMode.preference === 'dark' ? 'show' : 'hide'"
       />
-      <SystemIcon
+      <AppIcon
+        name="system"
         class="w-5 h-5 absolute"
         :class="$colorMode.preference === 'system' ? 'show' : 'hide'"
       />
-      <SunIcon
+      <AppIcon
+        name="sun"
         class="w-5 h-5 absolute"
         :class="$colorMode.preference === 'light' ? 'show' : 'hide'"
       />
@@ -46,16 +49,7 @@
 </template>
 
 <script>
-import SunIcon from '~/assets/icons/sun.svg?inline'
-import MoonIcon from '~/assets/icons/moon.svg?inline'
-import SystemIcon from '~/assets/icons/system.svg?inline'
-
 export default {
-  components: {
-    SunIcon,
-    MoonIcon,
-    SystemIcon
-  },
   props: [],
   data() {
     return {

--- a/components/partials/ads/BlackFriday.vue
+++ b/components/partials/ads/BlackFriday.vue
@@ -1,7 +1,8 @@
 <template>
   <AppContainer v-if="isDisplayed" class="mt-6 lg:-mt-1 xl:-mt-2">
     <div class="bg-deep-cove bg-blackfriday">
-      <TimesIcon
+      <AppIcon
+        name="times"
         class="fill-current text-gray-500 w-3 m-2 float-right cursor-pointer hover:text-gray-300"
         @click.native="isDisplayed = false"
       />
@@ -46,12 +47,7 @@
 </template>
 
 <script>
-import TimesIcon from '~/assets/icons/times.svg?inline'
-
 export default {
-  components: {
-    TimesIcon
-  },
   data() {
     return {
       isDisplayed: true

--- a/components/partials/blog/BlogpostNavigationLinks.vue
+++ b/components/partials/blog/BlogpostNavigationLinks.vue
@@ -5,7 +5,7 @@
       :to="toLink(prev.slug)"
       class="inline-flex items-center dark:hover:text-nuxt-lightgreen light:hover:text-nuxt-lightgreen dark:text-dark-onSurfaceSecondary light:text-light-onSurfaceSecondary transition-colors duration-300 ease-linear"
     >
-      <ArrowLeftIcon class="h-5 mr-2" />
+      <AppIcon name="arrowLeft" class="h-5 mr-2" />
       {{ prev.title || 'back to blog list' }}
     </NuxtLink>
     <NuxtLink
@@ -14,21 +14,14 @@
       class="inline-flex items-center text-right dark:hover:text-nuxt-lightgreen light:hover:text-nuxt-lightgreen dark:text-dark-onSurfaceSecondary light:text-light-onSurfaceSecondary transition-colors duration-300 ease-linear"
     >
       {{ next.title }}
-      <ArrowRightIcon class="h-5 ml-2" />
+      <AppIcon name="arrowRight" class="h-5 ml-2" />
     </NuxtLink>
   </div>
 </template>
 
 <script>
-import ArrowLeftIcon from '~/assets/icons/arrow-left.svg?inline'
-import ArrowRightIcon from '~/assets/icons/arrow-right.svg?inline'
-
 export default {
   name: 'BlogpostNavigationLinks',
-  components: {
-    ArrowLeftIcon,
-    ArrowRightIcon
-  },
   props: {
     prev: {
       type: Object,

--- a/components/partials/home/HomeModes.vue
+++ b/components/partials/home/HomeModes.vue
@@ -14,7 +14,8 @@
         </i18n>
         <div class="flex flex-wrap">
           <div class="lg:w-1/2 p-4 lg:p-8">
-            <FireIcon
+            <AppIcon
+              name="fire"
               class="text-nuxt-green dark:text-nuxt-lightgreen mx-auto my-8 w-32"
             />
             <h4 class="text-center uppercase text-2xl pt-8 pb-4 font-medium">
@@ -34,7 +35,7 @@
             </i18n>
           </div>
           <div class="lg:w-1/2 p-4 lg:p-8">
-            <SnowIcon class="mx-auto my-8 w-32" />
+            <AppIcon name="snow" class="mx-auto my-8 w-32" />
             <h4 class="text-center uppercase text-2xl pt-8 pb-4 font-medium">
               {{ $t('homepage.modes.ssg.title') }}
             </h4>
@@ -68,15 +69,3 @@
     </div>
   </div>
 </template>
-
-<script>
-import SnowIcon from '~/assets/icons/snow.svg?inline'
-import FireIcon from '~/assets/icons/fire.svg?inline'
-
-export default {
-  components: {
-    SnowIcon,
-    FireIcon
-  }
-}
-</script>

--- a/components/partials/home/HomeSponsors.vue
+++ b/components/partials/home/HomeSponsors.vue
@@ -80,8 +80,9 @@
             data-cy="sponsors"
             class="py-3 px-6 text-base"
           >
-            <OpenCollectiveIcon
+            <AppIcon
               slot="icon"
+              name="openCollective"
               class="inline-block h-5 -mt-1 mr-1"
             />
             {{ $t('homepage.sponsors.become_a_sponsor') }}
@@ -93,12 +94,10 @@
 </template>
 
 <script>
-import OpenCollectiveIcon from '~/assets/icons/open-collective.svg?inline'
 import SponsoringIllustration from '~/assets/illustrations/sponsoring.svg?inline'
 
 export default {
   components: {
-    OpenCollectiveIcon,
     SponsoringIllustration
   },
   data() {

--- a/components/partials/home/HomeWelcome.vue
+++ b/components/partials/home/HomeWelcome.vue
@@ -17,9 +17,7 @@
               <br />
             </template>
             <template v-slot:frameworkType>
-              <span class="text-nuxt-lightgreen">
-                Vue
-              </span>
+              <span class="text-nuxt-lightgreen"> Vue </span>
             </template>
           </i18n>
           <!--welcome description i18n -->
@@ -48,7 +46,7 @@
               data-cy="get-started"
               class="sm:mr-4 py-3 px-6 text-base mb-4"
             >
-              <MeteorIcon slot="icon" class="h-5 -mb-1 mr-1" />
+              <AppIcon slot="icon" name="meteor" class="h-5 -mb-1 mr-1" />
               {{ $t('homepage.welcome.get_started') }}
             </AppButton>
             <AppButton
@@ -57,7 +55,11 @@
               class="sm:mr-4 py-3 px-6 text-base"
               data-cy="github-stars"
             >
-              <GithubIcon slot="icon" class="inline-block h-6 -mt-1 mr-1" />
+              <AppIcon
+                slot="icon"
+                name="github"
+                class="inline-block h-6 -mt-1 mr-1"
+              />
               {{ $config.nuxtStars }} github stars
             </AppButton>
           </div>
@@ -74,10 +76,7 @@
           </div>
         </div>
         <figure class="hidden lg:block lg:w-5/12" data-cy="video">
-          <AppMedia
-            :src="videoUrl"
-            class="mb-4"
-          />
+          <AppMedia :src="videoUrl" class="mb-4" />
           <!--welcome video i18n -->
           <i18n
             path="homepage.welcome.video"
@@ -114,14 +113,7 @@
 </template>
 
 <script>
-import MeteorIcon from '~/assets/icons/meteor.svg?inline'
-import GithubIcon from '~/assets/icons/github.svg?inline'
-
 export default {
-  components: {
-    MeteorIcon,
-    GithubIcon
-  },
   computed: {
     /**
      * This was done because the vimeo.com site has been blocked in Indonesia.

--- a/components/partials/team/TeamMembers.vue
+++ b/components/partials/team/TeamMembers.vue
@@ -41,7 +41,8 @@
                 target="_blank"
                 class="mx-1"
               >
-                <github-icon
+                <AppIcon
+                  name="github"
                   class="h-5 inline-block text-gray-700 hover:text-gray-900 cursor-pointer text-light-onSurfacePrimary dark:text-dark-onSurfacePrimary transition-colors duration-300 ease-linear"
                 />
               </a>
@@ -52,7 +53,8 @@
                 target="_blank"
                 class="mx-1"
               >
-                <twitter-icon
+                <AppIcon
+                  name="twitter"
                   class="h-5 ml-1 inline-block text-blue-600 hover:text-blue-400"
                 />
               </a>
@@ -63,7 +65,8 @@
                 target="_blank"
                 class="mx-1"
               >
-                <website-icon
+                <AppIcon
+                  name="website"
                   class="h-5 inline-block text-nuxt-green hover:text-nuxt-lightgreen"
                 />
               </a>
@@ -87,15 +90,7 @@
 </template>
 
 <script>
-import TwitterIcon from '~/assets/icons/twitter.svg?inline'
-import GithubIcon from '~/assets/icons/github.svg?inline'
-import WebsiteIcon from '~/assets/icons/link.svg?inline'
 export default {
-  components: {
-    TwitterIcon,
-    GithubIcon,
-    WebsiteIcon
-  },
   props: {
     team: {
       type: Array,

--- a/pages/blog/_slug.vue
+++ b/pages/blog/_slug.vue
@@ -5,7 +5,7 @@
         :to="localePath({ name: 'blog' })"
         class="inline-flex items-center dark:hover:text-nuxt-lightgreen light:hover:text-nuxt-lightgreen dark:text-dark-onSurfaceSecondary light:text-light-onSurfaceSecondary"
       >
-        <ArrowLeftIcon class="h-5 mr-2" />back to blog list
+        <AppIcon name="arrowLeft" class="h-5 mr-2" />back to blog list
       </NuxtLink>
 
       <BlogpostItem :post="post" />
@@ -17,15 +17,11 @@
 
 <script>
 import { mapState } from 'vuex'
-import ArrowLeftIcon from '~/assets/icons/arrow-left.svg?inline'
 import copyCodeBlock from '~/mixins/copyCodeBlock'
 
 export default {
   name: 'PageSlug',
   scrollToTop: true,
-  components: {
-    ArrowLeftIcon
-  },
   mixins: [copyCodeBlock],
   middleware({ params, redirect }) {
     if (params.slug === 'index') {

--- a/pages/sponsor-nuxtjs.vue
+++ b/pages/sponsor-nuxtjs.vue
@@ -57,7 +57,7 @@
               :class="{ 'bg-gray-300': onetime.current === 'btc' }"
               @click.prevent="onetime.current = 'btc'"
             >
-              <BtcLogo class="mr-3" /> BTC
+              <AppIcon name="btc" class="mr-3" /> BTC
             </a>
             <a
               href="#bch"
@@ -65,7 +65,7 @@
               :class="{ 'bg-gray-300': onetime.current === 'bch' }"
               @click.prevent="onetime.current = 'bch'"
             >
-              <BchLogo class="mr-3" /> BCH
+              <AppIcon name="bch" class="mr-3" /> BCH
             </a>
             <a
               href="#eth"
@@ -73,7 +73,7 @@
               :class="{ 'bg-gray-300': onetime.current === 'eth' }"
               @click.prevent="onetime.current = 'eth'"
             >
-              <EthLogo class="mr-3" /> ETH
+              <AppIcon name="eth" class="mr-3" /> ETH
             </a>
             <a
               href="#ltc"
@@ -81,7 +81,7 @@
               :class="{ 'bg-gray-300': onetime.current === 'ltc' }"
               @click.prevent="onetime.current = 'ltc'"
             >
-              <LtcLogo class="mr-3" /> LTC
+              <AppIcon name="ltc" class="mr-3" /> LTC
             </a>
           </div>
         </div>
@@ -150,8 +150,9 @@
             href="https://opencollective.com/nuxtjs"
             class="py-3 px-6 text-base"
           >
-            <OpenCollectiveIcon
+            <AppIcon
               slot="icon"
+              name="openCollective"
               class="h-5 -mt-1 mr-1 inline-block"
             />
             {{ $t('sponsor.become_a_sponsor') }}
@@ -163,21 +164,11 @@
 </template>
 
 <script>
-import OpenCollectiveIcon from '~/assets/icons/open-collective.svg?inline'
-import BtcLogo from '~/assets/icons/btc.svg?inline'
-import BchLogo from '~/assets/icons/bch.svg?inline'
-import EthLogo from '~/assets/icons/eth.svg?inline'
-import LtcLogo from '~/assets/icons/ltc.svg?inline'
 import SponsorIllustration from '~/assets/illustrations/sponsor.svg?inline'
 
 export default {
   components: {
-    SponsorIllustration,
-    OpenCollectiveIcon,
-    BtcLogo,
-    BchLogo,
-    EthLogo,
-    LtcLogo
+    SponsorIllustration
   },
   data() {
     return {

--- a/pages/support.vue
+++ b/pages/support.vue
@@ -53,7 +53,7 @@
               target="_blank"
               class="sm:mr-4 py-3 px-6 text-base"
             >
-              <CommentsIcon slot="icon" class="h-5 -mb-1 mr-1" />
+              <AppIcon slot="icon" name="comments" class="h-5 -mb-1 mr-1" />
               {{ $t('support.technical.start') }}
             </AppButton>
           </div>
@@ -115,7 +115,7 @@
         target="_blank"
         class="sm:mr-4 py-3 px-6 text-base"
       >
-        <AngleDoubleRightIcon slot="icon" class="h-5 -mb-1 mr-1" />
+        <AppIcon slot="icon" name="angleDoubleRight" class="h-5 -mb-1 mr-1" />
         {{ $t('support.entreprise.learn_more') }}
       </AppButton>
       <AppButton
@@ -124,7 +124,7 @@
         target="_blank"
         class="sm:mr-4 py-3 px-6 text-base"
       >
-        <InboxInIcon slot="icon" class="h-5 -mb-1 mr-1" />
+        <AppIcon slot="icon" name="inboxIn" class="h-5 -mb-1 mr-1" />
         {{ $t('support.entreprise.request_a_demo') }}
       </AppButton>
     </div>
@@ -132,18 +132,12 @@
 </template>
 
 <script>
-import AngleDoubleRightIcon from '~/assets/icons/angle-double-right.svg?inline'
-import InboxInIcon from '~/assets/icons/inbox-in.svg?inline'
-import CommentsIcon from '~/assets/icons/comments.svg?inline'
 import TechnicalSupportIllustration from '~/assets/illustrations/technical-support.svg?inline'
 import SupportIllustration from '~/assets/illustrations/support.svg?inline'
 
 export default {
   components: {
     SupportIllustration,
-    AngleDoubleRightIcon,
-    CommentsIcon,
-    InboxInIcon,
     TechnicalSupportIllustration
   },
   head() {

--- a/pages/video-courses.vue
+++ b/pages/video-courses.vue
@@ -52,7 +52,7 @@
                 target="_blank"
                 class="sm:mr-4 p-3 mt-3 text-sm text-left"
               >
-                <PlayCircleIcon slot="icon" class="h-4 -mb-1 mr-1" />
+                <AppIcon slot="icon" name="playCircle" class="h-4 -mb-1 mr-1" />
                 {{ $t('video-courses.cta.start') }}
               </AppButton>
             </div>
@@ -71,14 +71,10 @@
 
 <script>
 import ThemesIllustration from '~/assets/illustrations/themes.svg?inline'
-import PlayCircleIcon from '~/assets/icons/play-circle.svg?inline'
-import MeteorIcon from '~/assets/icons/meteor.svg?inline'
 
 export default {
   components: {
-    ThemesIllustration,
-    PlayCircleIcon,
-    MeteorIcon
+    ThemesIllustration
   },
   data() {
     return {


### PR DESCRIPTION
## Context

I have noticed the icons or specifically SVG assets are imported using the syntax as suggested from the nuxt svg module [over here](https://github.com/nuxt-community/svg-module#vue-svg-loader), which is the following format (as example):

```vue
<template>
  <NuxtLogo />
</template>

<script>
  import NuxtLogo from "~/assets/nuxt.svg?inline";

  export default {
    components: { NuxtLogo },
  };
</script>
```

However when I was using this approach, it started to feel redundant or sort of repetitive, especially in instances like wanting to display a Github icon in 2 pages respectively. This means we'll need to have 1 line for import and 3 lines for `components` option in the export default just to use the same exact icon.

## Solution

This is the reason why I created a component that will load the icon we want based on the prop `name` in my personal projects, and I think it's useful to introduce it here as well. There is a also validator in place to assure that the name we used actually exists in the list of available/defined icons. This makes us able to use the `<AppIcon />` component freely as a single line of code, remove a lot of redundant import statements and even remove the need for `components` option in many cases!

I think another added benefit of this approach is we can just check the AppIcon component to see what are the icons available without having to go through the assets folder manually. Only when we need to import a new icon then we'll just need to do it once.

In case anyone wonders why we can't use the dynamic require approach such as `require('~/assets/icons/${name}.svg?inline')` instead and call it a day, it is because webpack doesn't know what value will we pass for `name` variable, thus it will just include **every** assets inside `~/assets/icons` instead. Reference: https://webpack.js.org/guides/dependency-management/#require-with-expression

Notable quotes from referenced Webpack dynamic require docs:

> A context module is generated. It contains references to **all modules in that directory** that can be required with a request matching the regular expression.

> This means dynamic requires are supported but will cause all matching modules to be included in the bundle.

As there might be assets in the icons folder that are just being put there without being use, I opt for the tree-shakable approach instead. With that said, I think the part where this solution shines the most is in this scenario:
https://github.com/nuxt/nuxtjs.org/blob/53dfa576d0408568d2114ff9e7c618a5f1d59d48/components/TheMobileBottomNav.vue#L15-L21

Here the `link.slug` will pass us the icon name for the mobile bottom nav icon, then it is dynamically determined with the `component is:` solution while appending `-icon` to the string since the imported icon components has `Icon` at the end, like so:
https://github.com/nuxt/nuxtjs.org/blob/53dfa576d0408568d2114ff9e7c618a5f1d59d48/components/TheMobileBottomNav.vue#L60-L65

In this instance, the `<AppIcon />` component is already able to simplify this just by passing the `link.slug` to the `name` prop, so no string concatenation is needed.

---

### Side note 1

I was using `<AppIcon />` as a **functional** component in my projects (for the perfomance gain in Vue 2), but since the performance gain is negligible in Vue 3 , the `functional` attribute is  going to be deprecated. Reference: https://v3.vuejs.org/guide/migration/functional-components.html#overview

And since Nuxt 3 is on the horizon, and I'm aware this site is under an overhaul development which I promptly assume should be using Nuxt 3, I opt to make it as a normal component in this PR.

### Side note 2

If this approach is acceptable, I will make additional PRs for Illustrations as well (`~/assets/illustrations` imported components). So do let me know if you guys think I can proceed with the additional PRs or just halt the PRs if this approach is already being or going to be implemented in the next overhaul.