### PR TITLE
docs: spanish - move page of the root and fix tabs

### DIFF
--- a/content/es/guides/concepts/static-site-generation.md
+++ b/content/es/guides/concepts/static-site-generation.md
@@ -4,34 +4,34 @@ description: Con generación estática de sitio puedes renderizar tu aplicación
 position: 4
 category: concepts
 questions:
-- question: Necesitas un server para hospedar tu sitio estático ?
-answers:
-- True
-- False
-correctAnswer: False
-- question: Qué comando usas para generar tu sitio estático ?
-answers:
-- nuxt build
-- nuxt prerender
-- nuxt generate
-correctAnswer: nuxt generate
-- question: Cuándo es llamada tu API ?
-answers:
-- Cada vez que navegas a la página con el contenido del API
-- Cuando generas tu sitio
-- Cuando generas tu sitio y cada vez que navegas a la página con el contenido del API
-correctAnswer: Cuando generas tu sitio
-- question: Que páginas alternarán a single page application mode ?
-answers:
-- La página de error
-- Las páginas excluidas del proceso de generación con generate.excludes 
-- Todas páginas en navegación
-correctAnswer: Las páginas excluidas del proceso de generación con generate.excludes
-- question: Cómo actualizas el contenido de tu sitio ?
-answers:
-- Es actualizado automáticamente
-- Es necesario regenerar el sitio
-correctAnswer: Es necesario regenerar el sitio
+  - question: Necesitas un server para hospedar tu sitio estático ?
+    answers:
+      - True
+      - False
+    correctAnswer: False
+  - question: Qué comando usas para generar tu sitio estático ?
+    answers:
+      - nuxt build
+      - nuxt prerender
+      - nuxt generate
+    correctAnswer: nuxt generate
+  - question: Cuándo es llamada tu API ?
+    answers:
+      - Cada vez que navegas a la página con el contenido del API
+      - Cuando generas tu sitio
+      - Cuando generas tu sitio y cada vez que navegas a la página con el contenido del API
+    correctAnswer: Cuando generas tu sitio
+  - question: Que páginas alternarán a single page application mode ?
+    answers:
+      - La página de error
+      - Las páginas excluidas del proceso de generación con generate.excludes
+      - Todas páginas en navegación
+    correctAnswer: Las páginas excluidas del proceso de generación con generate.excludes
+  - question: Cómo actualizas el contenido de tu sitio ?
+    answers:
+      - Es actualizado automáticamente
+      - Es necesario regenerar el sitio
+    correctAnswer: Es necesario regenerar el sitio
 ---
 
 Con generación estática de sitio puedes renderizar tu aplicación durante la fase de build y desplegarlo a cualquier servicio de hosting de sitios estáticos como Netlify, GitHub pages, Vercel etc. Esto implica que no es necesario un server para desplegar tu aplicación.
@@ -49,11 +49,11 @@ Cuando el navegador envíe el request inicial, lo recibirá el CDN.
 El CDN enviará los previamente generados HTML, JavaScript y activos de static al navegador.
 El contenido será mostrado y la hidratación de Vue.js entrará en acción, haciéndolo reactivo. Después de este proceso, la página será interactiva.
 
-### Paso 3: Navegador a  Navegador
+### Paso 3: Navegador a Navegador
 
 La navegación entre rutas con [`<NuxtLink>`](/guides/features/nuxt-components#the-nuxtlink-component) es realizada en el cliente, no será necesario acceder al CDN nuevamente, todas las llamadas a la API serán cargadas desde el caché de la carpeta static, incluso si refrescas el navegador.
 
-### Alternando a SPA 
+### Alternando a SPA
 
 Las páginas que han sido excluidas del proceso de generación usando la propiedad `generate.exclude` alternarán a single page application. Estas páginas no existirán en el CDN y serán renderizadas en el cliente una vez el usuario navegue a ellas.
 


### PR DESCRIPTION
This commit put a docs spanish page in the root of the repository. https://github.com/nuxt/nuxtjs.org/commit/ff6194d8b4cc13ccd00858b86cb4911952781d84

I made this PR to fix that, and fix some tabs in the start of the page (I don't know is that is important or not.).