### PR TITLE
fix (#1099): add dynamic spacing for cookie banner

### DIFF
--- a/components/templates/TheCookieBox.vue
+++ b/components/templates/TheCookieBox.vue
@@ -15,6 +15,7 @@
       <template slot="button">
         <button
           class="ml-4 no-underline mt-4 font-medium text-sm px-4 py-2 shadow uppercase rounded hover:shadow-md sm:mr-4 py-3 px-6 text-base mb-4 primary bg-primary-base text-white hover:bg-primary-light"
+          @click="$emit('remove-spacer')"
         >
           {{ $t('cookies.button') }}
         </button>

--- a/components/templates/TheCookieBox.vue
+++ b/components/templates/TheCookieBox.vue
@@ -15,7 +15,7 @@
       <template slot="button">
         <button
           class="ml-4 no-underline mt-4 font-medium text-sm px-4 py-2 shadow uppercase rounded hover:shadow-md sm:mr-4 py-3 px-6 text-base mb-4 primary bg-primary-base text-white hover:bg-primary-light"
-          @click="$emit('remove-spacer')"
+          @click="$emit('acknowledge-banner')"
         >
           {{ $t('cookies.button') }}
         </button>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div :class="cookieSpacerStyles">
     <!-- <MasteringNuxtBanner /> -->
     <TheHeader />
     <main
@@ -10,13 +10,17 @@
     <TheFooter />
     <TheMobileBottomNav />
     <TheCookieBox
-      class="w-full fixed bottom-0 left-0 z-40 bg-light-elevatedSurface dark:bg-dark-elevatedSurface"
+      class="w-full fixed bottom-0 left-0 mt-8 z-40 bg-light-elevatedSurface dark:bg-dark-elevatedSurface"
+      @remove-spacer="showCookieBanner = false"
     />
   </div>
 </template>
 
 <script>
 export default {
+  data: () => ({
+    showCookieBanner: false
+  }),
   head() {
     const i18nSeo = this.$nuxtI18nSeo()
     const { path } = this.$route
@@ -94,6 +98,17 @@ export default {
         ...i18nSeo.link
       ]
     }
+  },
+  computed: {
+    cookieSpacerStyles() {
+      return this.showCookieBanner ? 'pb-20 md:pb-4 lg:pb-20' : ''
+    }
+  },
+  mounted() {
+    const bannerCookie = 'cookieconsent_status'
+    const docCookies = `; ${document.cookie}`
+
+    this.showCookieBanner = !docCookies.includes(bannerCookie)
   }
 }
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -11,7 +11,7 @@
     <TheMobileBottomNav />
     <TheCookieBox
       class="w-full fixed bottom-0 left-0 mt-8 z-40 bg-light-elevatedSurface dark:bg-dark-elevatedSurface"
-      @remove-spacer="showCookieBanner = false"
+      @acknowledge-banner="showCookieBanner = false"
     />
   </div>
 </template>


### PR DESCRIPTION
## Proposed Solution 

Use utility padding-bottom to allow footer to appear correctly when cookie banner appears.

<img width="1390" alt="Screen Shot 2020-12-21 at 1 49 38 PM" src="https://user-images.githubusercontent.com/4836334/102811844-08fdbe80-4394-11eb-9ef9-020d4d1ba7cb.png">

<img width="680" alt="Screen Shot 2020-12-21 at 1 49 25 PM" src="https://user-images.githubusercontent.com/4836334/102811851-0b601880-4394-11eb-9b62-28796dc40cc6.png">

