### PR TITLE
Fix: Add root container to default layout example

### DIFF
--- a/content/en/guides/directory-structure/layouts.md
+++ b/content/en/guides/directory-structure/layouts.md
@@ -86,9 +86,11 @@ You can add more components here such as Navigation, Header, Footer etc.
 
 ```html{}[layouts/default.vue]
 <template>
-  <TheHeader />
-  <Nuxt />
-  <TheFooter />
+  <div>
+    <TheHeader />
+    <Nuxt />
+    <TheFooter />
+  </div>
 </template>
 ```
 


### PR DESCRIPTION
Fixes the example code for the default layout which had more than one root element causing a compile error.