### PR TITLE
docs(en): add nuxt version tag for `asyncScripts`

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -102,7 +102,7 @@ The assets will be joined together with `,` and passed as a single `Link` header
 - Type: `Boolean`
   - Default: `false`
 
-> Adds an `async` attribute to `<script>` tags for Nuxt bundles, enabling them to be fetched in parallel to parsing. [More information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).
+> Adds an `async` attribute to `<script>` tags for Nuxt bundles, enabling them to be fetched in parallel to parsing (available with `2.14.8+`). [More information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).
 
 ## injectScripts
 


### PR DESCRIPTION
Amends https://github.com/nuxt/nuxtjs.org/pull/989 to add expected release version for https://github.com/nuxt/nuxt.js/pull/8347