### PR TITLE
fix: curly brackets after filename in docs

### DIFF
--- a/content/en/guides/components-glossary/pages-middleware.md
+++ b/content/en/guides/components-glossary/pages-middleware.md
@@ -15,7 +15,7 @@ Set the middleware for a specific page of the application.
 
 You can create named middleware by creating a file inside the `middleware/` directory, the file name will be the middleware name.
 
-```js{[middleware/authenticated.js]}
+```js{}[middleware/authenticated.js]
 export default function ({ store, redirect }) {
   // If the user is not authenticated
   if (!store.state.authenticated) {
@@ -40,7 +40,7 @@ export default function ({ store, redirect }) {
 
 If you need to use a middleware only for a specific page, you can directly use a function for it (or an array of functions):
 
-```html{[pages/secret.vue]}
+```html{}[pages/secret.vue]
 <template>
   <h1>Secret page</h1>
 </template>


### PR DESCRIPTION

<img width="259" alt="Screenshot 2020-11-18 at 10 55 47" src="https://user-images.githubusercontent.com/5277979/99515187-edfeef80-298c-11eb-8853-4a98b2c869d0.png">
<img width="195" alt="Screenshot 2020-11-18 at 10 55 50" src="https://user-images.githubusercontent.com/5277979/99515190-ef301c80-298c-11eb-833b-abafa7ac4190.png">

https://nuxtjs.org/docs/2.x/components-glossary/pages-middleware/

the code snippets show the filename as: `middleware/authenticated.js}` and `pages/secret.vue}`