### PR TITLE
docs(en): Correct spelling mistakes

### DIFF
--- a/content/en/guides/concepts/context-helpers.md
+++ b/content/en/guides/concepts/context-helpers.md
@@ -116,7 +116,7 @@ export default {
 }
 ```
 
-With [ES6](https://hacks.mozilla.org/2015/05/es6-in-depth-destructuring/) you can use this syntax to descructure your context object. You can pass in the objects you want to have access to and then you can use them in the code without using the word context.
+With [ES6](https://hacks.mozilla.org/2015/05/es6-in-depth-destructuring/) you can use this syntax to destructure your context object. You can pass in the objects you want to have access to and then you can use them in the code without using the word context.
 
 ```js{}[pages/posts/_id.vue]
 export default {

--- a/content/en/guides/configuration-glossary/configuration-hooks.md
+++ b/content/en/guides/configuration-glossary/configuration-hooks.md
@@ -29,7 +29,7 @@ export default {
 }
 ```
 
-Internally, hooks follow a naming pattern using colons (e.g., `build:done`). For ease of configuration, you can structure them as an hierarchical object when using `nuxt.config.js` (as exemplifed above) to set your own hooks. See [Nuxt Internals](/guides/internals-glossary/internals) for more detailed information on how they work.
+Internally, hooks follow a naming pattern using colons (e.g., `build:done`). For ease of configuration, you can structure them as an hierarchical object when using `nuxt.config.js` (as exemplified above) to set your own hooks. See [Nuxt Internals](/guides/internals-glossary/internals) for more detailed information on how they work.
 
 ## List of hooks
 
@@ -108,9 +108,9 @@ Then, create a few files;
    import parseurl from 'parseurl'
 
    /**
-    * Connect middleware to handle redirecting to desired Web Applicatin Context Root.
+    * Connect middleware to handle redirecting to desired Web Application Context Root.
     *
-    * Notice that Nuxt docs lacks explaning how to use hooks.
+    * Notice that Nuxt docs lacks explaining how to use hooks.
     * This is a sample router to help explain.
     *
     * See nice implementation for inspiration:

--- a/content/en/guides/configuration-glossary/configuration-router.md
+++ b/content/en/guides/configuration-glossary/configuration-router.md
@@ -40,7 +40,7 @@ When `base` is set, Nuxt.js will also add in the document header `<base href="{{
 - Type: `String`
 - Default: `'-'`
 
-You may want to change the separator between route names that Nuxt.js uses. You can do so via the `routeNameSplitter` option in your configuration file. Imagine we have the page file `pages/posts/_id.vue`. Nuxt will generate the route name programatically, in this case `posts-id`. Changing the `routeNameSplitter` config to `/` the name will therefore change to `posts/id`.
+You may want to change the separator between route names that Nuxt.js uses. You can do so via the `routeNameSplitter` option in your configuration file. Imagine we have the page file `pages/posts/_id.vue`. Nuxt will generate the route name programmatically, in this case `posts-id`. Changing the `routeNameSplitter` config to `/` the name will therefore change to `posts/id`.
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/en/guides/directory-structure/nuxt-config.md
+++ b/content/en/guides/directory-structure/nuxt-config.md
@@ -84,7 +84,7 @@ See more on the [css property](/guides/configuration-glossary/configuration-css
 
 ### dev
 
-This option lets you define the `development` or `production` mode of Nuxt.js (important when you use Nuxt.js programatically)
+This option lets you define the `development` or `production` mode of Nuxt.js (important when you use Nuxt.js programmatically)
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/en/guides/directory-structure/store.md
+++ b/content/en/guides/directory-structure/store.md
@@ -46,7 +46,7 @@ questions:
       - fetch
       - asyncData
     correctAnswer: nuxtServerInit
-  - question: In asynData the context is given to the nuxtServerInit as the
+  - question: In asyncData the context is given to the nuxtServerInit as the
     answers:
       - first argument
       - second argument

--- a/content/en/guides/features/data-fetching.md
+++ b/content/en/guides/features/data-fetching.md
@@ -102,7 +102,7 @@ In addition to fetch being called by Nuxt, you can manually call fetch in your c
 ```html{}[components/NuxtMountains.vue]
 <template>
   <p v-if="$fetchState.pending">Fetching mountains...</p>
-  <p v-else-if="$fetchState.error">An error occured :(</p>
+  <p v-else-if="$fetchState.error">An error occurred :(</p>
   <div v-else>
     <h1>Nuxt Mountains</h1>
     <ul>

--- a/content/en/guides/internals-glossary/internals.md
+++ b/content/en/guides/internals-glossary/internals.md
@@ -81,7 +81,7 @@ class SomeClass {
 }
 ```
 
-Classes are _plugable_ so they should register a plugin on main `nuxt` container to register more hooks.
+Classes are _pluggable_ so they should register a plugin on main `nuxt` container to register more hooks.
 
 ```js
 class FooClass {


### PR DESCRIPTION
Fixes spelling mistakes in the English guides.

There were instances of both British English and US English, so I left them as-is. The `nuxt.js` codebase appears to use US English, so I can make the following changes if desired:
- Customising ➡️ Customizing
- artefacts ➡️ artifacts
- behaviour ➡️ behavior