### PR TITLE
docs: Replace buildTargets with targets in configuration-build - preset example

### DIFF
--- a/content/en/api/configuration-build.md
+++ b/content/en/api/configuration-build.md
@@ -100,7 +100,7 @@ export default {
           [
             preset,
             {
-              buildTarget: isServer ? 'server' : 'client',
+              targets: isServer ? ... :  ...,
               ...options
             }
           ],

--- a/content/en/guides/configuration-glossary/configuration-build.md
+++ b/content/en/guides/configuration-glossary/configuration-build.md
@@ -99,7 +99,7 @@ export default {
           [
             preset,
             {
-              buildTarget: isServer ? 'server' : 'client',
+              targets: isServer ? ... :  ...,
               ...options
             }
           ],
@@ -281,13 +281,11 @@ export default {
 
 To understand a bit more about the use of manifests, take a look at this [webpack documentation](https://webpack.js.org/guides/code-splitting/).
 
-
 <base-alert>
 
 Be careful when using non-hashed based filenames in production as most browsers will cache the asset and not detect the changes on first load.
 
 </base-alert>
-
 
 ## friendlyErrors
 

--- a/content/es/guides/configuration-glossary/configuration-build.md
+++ b/content/es/guides/configuration-glossary/configuration-build.md
@@ -99,7 +99,7 @@ export default {
           [
             preset,
             {
-              buildTarget: isServer ? 'server' : 'client',
+              targets: isServer ? ... :  ...,
               ...options
             }
           ],
@@ -281,13 +281,11 @@ export default {
 
 Para entender mejor como funciona el uso de manifests, echa un vistazo a la [documentación de webpack](https://webpack.js.org/guides/code-splitting/).
 
-
 <base-alert>
 
 Tenga cuidado al usar nombres de archivo no basados en hash en producción, ya que la mayoría de los navegadores almacenarán en caché el activo y no detectarán los cambios en la primera carga.
 
 </base-alert>
-
 
 ## friendlyErrors
 
@@ -637,7 +635,7 @@ Esta opción se establece automáticamente en función del valor de `mode` si no
 
 <base-alert>
 
-**Advertencia:** Esta propiedad está obsoleta. En su lugar use por favor  [style-resources-module](https://github.com/nuxt-community/style-resources-module/) para mejorar rendimiento y un mejor DX!
+**Advertencia:** Esta propiedad está obsoleta. En su lugar use por favor [style-resources-module](https://github.com/nuxt-community/style-resources-module/) para mejorar rendimiento y un mejor DX!
 
 </base-alert>
 
@@ -725,7 +723,7 @@ Mira [webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/
 
 Si desea transpilar dependencias específicas con Babel, puede agregarlas en `build.transpile`. Cada elemento en transpile puede ser un nombre de paquete, una string o un objeto regex que coincida con el nombre del archivo de la dependencia.
 
-Comenzando con `v2.9.0`, también puedes usar una función para transpilar condicionalmente, la función recibirá un objeto (` {isDev, isServer, isClient, isModern, isLegacy} `):
+Comenzando con `v2.9.0`, también puedes usar una función para transpilar condicionalmente, la función recibirá un objeto (`{isDev, isServer, isClient, isModern, isLegacy}`):
 
 ```js{}[nuxt.config.js]
 {

--- a/content/fr/api/configuration-build.md
+++ b/content/fr/api/configuration-build.md
@@ -93,7 +93,7 @@ export default {
           [
             preset,
             {
-              buildTarget: isServer ? 'server' : 'client',
+              targets: isServer ? ... :  ...,
               ...options
             }
           ],

--- a/content/ja/api/configuration-build.md
+++ b/content/ja/api/configuration-build.md
@@ -93,7 +93,7 @@ export default {
           [
             preset,
             {
-              buildTarget: isServer ? 'server' : 'client',
+              targets: isServer ? ... :  ...,
               ...options
             }
           ],

--- a/content/ja/guides/configuration-glossary/configuration-build.md
+++ b/content/ja/guides/configuration-glossary/configuration-build.md
@@ -99,7 +99,7 @@ export default {
           [
             preset,
             {
-              buildTarget: isServer ? 'server' : 'client',
+              targets: isServer ? ... :  ...,
               ...options
             }
           ],

--- a/content/pt/guides/configuration-glossary/configuration-build.md
+++ b/content/pt/guides/configuration-glossary/configuration-build.md
@@ -99,7 +99,7 @@ export default {
           [
             preset,
             {
-              buildTarget: isServer ? 'server' : 'client',
+              targets: isServer ? ... :  ...,
               ...options
             }
           ],


### PR DESCRIPTION
If I understand it correctly, newer versions of `@nuxt/babel-preset-app` does not support the `buildTarget` option anymore.

Anyway, looking at the documentation there is still a reference to that option.

If this is correct, I can expand the PR to other languages as well. If not, feel free to close this PR. 