### PR TITLE
docs(en/es/id/pt): Updating example code typo in plugins.md

### DIFF
--- a/content/en/guides/directory-structure/plugins.md
+++ b/content/en/guides/directory-structure/plugins.md
@@ -357,7 +357,7 @@ Global mixins can be easily added with Nuxt plugins but can cause trouble and me
 
 ```js{}[plugins/my-mixin-plugin.js]
 if (!Vue.__my_mixin__) {
-	Vue.__my__mixin__ = true
+	Vue.__my_mixin__ = true
   Vue.mixin({ ... }) // Set up your mixin then
 }
 ```

--- a/content/en/guides/directory-structure/plugins.md
+++ b/content/en/guides/directory-structure/plugins.md
@@ -357,7 +357,7 @@ Global mixins can be easily added with Nuxt plugins but can cause trouble and me
 
 ```js{}[plugins/my-mixin-plugin.js]
 if (!Vue.__my_mixin__) {
-	Vue.__my_mixin__ = true
+  Vue.__my_mixin__ = true
   Vue.mixin({ ... }) // Set up your mixin then
 }
 ```

--- a/content/es/guides/directory-structure/plugins.md
+++ b/content/es/guides/directory-structure/plugins.md
@@ -356,7 +356,7 @@ Puedes añadir fácilmente mixins globales con Nuxt plugins, pero puedes causar 
 
 ```js{}[plugins/my-mixin-plugin.js]
 if (!Vue.__my_mixin__) {
- Vue.__my__mixin__ = true
+  Vue.__my_mixin__ = true
   Vue.mixin({ ... }) // Configura tu mixin
 }
 ```

--- a/content/id/guides/directory-structure/plugins.md
+++ b/content/id/guides/directory-structure/plugins.md
@@ -327,7 +327,7 @@ _Global mixins_ daoat ditambahkan secara mudah dengan Nuxt _plugins_, tetapi dap
 
 ```js{}[plugins/my-mixin-plugin.js]
 if (!Vue.__my_mixin__) {
-	Vue.__my__mixin__ = true
+  Vue.__my_mixin__ = true
   Vue.mixin({ ... }) // Tetapkan mixin Anda lalu
 }
 ```

--- a/content/pt/guides/directory-structure/plugins.md
+++ b/content/pt/guides/directory-structure/plugins.md
@@ -327,7 +327,7 @@ Mixins globais podem ser facilmente adicionados com plugins do Nuxt, mas podem c
 
 ```js{}[plugins/meu-mixin-plugin.js]
 if (!Vue.__meu_mixin__) {
-  Vue.__meu__mixin__ = true
+  Vue.__meu_mixin__ = true
   Vue.mixin({ ... }) // Então, configure seu mixin
 }
 ```


### PR DESCRIPTION
Global Mixins example code had an additional underscore which could lead to confusion over the example for beginner devs; or those who copy + paste this example.