### PR TITLE
Update Repository Name in Module Guide

### DIFF
--- a/content/en/_archives/guide/modules.md
+++ b/content/en/_archives/guide/modules.md
@@ -292,7 +292,7 @@ export default function (moduleOptions) {
 
 ## Run Tasks on Specific hooks
 
-Your module may need to do things only on specific conditions and not just during Nuxt initialization. We can use the powerful hooks Nuxt.js system to do tasks on specific events (based on [Hable](https://github.com/jsless/hable)). Nuxt will wait for your function if it return a Promise or is defined as `async`.
+Your module may need to do things only on specific conditions and not just during Nuxt initialization. We can use the powerful hooks Nuxt.js system to do tasks on specific events (based on [Hookable](https://github.com/nuxt-contrib/hookable)). Nuxt will wait for your function if it return a Promise or is defined as `async`.
 
 Here are some basic examples:
 

--- a/content/en/guides/directory-structure/modules.md
+++ b/content/en/guides/directory-structure/modules.md
@@ -268,7 +268,7 @@ Please look into the [ModuleContainer](/docs/2.x/internals-glossary/internals-m
 
 ### Run Tasks on Specific hooks
 
-Your module may need to do things only on specific conditions and not just during Nuxt.js initialization. We can use the powerful Nuxt.js hooks to do tasks on specific events (based on [Hable](https://github.com/jsless/hable)). Nuxt.js will wait for your function if it returns a Promise or is defined as `async`.
+Your module may need to do things only on specific conditions and not just during Nuxt.js initialization. We can use the powerful Nuxt.js hooks to do tasks on specific events (based on [Hookable](https://github.com/nuxt-contrib/hookable)). Nuxt.js will wait for your function if it returns a Promise or is defined as `async`.
 
 Here are some basic examples:
 

--- a/content/es/guides/directory-structure/modules.md
+++ b/content/es/guides/directory-structure/modules.md
@@ -255,7 +255,7 @@ Mira la documentación de la clases [ModuleContainer](/docs/2.x/internals-gloss
 
 ### Ejecutar tareas en hooks específicos
 
-Es posible que tu módulo deba hacer cosas solo en condiciones específicas y no solo durante la inicialización de Nuxt.js. Podemos usar los poderosos hooks de Nuxt.js para realizar tareas en eventos específicos (basados en [Hable](https://github.com/jsless/hable)). Nuxt.js esperará a que la función termine si esta devuelve un Promise o si está definida como `async`.
+Es posible que tu módulo deba hacer cosas solo en condiciones específicas y no solo durante la inicialización de Nuxt.js. Podemos usar los poderosos hooks de Nuxt.js para realizar tareas en eventos específicos (basados en [Hookable](https://github.com/nuxt-contrib/hookable)). Nuxt.js esperará a que la función termine si esta devuelve un Promise o si está definida como `async`.
 
 Algunos ejemplos básicos:
 

--- a/content/fr/guide/modules.md
+++ b/content/fr/guide/modules.md
@@ -293,7 +293,7 @@ export default function (moduleOptions) {
 
 ## Exécuter des tâches sur des écouteurs spécifiques
 
-Votre module peut avoir besoin de faire des choses uniquement dans certaines conditions spécifiques et pas seulement lors de l'initialisation de Nuxt. Nous pouvons utiliser le puissant système d'écouteurs de Nuxt.js pour effectuer des tâches sur des événements spécifiques (basés sur [Hable](https://github.com/jsless/hable)). Nuxt attendra votre fonction si elle retourne une promesse ou est définie en tant que `async`.
+Votre module peut avoir besoin de faire des choses uniquement dans certaines conditions spécifiques et pas seulement lors de l'initialisation de Nuxt. Nous pouvons utiliser le puissant système d'écouteurs de Nuxt.js pour effectuer des tâches sur des événements spécifiques (basés sur [Hookable](https://github.com/nuxt-contrib/hookable)). Nuxt attendra votre fonction si elle retourne une promesse ou est définie en tant que `async`.
 
 Voici quelques exemples de base :
 

--- a/content/ja/guide/modules.md
+++ b/content/ja/guide/modules.md
@@ -291,7 +291,7 @@ export default function (moduleOptions) {
 
 ## 特定のフックでタスクを実行する
 
-単に Nuxt の初期化処理時だけではなく、特定の条件下でのみ、モジュールにある処理を実行させたいこともあるでしょう。Nuxt.js システムの強力なフックを使用して特定のイベントでタスクを実行できます（[Hable](https://github.com/jsless/hable) をベースにしています）。Nuxt は関数が Promise を返すか、`async` として定義されている場合その関数を待機します。
+単に Nuxt の初期化処理時だけではなく、特定の条件下でのみ、モジュールにある処理を実行させたいこともあるでしょう。Nuxt.js システムの強力なフックを使用して特定のイベントでタスクを実行できます（[Hookable](https://github.com/nuxt-contrib/hookable) をベースにしています）。Nuxt は関数が Promise を返すか、`async` として定義されている場合その関数を待機します。
 
 以下が基本的な例です。
 

--- a/content/pt/guides/directory-structure/modules.md
+++ b/content/pt/guides/directory-structure/modules.md
@@ -255,7 +255,7 @@ Consulte a documentação da classe [ModuleContainer](/docs/2.x/internals-glossa
 
 ### Executa tarefas em hooks específicos
 
-Seu módulo pode precisar fazer coisas apenas em condições específicas e não somente durante a inicialização do Nuxt.js. Podemos usar os poderosos hooks do Nuxt.js para fazer tarefas em eventos específicos (baseado no [Hable](https://github.com/jsless/hable)). Nuxt.js esperará por sua função se ela retornar uma promise ou for definida como `async`.
+Seu módulo pode precisar fazer coisas apenas em condições específicas e não somente durante a inicialização do Nuxt.js. Podemos usar os poderosos hooks do Nuxt.js para fazer tarefas em eventos específicos (baseado no [Hookable](https://github.com/nuxt-contrib/hookable)). Nuxt.js esperará por sua função se ela retornar uma promise ou for definida como `async`.
 
 Aqui estão alguns exemplos básicos:
 


### PR DESCRIPTION
### What Does This Do?

This PR updates the Modules guide to refer to **[Hookable](https://github.com/nuxt-contrib/hookable)** instead of **[Hable](https://github.com/jsless/hable)**. It appears that the repository for Hable was transferred to Hookable, as https://github.com/jsless/hable redirects to https://github.com/nuxt-contrib/hookable.