### PR TITLE
Fix typos

### DIFF
--- a/content/en/guide/routing.md
+++ b/content/en/guide/routing.md
@@ -112,7 +112,7 @@ As of Nuxt >= v2.13 there is a crawler installed that will now crawl your link t
 
 <div class="Alert Alert--orange">
 
-**Warning:** If you using Nuxt >= v2.13 and have pages that have no links such as secret pages and you would like these to also be generated then you can use the `generate.routes` property.
+**Warning:** If you are using Nuxt >= v2.13 and have pages that have no links such as secret pages and you would like these to also be generated then you can use the `generate.routes` property.
 
 **Warning:** dynamic routes are ignored by the `generate` command when using Nuxt <= v2.12
 

--- a/content/en/guide/routing.md
+++ b/content/en/guide/routing.md
@@ -112,7 +112,7 @@ As of Nuxt >= v2.13 there is a crawler installed that will now crawl your link t
 
 <div class="Alert Alert--orange">
 
-**Warning:** If you are using Nuxt >= v2.13 and have pages that have no links such as secret pages and you would like these to also be generated then you can use the `generate.routes` property.
+**Warning:** If you are using Nuxt >= v2.13 and have pages that have no links, such as secret pages, and you would like these to also be generated then you can use the `generate.routes` property.
 
 **Warning:** dynamic routes are ignored by the `generate` command when using Nuxt <= v2.12
 


### PR DESCRIPTION
Hello :wave: 

This PR fixes a couple of typos that I noticed in the warning for `/guide/routing#dynamic-routes`. You can find justifications for the changes in the bodies of the commits.