### PR TITLE
fix: remove 'and send it' to fix sentence structure

### DIFF
--- a/content/en/guides/concepts/static-site-generation.md
+++ b/content/en/guides/concepts/static-site-generation.md
@@ -46,7 +46,7 @@ When a browser sends the initial request, it will hit the CDN.
 
 ### Step 2: CDN to Browser
 
-The CDN will send the already generated HTML, JavaScript and static assets and send it back to the browser. The content is displayed and the Vue.js hydration kicks in, making it reactive. After this process, the page is interactive.
+The CDN will send the already generated HTML, JavaScript and static assets back to the browser. The content is displayed and the Vue.js hydration kicks in, making it reactive. After this process, the page is interactive.
 
 ### Step 3: Browser to Browser
 


### PR DESCRIPTION
Hi. Just removed "and send it" from the static site generation docs to fix the sentence structure.