### PR TITLE
docs(en): add documentation for config property generate.nonRootPageExtension

### DIFF
--- a/content/en/api/configuration-generate.md
+++ b/content/en/api/configuration-generate.md
@@ -197,6 +197,14 @@ Interval (in milliseconds) between two render cycles to avoid flooding a potenti
 - **Deprecated!**
 - Use [build.html.minify](/api/configuration-build#html-minify) instead
 
+## nonRootPageExtension
+
+- Type: `String`
+
+With `subFolders` set to `false`, allows setting the extension of generated non-root pages. For example, setting `generate.nonRootPageExtension` to `''` will generate the pages' files without any extension.
+
+If not set, all the files will be generated with a `.html` extension.
+
 ## routes
 
 - Type: `Array`


### PR DESCRIPTION
This adds documentation for a new feature, purposed in issue 8212 and implemented in PR 8222 in Nuxt. Basically, it allows setting the extension of the generated pages.