### PR TITLE
docs(en) Proposed changes `addPlugin` API

### DIFF
--- a/content/en/guides/internals-glossary/internals-module-container.md
+++ b/content/en/guides/internals-glossary/internals-module-container.md
@@ -57,7 +57,7 @@ This method returns final `{ dst, src, options }` object.
 
 - **template**: On top of [`addTemplate`](#addtemplate-template)'s `template` Object properties (`src`, `options`, and `fileName`),
 the parameter `template` in this scope also has plugin-specific options:
-  - `mode` (`'client'` or `'server'`): as in plugins [mode](/docs/2.x/directory-structure/plugins#object-syntax) 
+  - `mode` (`'all'`, `'client'` or `'server'`): as in plugins [mode](/docs/2.x/directory-structure/plugins#object-syntax) 
   - `ssr` (`Boolean`): Prefer `mode`, as this option will be deprecated in Nuxt 3.
 
 Registers a plugin using `addTemplate` and adds it to first of `plugins[]` option.

--- a/content/en/guides/internals-glossary/internals-module-container.md
+++ b/content/en/guides/internals-glossary/internals-module-container.md
@@ -55,6 +55,11 @@ This method returns final `{ dst, src, options }` object.
 
 ### addPlugin (template)
 
+- **template**: On top of [`addTemplate`](#addtemplate-template)'s `template` Object properties (`src`, `options`, and `fileName`),
+the parameter `template` in this scope also has plugin-specific options:
+  - `mode` (`'client'` or `'server'`): as in plugins [mode](/docs/2.x/directory-structure/plugins#object-syntax) 
+  - `ssr` (`Boolean`): Prefer `mode`, as this option will be deprecated in Nuxt 3.
+
 Registers a plugin using `addTemplate` and adds it to first of `plugins[]` option.
 
 You can use `template.ssr: false` to disable plugin including in SSR bundle.

--- a/content/en/guides/internals-glossary/internals-module-container.md
+++ b/content/en/guides/internals-glossary/internals-module-container.md
@@ -55,23 +55,23 @@ This method returns final `{ dst, src, options }` object.
 
 ### addPlugin (template)
 
-- **template**: same signature as [`addTemplate`](#addtemplate-template)'s `template` Object properties (`src`, `options`, and `fileName`).
-  
-  Remember that with [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin), you can specify a `fileName` to be run only in `client` or in `server` sides. Avoid passing `mode` and `ssr` options, as those will be deprecated.
+- **template**: Object properties (`src`, `options`, `fileName`, `mode`).
 
-Registers a plugin using `addTemplate` and adds it to the top of `plugins[]` option.
-  
-```
+Registers a plugin using `addTemplate` and prepends it it to `plugins[]` array.
+
+```js
 this.addPlugin({
   src: path.resolve(__dirname, 'templates/foo.js'),
-  /* optional */ fileName: 'foo.server.js' // will only run in server side
+  fileName: 'foo.server.js' // [optional] only include in server bundle
   options: moduleOptions
 })
 ```
 
-If you choose to specify a `fileName`, you can configure a custom path for the `fileName` too, so you can choose the folder structure inside `.nuxt` folder or prevent name collisioning:
+**Note:** You can use `mode` or `.client` and `.server` prefixes with `fileName` option to use plugin only in client or server side. (See [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin) for all available options)
 
-```
+If you choose to specify a `fileName`, you can configure a custom path for the `fileName` too, so you can choose the folder structure inside `.nuxt` folder in order to prevent name collisioning:
+
+```js
 {
   fileName: path.join('folder', 'foo.client.js'), // will result in `.nuxt/folder/foo.client.js`
 }

--- a/content/en/guides/internals-glossary/internals-module-container.md
+++ b/content/en/guides/internals-glossary/internals-module-container.md
@@ -69,7 +69,7 @@ this.addPlugin({
 })
 ```
 
-If you want, you can specify a custom path for the `fileName` too, so you can prevent name clashing and choose the folder structure inside `.nuxt` folder:
+If you choose to specify a `fileName`, you can configure a custom path for the `fileName` too, so you can choose the folder structure inside `.nuxt` folder or prevent name collisioning:
 
 ```
 {

--- a/content/en/guides/internals-glossary/internals-module-container.md
+++ b/content/en/guides/internals-glossary/internals-module-container.md
@@ -67,7 +67,7 @@ this.addPlugin({
 })
 ```
 
-**Note:** You can use `mode` or `.client` and `.server` prefixes with `fileName` option to use plugin only in client or server side. (See [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin) for all available options)
+**Note:** You can use `mode` or `.client` and `.server` modifiers with `fileName` option to use plugin only in client or server side. (See [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin) for all available options)
 
 If you choose to specify a `fileName`, you can configure a custom path for the `fileName` too, so you can choose the folder structure inside `.nuxt` folder in order to prevent name collisioning:
 

--- a/content/en/guides/internals-glossary/internals-module-container.md
+++ b/content/en/guides/internals-glossary/internals-module-container.md
@@ -55,14 +55,28 @@ This method returns final `{ dst, src, options }` object.
 
 ### addPlugin (template)
 
-- **template**: On top of [`addTemplate`](#addtemplate-template)'s `template` Object properties (`src`, `options`, and `fileName`),
-the parameter `template` in this scope also has plugin-specific options:
-  - `mode` (`'all'`, `'client'` or `'server'`): as in plugins [mode](/docs/2.x/directory-structure/plugins#object-syntax) 
-  - `ssr` (`Boolean`): Prefer `mode`, as this option will be deprecated in Nuxt 3.
+- **template**: same signature as [`addTemplate`](#addtemplate-template)'s `template` Object properties (`src`, `options`, and `fileName`).
+  
+  Remember that with [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin), you can specify a `fileName` to be run only in `client` or in `server` sides. Avoid passing `mode` and `ssr` options, as those will be deprecated.
 
-Registers a plugin using `addTemplate` and adds it to first of `plugins[]` option.
+Registers a plugin using `addTemplate` and adds it to the top of `plugins[]` option.
+  
+```
+this.addPlugin({
+  src: path.resolve(__dirname, 'templates/foo.js'),
+  /* optional */ fileName: 'foo.server.js' // will only run in server side
+  options: moduleOptions
+})
+```
 
-You can use `template.ssr: false` to disable plugin including in SSR bundle.
+If you want, you can specify a custom path for the `fileName` too, so you can prevent name clashing and choose the folder structure inside `.nuxt` folder:
+
+```
+{
+  fileName: path.join('folder', 'foo.client.js'), // will result in `.nuxt/folder/foo.client.js`
+}
+```
+
 
 ### addServerMiddleware (middleware)
 


### PR DESCRIPTION
As of current implementation of https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/module.js

The object syntax for `addPlugin(template)` was missing.