### PR TITLE
Translate glossary pages

### DIFF
--- a/content/es/guides/components-glossary/pages-watchquery.md
+++ b/content/es/guides/components-glossary/pages-watchquery.md
@@ -1,0 +1,38 @@
+---
+title: 'La propiedad watchQuery'
+description: Observar los query strings y ejecutar métodos del componente cuando cambien (asyncData, fetch, validate, layout, ...)
+menu: Propiedad WatchQuery
+category: components-glossary
+---
+
+> Observar los query strings y ejecutar métodos del componente cuando cambien (asyncData, fetch(context), validate, layout, ...)
+
+- **Tipo:** `Boolean` o `Array` o `Function` (default: `[]`)
+
+Utiliza `watchQuery` para configurar un watcher para las query strings. Si las strings definidas cambian, se llamará a todos los métodos del componente (asyncData, fetch(context), validate, layout, ...). Este seguimiento está desactivado por defecto para mejorar el rendimiento.
+
+Si quieres configurar un watcher para todas las strings, asigna el valor `watchQuery: true`.
+
+```js
+export default {
+  watchQuery: ['page']
+}
+```
+
+También puedes utilizar la función `watchQuery(newQuery, oldQuery)` para tener watchers más refinados.
+
+```js
+export default {
+  watchQuery(newQuery, oldQuery) {
+    // Solo ejecuta los métodos del componente si la query string antigua contenía `bar`
+    // y la nueva query string contiene `foo`
+    return newQuery.foo && oldQuery.bar
+  }
+}
+```
+
+<base-alert>
+
+**Advertencia**: El nuevo hook `fetch` introducido en la versión 2.12 no se ve afectado por `watchQuery`. Para más información ver [escuchando cambios en query strings](/guides/features/data-fetching#the-fetch-hook).
+
+</base-alert>

--- a/content/es/guides/configuration-glossary/configuration-mode.md
+++ b/content/es/guides/configuration-glossary/configuration-mode.md
@@ -14,8 +14,20 @@ position: 17
 
 > Puedes utilizar esta opción para cambiar el modo de nuxt por defecto de tu proyecto usando `nuxt.config.js`
 
+<base-alert type="warning">
+
+Obsoleta: por favor, utiliza `ssr: false` en lugar de `mode: spa`
+
+</base-alert>
+
 <base-alert type="next">
 
-Para aprender más sobre la opción `mode`, échale un vistazo a la [sección modos de renderizado](https://nuxtjs.org/guides/features/rendering-modes).
+Para aprender más sobre la opción `ssr`, échale un vistazo a la [sección propiedad ssr](/guides/configuration-glossary/configuration-ssr).
+
+</base-alert>
+
+<base-alert type="next">
+
+Para aprender más sobre la opción `mode`, échale un vistazo a la [sección modos de renderizado](/guides/features/rendering-modes).
 
 </base-alert>

--- a/content/es/guides/configuration-glossary/configuration-ssr.md
+++ b/content/es/guides/configuration-glossary/configuration-ssr.md
@@ -1,0 +1,26 @@
+---
+title: 'La propiedad ssr'
+description: Cambia el valor por defecto de ssr de nuxt
+menu: ssr
+category: configuration-glossary
+position: 28.1
+---
+
+- Tipo: `boolean`
+  - Por defecto: `true`
+  - Posibles valores:
+    - `false`: No hay renderizado del lado del servidor (solo navegación del lado del cliente)
+
+> Debes configurar esta opción cuando trabajas con single page applications
+
+```js{}[nuxt.config.js]
+export default {
+  ssr: false // para SPAs
+}
+```
+
+<base-alert type="next">
+
+Anteriormente, `mode` se utilizaba para desactivar o activar el renderizado server-side. Aquí está la [documentación de `mode`](/guides/configuration-glossary/configuration-mode).
+
+</base-alert>


### PR DESCRIPTION
Related to #543 

Translates the following pages:

* /guides/configuration-glossary/configuration-mode
* /guides/configuration-glossary/configuration-ssr
* /guides/components-glossary/pages-watchquery
