### PR TITLE
fix(content): nuxt class link

### DIFF
--- a/content/en/guides/internals-glossary/internals.md
+++ b/content/en/guides/internals-glossary/internals.md
@@ -18,7 +18,7 @@ These classes are the heart of Nuxt and should exist on both runtime and build t
 
 #### Nuxt
 
-- [`Nuxt` Class](/docs/2.x/internals-glossary/nuxt)
+- [`Nuxt` Class](/docs/2.x/internals-glossary/internals-nuxt)
 - Source: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer

--- a/content/es/guides/internals-glossary/internals.md
+++ b/content/es/guides/internals-glossary/internals.md
@@ -18,7 +18,7 @@ Estas clases son el corazón de Nuxt y deberían existir tanto en tiempo de ejec
 
 #### Nuxt
 
-- [Clase `Nuxt`](/docs/2.x/internals-glossary/nuxt)
+- [Clase `Nuxt`](/docs/2.x/internals-glossary/internals-nuxt)
 - Fuente: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer

--- a/content/fr/guides/internals-glossary/internals.md
+++ b/content/fr/guides/internals-glossary/internals.md
@@ -18,7 +18,7 @@ Ces classes sont le cœur de Nuxt et doivent exister à la fois sur le runtime e
 
 #### Nuxt
 
-- [Classe `Nuxt`](/guides/internals-glossary/nuxt)
+- [Classe `Nuxt`](/guides/internals-glossary/internals-nuxt)
 - Source: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer

--- a/content/id/guides/internals-glossary/internals.md
+++ b/content/id/guides/internals-glossary/internals.md
@@ -18,7 +18,7 @@ Kelas-kelas berikut merupakan kelas utama dalam Nuxt dan tersedia baik pada saat
 
 #### Nuxt
 
-- [Kelas `Nuxt`](/guides/internals-glossary/nuxt)
+- [Kelas `Nuxt`](/guides/internals-glossary/internals-nuxt)
 - Sumber: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer

--- a/content/ja/guides/internals-glossary/internals.md
+++ b/content/ja/guides/internals-glossary/internals.md
@@ -18,7 +18,7 @@ These classes are the heart of Nuxt and should exist on both runtime and build t
 
 #### Nuxt
 
-- [`Nuxt` Class](/docs/2.x/internals-glossary/nuxt)
+- [`Nuxt` Class](/docs/2.x/internals-glossary/internals-nuxt)
 - Source: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer

--- a/content/pt/guides/internals-glossary/internals.md
+++ b/content/pt/guides/internals-glossary/internals.md
@@ -18,7 +18,7 @@ Essas classes são o coração do Nuxt e devem existir tanto no tempo de execuç
 
 #### Nuxt
 
-- [A classe `Nuxt`](/docs/2.x/internals-glossary/nuxt)
+- [A classe `Nuxt`](/docs/2.x/internals-glossary/internals-nuxt)
 - Fonte: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer


### PR DESCRIPTION
The `Nuxt Class` link in the 'Core > Nuxt' section of the 'Nuxt Modules Intro' page was incorrectly pointing to the [Using Nuxt.js Programmatically](https://nuxtjs.org/docs/2.x/internals-glossary/nuxt) page.

This change updates the link target from `/docs/2.x/internals-glossary/nuxt` to `/docs/2.x/internals-glossary/internals-nuxt`.