### PR TITLE
Added warning for including images in articles

### DIFF
--- a/content/en/blog/creating-blog-with-nuxt-content.md
+++ b/content/en/blog/creating-blog-with-nuxt-content.md
@@ -248,13 +248,24 @@ We now have a title, description, img and alt variable that we can access to by 
   <article>
     <h1>{{ article.title }}</h1>
     <p>{{ article.description }}</p>
-    <img :src="article.img" :alt="article.alt" />
+    <img
+      :src="require(`~/assets/images/${article.image}`)"
+      :alt="article.alt"
+    />
     <p>Article last updated: {{ formatDate(article.updatedAt) }}</p>
 
     <nuxt-content :document="article" />
   </article>
 </template>
 ```
+
+<base-alert>
+
+In order to render images included in the YAML of the article we either need to place them in the static folder or use the syntax: `` :src="require(`~/assets/images/${article.image}`)" ``.
+
+Images included in the article content should always be placed **in the static folder** as @nuxt/content is independent of Webpack (see issue [#106](https://github.com/nuxt/content/issues/106)).
+
+</base-alert>
 
 ### Styling our markdown content
 
@@ -276,13 +287,13 @@ If we inspect this page we can see that everything written inside our markdown i
 </style>
 ```
 
-All other tags that come from our YAML front matter can be styled as normal either using [TailwindCSS](https://tailwindcss.com/) or adding css in the style tag.
-
 <base-alert>
 Scoped styles will not work with nuxt-content so if adding them in the style
 tag you shouldn't use scoped. You can add the styles here or as a global style
 in your css folder.
 </base-alert>
+
+All other tags that come from our YAML front matter can be styled as normal either using [TailwindCSS](https://tailwindcss.com/) or adding css in the style tag.
 
 Our markdown tags are converted into the correct tags which means we now have two `<h1>` tags. We should now remove the one from our markdown file.
 

--- a/content/en/blog/creating-blog-with-nuxt-content.md
+++ b/content/en/blog/creating-blog-with-nuxt-content.md
@@ -249,7 +249,7 @@ We now have a title, description, img and alt variable that we can access to by 
     <h1>{{ article.title }}</h1>
     <p>{{ article.description }}</p>
     <img
-      :src="require(`~/assets/images/${article.image}`)"
+      :src="article.image"
       :alt="article.alt"
     />
     <p>Article last updated: {{ formatDate(article.updatedAt) }}</p>
@@ -263,7 +263,7 @@ We now have a title, description, img and alt variable that we can access to by 
 
 In order to render images included in the YAML of the article we either need to place them in the static folder or use the syntax: `` :src="require(`~/assets/images/${article.image}`)" ``.
 
-Images included in the article content should always be placed **in the static folder** as @nuxt/content is independent of Webpack (see issue [#106](https://github.com/nuxt/content/issues/106)).
+Images included in the article content should always be placed **in the static folder** as @nuxt/content is independent of Webpack. The static folder doesn't go through webpack whereas the assets folder does.
 
 </base-alert>
 


### PR DESCRIPTION
Added a warning for placing images from the assets folder in posts articles. Changed warning location for scoped styles to improve readability. 