### PR TITLE
fix: options text color for language switcher in dark mode

### DIFF
--- a/components/common/AppLangSelect.vue
+++ b/components/common/AppLangSelect.vue
@@ -17,6 +17,7 @@
             v-for="(locale, i) in $i18n.locales"
             :key="i"
             :value="locale.code"
+            class="dark:text-dark-surface"
           >
             {{ getLocaleDescription(locale) }}
           </option>


### PR DESCRIPTION
Fixes #753 

## Context

The issue mentions the language switcher options text color are not visible in dark mode, as seen in this screenshot: ![](https://user-images.githubusercontent.com/9987732/93862787-e390e400-fcc2-11ea-9e90-8dbdf8058435.png)

This doesn't happen for Windows since the option background color is lighter than Mac OS' one, though it's still not super legible:
![chrome_KQkdx2ggHS](https://user-images.githubusercontent.com/42867097/93916693-8174c500-fd3c-11ea-88a7-b072b7edf82e.png)

## Investigation

I suspected it's due to the color being too similar, thus making it seem like it's invisible.  That's because it's very unlikely a code or CSS style will make it literally hidden or disappear in this scenario.

Once I tweaked and overblown the levels of the screenshot from the issue, we can confirm this is the actual cause of it since the text are more visible after the tweak:
![93862787-e390e400-fcc2-11ea-9e90-8dbdf8058435 (1)](https://user-images.githubusercontent.com/42867097/93916523-4377a100-fd3c-11ea-9329-e91f14a05276.png)

It's because the text color is inherited from the root div of the component, like so:
![chrome_HRuyZq1Sr1](https://user-images.githubusercontent.com/42867097/93917082-14adfa80-fd3d-11ea-8256-c861a673e109.png)

## Solution

At first I tried adding the `dark:text-dark-surface` to the root div of the component, but this makes even the globe icon + "English" + chevron down icon become dark thus being "invisible".

Then I tried adding the class to the `select` tag, but while the globe icon & chevron down icon is not affected, the "English" text still becomes "invisible".

That's why I ended up having to put it to the `option` tag in the end. Here is the solution result for Windows in my local machine:
![chrome_EmxO7I26h3](https://user-images.githubusercontent.com/42867097/93916949-e6c8b600-fd3c-11ea-95c4-4e62884a1814.png)

It is definitely more legible now for Windows, so I assume it should be legible as well for Mac OS since `text-dark-surface` is a pretty dark color.