### PR TITLE
docs(import error note): Note on fixing import error

### DIFF
--- a/content/en/guide/plugins.md
+++ b/content/en/guide/plugins.md
@@ -41,6 +41,16 @@ Then we can use it directly in our page components:
   }
 </script>
 ```
+__NOTE__: If you get an "__Cannot use import statement outside a module__" error, you may need to add your package to the build > transpile option in nuxt.config.js for webpack loader to make your plugin available.
+```js
+  build: {
+    /*
+     ** You can extend webpack config here
+     */
+    transpile: ['your-plugin-name'],
+  },
+```
+
 
 ## Vue Plugins
 


### PR DESCRIPTION
Fix for "Cannot use import statement outside a module" error by adding plugins to the transpile build step.
Source: https://stackoverflow.com/a/61196076