### PR TITLE
refactor(sponsors): improve ref handling

### DIFF
--- a/pages/sponsor-nuxtjs.vue
+++ b/pages/sponsor-nuxtjs.vue
@@ -130,7 +130,7 @@
             v-for="(sponsor, i) in group"
             :key="i"
             class="sponsor inline-block m-4"
-            :href="sponsor.url"
+            :href="`${sponsor.url}?ref=nuxt`"
             target="_blank"
             rel="noopener sponsored"
           >
@@ -186,12 +186,12 @@ export default {
           {
             name: 'Storyblok',
             img: 'storyblok-logo.svg',
-            url: 'https://www.storyblok.com/?ref=nuxt',
+            url: 'https://www.storyblok.com/',
             class: 'h-24'
           },
           {
             name: 'Moovweb',
-            url: 'https://www.moovweb.com/?ref=nuxt',
+            url: 'https://www.moovweb.com/',
             img: 'moovweb-logo.png',
             class: 'h-12'
           }
@@ -200,7 +200,7 @@ export default {
           {
             name: 'VueMastery',
             img: 'vueMastery-brand.svg',
-            url: 'https://www.vuemastery.com/?ref=nuxt',
+            url: 'https://www.vuemastery.com/',
             class: 'h-10'
           }
         ],
@@ -208,31 +208,31 @@ export default {
           {
             name: 'Sparheld',
             img: 'sparheld.svg',
-            url: 'https://www.sparheld.de/?ref=nuxt',
+            url: 'https://www.sparheld.de/',
             class: 'h-8'
           },
           {
             name: 'Icons8',
             img: 'icons8.svg',
-            url: 'https://icons8.com/?ref=nuxt',
+            url: 'https://icons8.com/',
             class: 'h-8'
           },
           {
             name: 'FireStickHow',
             img: 'fire-stick-how.png',
-            url: 'https://www.firestickhow.com/?ref=nuxt',
+            url: 'https://www.firestickhow.com/',
             class: 'h-8'
           },
           {
             name: 'MiniTool',
             img: 'minitool.png',
-            url: 'https://www.minitool.com?ref=nuxt',
+            url: 'https://www.minitool.com/',
             class: 'h-8'
           },
           {
             name: 'VPS Server',
             img: 'vps-server.png',
-            url: 'https://www.vpsserver.com/?ref=nuxt',
+            url: 'https://www.vpsserver.com/',
             class: 'h-8'
           }
         ],
@@ -240,7 +240,7 @@ export default {
           {
             name: 'SendCloud',
             img: 'sendcloud.svg',
-            url: 'https://www.sendcloud.com/?ref=nuxt',
+            url: 'https://www.sendcloud.com/',
             class: 'h-8'
           }
         ],
@@ -248,7 +248,7 @@ export default {
           {
             name: 'Google Chrome',
             img: 'google-chrome.svg',
-            url: 'https://www.google.com/chrome/?ref=nuxt',
+            url: 'https://www.google.com/chrome/',
             class: 'h-12'
           }
         ]


### PR DESCRIPTION
As `?ref=nuxt` should be part of all URLs, I'd hardcode it in the `a` tag `href` value instead of adding it to each url manually.