### PR TITLE
docs(en): include the unit for the `interval` property

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-generate.md
+++ b/content/en/guides/configuration-glossary/configuration-generate.md
@@ -186,7 +186,7 @@ _Note: Multiple services (e.g. Netlify) detect a `404.html` automatically. If yo
 - Type: `Number`
 - Default: `0`
 
-Interval between two render cycles to avoid flooding a potential API with API calls from the web application.
+Interval in milliseconds between two render cycles to avoid flooding a potential API with calls from the web application.
 
 ## minify
 


### PR DESCRIPTION
Just a quick PR as it wasn't clear to me if it was seconds or milliseconds.