### PR TITLE
style: some suggested tweaks

### DIFF
--- a/content/en/blog/build-dev-to-clone-with-nuxt-new-fetch.md
+++ b/content/en/blog/build-dev-to-clone-with-nuxt-new-fetch.md
@@ -1,6 +1,6 @@
 ---
-title: 'Build a DEV.TO clone with Nuxt new fetch'
-description: Let’s build a blazing fast articles and tutorials app using Nuxt, Dev.to API, with lazy loading, placeholders, caching and trendy neumorphic design UI.
+title: 'Build a dev.to clone with Nuxt new fetch'
+description: Let’s build a blazing fast articles and tutorials app using Nuxt and the DEV API, with lazy loading, placeholders, caching and trendy neumorphic design UI.
 imgUrl: blog/build-dev-to-clone-with-nuxt-new-fetch/main.png
 date: 2020-04-08
 authors:
@@ -17,7 +17,7 @@ tags:
   - API
 ---
 
-_Let’s build a blazing fast articles and tutorials app using Nuxt, Dev.to API, with lazy loading, placeholders, caching and trendy neumorphic design UI._
+_Let’s build a blazing fast articles and tutorials app using Nuxt and the DEV API, with lazy loading, placeholders, caching and trendy neumorphic design UI._
 
 <video src="/blog/build-dev-to-clone-with-nuxt-new-fetch/dev-clone-nuxt.mp4" autoplay loop playsinline controls></video>
 
@@ -26,7 +26,7 @@ _Let’s build a blazing fast articles and tutorials app using Nuxt, Dev.to API,
   <a href="https://github.com/bdrtsky/nuxt-dev-to-clone" target="_blank" rel="noopener nofollow">Source</a>
 </p>
 
-This article is intended to demonstrate use cases and awesomeness of new NuxtJS `fetch` functionality [introduced in release v2.12](/docs/2.x/components-glossary/pages-fetch#nuxt-gt-2-12), and show you how to apply its power in your own projects. For in-depth technical analysis and details of the new `fetch` you can check [Krutie Patel’s article](/blog/understanding-how-fetch-works-in-nuxt-2-12).
+This article is intended to demonstrate use cases and awesomeness of new Nuxt `fetch` functionality [introduced in release v2.12](/docs/2.x/components-glossary/pages-fetch#nuxt-gt-2-12), and show you how to apply its power in your own projects. For in-depth technical analysis and details of the new `fetch` you can check [Krutie Patel’s article](/blog/understanding-how-fetch-works-in-nuxt-2-12).
 
 Here’s the high-level outline of how we will build our dev.to clone using `fetch` hook. We will:
 
@@ -39,7 +39,7 @@ Here’s the high-level outline of how we will build our dev.to clone using `fet
 ## Table of Contents
 
 - [Table of Contents](#table-of-contents)
-- [DEV.TO API](#devto-api)
+- [DEV API](#dev-api)
 - [Setting up the Project](#setting-up-the-project)
   - [CSS Styles](#css-styles)
   - [UI Design](#ui-design)
@@ -55,18 +55,18 @@ Here’s the high-level outline of how we will build our dev.to clone using `fet
   - [Error handling](#error-handling)
 - [Conclusion](#conclusion)
 
-## DEV.TO API
+## DEV API
 
-In September 2019 DEV.TO [opened](https://twitter.com/bendhalpern/status/1176663688742395904) their public API that we can now use to access articles, users and other resources data. _Please note that it’s still Beta, so it could change in future or some things might not work as expected._
+In September 2019 DEV [opened](https://twitter.com/bendhalpern/status/1176663688742395904) their public API that we can now use to access articles, users and other resources data. _Please note that it’s still Beta, so it could change in future or some things might not work as expected._
 
-For creating our DEV.TO clone we are interested in such API endpoints:
+For creating our DEV clone we are interested in such API endpoints:
 
 - [getArticles](https://docs.dev.to/api/#operation/getArticles): to access a list of articles, filtered by the `tag`, `state`, `top`, `username` and paginated with `page` parameters
 - [getArticleById](https://docs.dev.to/api/#operation/getArticleById): to access an article content
 - [getUser](https://docs.dev.to/api/#operation/getUser): to access user data
 - [getCommentsByArticleId](https://docs.dev.to/api/#operation/getCommentsByArticleId): to fetch comments related to the article
 
-To keep it simple, for communication with DEV.TO API we will use native Javascript [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) .
+To keep it simple, for communication with the DEV API we will use native JavaScript [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) .
 
 ## Setting up the Project
 
@@ -85,7 +85,7 @@ Let’s install necessary packages and discuss how we will build our app next.
 
 ### CSS Styles
 
-For styling we will use the most common CSS preprocessor Sass/SCSS and leverage Vue.js [Scoped CSS](https://vue-loader.vuejs.org/guide/scoped-css.html) feature, to keep our components styles incapsulated. To [use Sass/SCSS with Nuxt](/faq/pre-processors) run:
+For styling we will use the most common CSS pre-processor Sass/SCSS and leverage Vue.js [Scoped CSS](https://vue-loader.vuejs.org/guide/scoped-css.html) feature, to keep our components styles encapsulated. To [use Sass/SCSS with Nuxt](/faq/pre-processors) run:
 
 <code-group>
   <code-block label="Yarn" active>
@@ -143,9 +143,9 @@ Our design tokens are now available through SCSS variables in every Vue componen
 
 ### UI Design
 
-It will be kinda boring just to copy existing DEV.TO design and layout, so why don’t we experiment a little bit. You have probably already heard of the new UI trend — neumorphism. If you missed it somehow, read more about it [here](https://uxdesign.cc/neumorphism-in-user-interfaces-b47cef3bf3a6).
+It will be kinda boring just to copy the existing DEV design and layout, so why don’t we experiment a little bit. You have probably already heard of the new UI trend — neumorphism. If you missed it somehow, read more about it [here](https://uxdesign.cc/neumorphism-in-user-interfaces-b47cef3bf3a6).
 
-We can find a lot of [dribbble shots](https://dribbble.com/tags/neumorphism) (from where this trend came from), but still only a few examples of real-world web apps built with neumorphism style interface, so we just can’t miss the chance to recreate it with CSS and Vue.js. It’s simple, clean and fresh.
+We can find a lot of [Dribbble shots](https://dribbble.com/tags/neumorphism) (from where this trend came from), but still only a few examples of real-world web apps built with neumorphism style interface, so we just can’t miss the chance to recreate it with CSS and Vue.js. It’s simple, clean and fresh.
 
 I am not going to describe the styling aspect of this application in detail, but if you are interested, you can check this awesome article from [CSS Tricks](https://css-tricks.com/neumorphism-and-css/) about neumorphism and CSS.
 
@@ -176,7 +176,7 @@ buildModules: ['@nuxtjs/svg', '@nuxtjs/style-resources']
 
 ### Dependencies
 
-To keep front-end app fast and simple we will use only two dependencies, both from Vue.js core members:
+To keep the frontend app fast and simple we will use only two dependencies, both from Vue.js core members:
 
 - [vue-observe-visibility](https://github.com/Akryum/vue-observe-visibility) by [Guillaume Chau](https://twitter.com/Akryum), for effective detecting elements in viewport with IntersectionObserver and trigger lazy loading. Only 1.6kB gzipped
 - [vue-content-placeholders](https://github.com/michalsnik/vue-content-placeholders) by [Michał Sajnóg](https://twitter.com/michalsnik), for showing nicely animated placeholders for UI elements while content is fetching. Only 650B gzipped.
@@ -208,11 +208,11 @@ plugins: [
 
 ## Developing the Application
 
-Now we finally can start developing our DEV.TO clone powered by Nuxt and [new fetch](/docs/2.x/components-glossary/pages-fetch).
+Now we finally can start developing our DEV clone powered by Nuxt and [new fetch](/docs/2.x/components-glossary/pages-fetch).
 
 ### URL structure
 
-Let’s imitate DEV.TO URL structure for our simple app. Our [pages](/docs/2.x/concepts/views#pages) folder should look like this:
+Let’s imitate the DEV URL structure for our simple app. Our [pages](/docs/2.x/concepts/views#pages) folder should look like this:
 
 ```
 ├── index.vue
@@ -233,7 +233,7 @@ For the rest of the app URL’s we will use convenient Nuxt file based [dynamic 
 
 - `_username/index.vue` - user profile page with list of his published articles
 - `_username/_article.vue` - this is where article, author profile and comments will be rendered
-- `t/_tag.vue` - list of best articles by any tag that exist on DEV.TO
+- `t/_tag.vue` - list of best articles by any tag that exist on DEV
 
 That’s all. Pretty simple, right?
 
@@ -305,7 +305,7 @@ async fetch() {
 }
 ```
 
-Here we are making a request to DEV.TO `/articles` endpoint, with query parameters that API understands. Don’t confuse `fetch` hook with the Javascript [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) interface which simply helps us to send a request to DEV.TO API, and then parse the response with `res.json()`.
+Here we are making a request to the DEV `/articles` endpoint, with query parameters that API understands. Don’t confuse the `fetch` hook with the JavaScript [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) interface which simply helps us to send a request to the DEV API, and then parse the response with `res.json()`.
 
 Also notice that the new `fetch` hook doesn’t serve just to dispatch Vuex store action or committing mutation to set state, now it has access to `this` context, and is able to mutate component’s data directly. This is a very important new feature, and you can [read more](/blog/understanding-how-fetch-works-in-nuxt-2-12) about it in the previous article about `fetch`.
 
@@ -379,7 +379,7 @@ Now let’s markup the `<article-card-block>` component which receives `article`
 
 ### Reuse `fetch` with `this.$fetch()`
 
-It already should display a list of articles fetched from DEV.TO but it feels like we are not making a full use of this API. Let’s add lazy loading to articles list, and use the pagination parameter provided by this API. So when we scroll to the bottom of the page a new chunk of articles will be fetched and rendered.
+It already should display a list of articles fetched from DEV - but it feels like we are not making full use of this API. Let’s add lazy loading to the articles list, and use the pagination parameter provided by this API. So when we scroll to the bottom of the page a new chunk of articles will be fetched and rendered.
 
 To efficiently detect when to fetch the next page it’s better to use [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). For that we will use a previously installed Vue plugin called `vue-observe-visibility` which is basically a wrapper around this API and it will detect when an element is becoming visible or hidden on the page. This plugin provides us a possibility to use `v-observe-visibility` directive on any element, so let’s add it to last `<article-card-block>` component:
 
@@ -488,7 +488,7 @@ To explore this great functionality let’s move to `_username/_article.vue` pag
 </script>
 ```
 
-Here we see no data fetching at all, only a template layout consisting of 3 components: `<article-block/>`, `<aside-username-block/>`, `<comments-block/>`. And each of those components has its own `fetch` hook. With old `fetch` or current `asyncData` earlier we would have to make all three requests to three different DEV.TO endpoints and then pass them to each component as a prop. But now those components are completely encapsulated.
+Here we see no data fetching at all, only a template layout consisting of 3 components: `<article-block/>`, `<aside-username-block/>`, `<comments-block/>`. And each of those components has its own `fetch` hook. With old `fetch` or current `asyncData` earlier we would have to make all three requests to three different DEV endpoints and then pass them to each component as a prop. But now those components are completely encapsulated.
 
 In `<article-block/>` we use `fetch` just like we’d use it in a page component.
 
@@ -583,10 +583,10 @@ Note here that we wrap `this.$nuxt.context.res.statusCode = 404` around `process
 
 ## Conclusion
 
-In this article we explored Nuxt.js new `fetch` and built an app with basic DEV.TO content features and structure using only this `fetch` hook. I hope you got some inspiration to build your own version of DEV.TO. Don’t forget to check out the [source code](https://github.com/bdrtsky/nuxt-dev-to-clone) for a more complete example and functionality.
+In this article we explored Nuxt.js new `fetch` and built an app with the basic DEV content features and structure using only this `fetch` hook. I hope you've got some inspiration to build your own version of DEV.TO. Don’t forget to check out the [source code](https://github.com/bdrtsky/nuxt-dev-to-clone) for a more complete example and functionality.
 
 **What to do next:**
 
 - Read [Krutie Patel article](/blog/understanding-how-fetch-works-in-nuxt-2-12) with in-depth analysis of how new `fetch` hook works
 - Check [nuxt-hackernews](https://github.com/nuxt/hackernews) for similar usage of [Hacker News API](https://github.com/HackerNews/API)
-- [Subscribe](#subscribe-to-newsletter) to the newsletter to not miss the upcoming articles and resources, I plan to write an article about How to create your personal blog with Nuxt and Dev.to as CMS.
+- [Subscribe](#subscribe-to-newsletter) to the newsletter to not miss the upcoming articles and resources, I plan to write an article about how to create your personal blog using Nuxt, with DEV as the CMS.

--- a/content/en/blog/creating-a-nuxt-module.md
+++ b/content/en/blog/creating-a-nuxt-module.md
@@ -84,7 +84,7 @@ npm install --dev ngrok
 
 ## Creating our module
 
-Now that we have installed and registered everything we can now go ahead and create our module. The first thing we need to do is to import ngrok from our node modules folder into our `index.js` file of our ngrok module.
+Now that we have installed and registered everything we can now go ahead and create our module. The first thing we need to do is to import ngrok from our `node_modules` folder into our `index.js` file of our ngrok module.
 
 ```js{}[modules/ngrok/index.js]
 import ngrok from 'ngrok'
@@ -201,7 +201,7 @@ Don't forget to make sure your `.env`file has been added to your `.gitignore`.
 
 </base-alert>
 
-We can now set a const of `options` equal to the options from the ngrok property of our `nuxt.config.js` or equal to an empty object incase we don't define any options. We also add a const of `authtoken` equal to the `NGROK_TOKEN` from our `.env` file or `options.authtoken` which is the same as `nuxt.options.ngrok.authtoken`, incase this value was defined directly in our `ngrok` property in the our `nuxt.config.js`.
+We can now set a const of `options` equal to the options from the ngrok property of our `nuxt.config.js` or equal to an empty object in case we don't define any options. We also add a const of `authtoken` equal to the `NGROK_TOKEN` from our `.env` file or `options.authtoken` which is the same as `nuxt.options.ngrok.authtoken`, in case this value was defined directly in our `ngrok` property in the our `nuxt.config.js`.
 
 We can then await the ngrok authtoken passing in the token value.
 

--- a/content/en/blog/creating-blog-with-nuxt-content.md
+++ b/content/en/blog/creating-blog-with-nuxt-content.md
@@ -501,7 +501,7 @@ We can now move this component out of the global folder and into the components 
 
 ### Adding a code block to your post
 
-With the content module we can style our code blocks with the automatic inclusion of [prismJS](https://prismjs.com/). That means we can write our code block using the correct markdown syntax and our code block will display with styling depending on the language.
+With the content module we can style our code blocks with the automatic inclusion of [Prism](https://prismjs.com/). That means we can write our code block using the correct markdown syntax and our code block will display with styling depending on the language.
 
 ```js
 export default {
@@ -521,7 +521,7 @@ export default {
 }
 ```
 
-The filename will be converted to a span with a filename class which we can then style how we like. For this example I am using tailwind classes but you can use ordinary CSS if you prefer.
+The file name will be converted to a span with a filename class which we can then style how we like. For this example I am using tailwind classes but you can use ordinary CSS if you prefer.
 
 ```css{}[assets/css/tailwind.css]
 .nuxt-content-highlight {
@@ -554,7 +554,7 @@ content: {
 
 ### Creating a previous and next component
 
-We now have a pretty complete blog post but wouldn't it be great if users could easily go from one post to another. First let's duplicate our post so we have 3 posts. Then, let's create a new component for our prev and next posts.
+We now have a pretty complete blog post but wouldn't it be great if users could easily go from one post to another. First let's duplicate our post so we have 3 posts. Then, let's create a new component for our previous and next posts.
 
 ```bash
 touch components/PrevNext.vue
@@ -604,7 +604,7 @@ In our component we pass the props `prev` and `next` to makes them available to 
 </script>
 ```
 
-We can now get our prev and next articles by adding them to our `asyncData`. We create an array of const with the name `prev` and `next` and we await the content from the articles folder. This time we only need the title and the slug so we can chain `only()` to our await and pass in title and slug.
+We can now get our previous and next articles by adding them to our `asyncData`. We create an array of const with the name `prev` and `next` and we await the content from the articles folder. This time we only need the title and the slug so we can chain `only()` to our await and pass in title and slug.
 
 We can use the `sortBy()` method to sort our data by the createdAt date in ascending order. We then use the `surround()` method and pass in the slug from params so that it can get the correct slug for the previous and next posts.
 
@@ -756,7 +756,7 @@ export default {
 
 As we can see we get all our data back only for the author Maria. If we were to use maria without a capital letter we wouldn't get anything back. We can therefore use `$regex` so that it remains with a capital letter.
 
-We then fetch all the details we want to show on this page. In the last example we used the `only()` method to return what we wanted but as we require quite a lot of content we can instead use the `without()` method and pass in what we don't wan't to return which is the body of the post.
+We then fetch all the details we want to show on this page. In the last example we used the `only()` method to return what we wanted but as we require quite a lot of content we can instead use the `without()` method and pass in what we don't want to return which is the body of the post.
 
 ```html{}[pages/blog/author/_author.vue]
 <script>

--- a/content/en/blog/going-dark-with-nuxtjs-color-mode.md
+++ b/content/en/blog/going-dark-with-nuxtjs-color-mode.md
@@ -17,18 +17,18 @@ tags:
   <a href="https://github.com/nuxt-community/color-mode-module" target="_blank" rel="noopener nofollow">Source</a>
 </p>
 
-The [@nuxtjs/color-mode module](https://github.com/nuxt-community/color-mode-module) is a cool way of adding dark mode to your site. But not only does it switch from dark to light but also any color theme (eg: sepia mode). It even has auto detection so that it will choose the right mode depending on your system appearance.
+The [@nuxtjs/color-mode module](https://github.com/nuxt-community/color-mode-module) is a cool way of adding dark mode to your site. But not only does it switch from dark to light but also any color theme (e.g.: sepia mode). It even has auto detection so that it will choose the right mode depending on your system appearance.
 
 - [How does it work](#how-does-it-work)
 - [Let's get started](#lets-get-started)
   - [Install the color-mode module](#install-the-color-mode-module)
-  - [Adding your colour styles](#adding-your-colour-styles)
+  - [Adding your color styles](#adding-your-color-styles)
   - [Inspecting the HTML](#inspecting-the-html)
   - [Creating a color-mode switcher](#creating-a-color-mode-switcher)
   - [Importing our component](#importing-our-component)
-  - [Adding a click event to change our colours](#adding-a-click-event-to-change-our-colours)
+  - [Adding a click event to change our colors](#adding-a-click-event-to-change-our-colors)
   - [Adding some icons](#adding-some-icons)
-  - [Importing the svgs as components](#importing-the-svgs-as-components)
+  - [Importing the SVGs as components](#importing-the-svgs-as-components)
   - [Adding a dynamic component](#adding-a-dynamic-component)
   - [Styling our icons](#styling-our-icons)
   - [Creating a method to show our preferred class](#creating-a-method-to-show-our-preferred-class)
@@ -40,11 +40,11 @@ The [@nuxtjs/color-mode module](https://github.com/nuxt-community/color-mode-mod
 
 ## How does it work
 
-The `@nuxtjs/color-mode` adds a `.${color}-mode` class to the `<html>` tag. It works with any NuxtJS target, either static or server and universal or client-side rendering. It auto detects the system color-mode so that you don't have to manually change the colour.
+The `@nuxtjs/color-mode` adds a `.${color}-mode` class to the `<html>` tag. It works with any Nuxt target, either static or server and universal or client-side rendering. It auto detects the system color-mode so that you don't have to manually change the color.
 
 It injects a `$colorMode` helper with:
 
-- `preference`: Actual color-mode selected (can be `'system'`), update it to change the user preferred colour mode
+- `preference`: Actual color-mode selected (can be `'system'`), update it to change the user preferred color mode
 - `value`: Useful to know what color mode has been detected when `$colorMode === 'system'`, you should not update it
 - `unknown`: Useful to know if, during SSR or static generation, we need to render a placeholder
 
@@ -101,9 +101,9 @@ If you using a version of Nuxt.js lower than 2.9.0 you will need to add it to th
 
 </base-alert>
 
-### Adding your colour styles
+### Adding your color styles
 
-Now you need to add some styles to your mode classes. Let's add a `main.css` file in our assets folder. We will use CSS variables to set the root colour which will be light mode and then set the colours for dark and sepia mode. Then we can add some styles to our body and link tags.
+Now you need to add some styles to your mode classes. Let's add a `main.css` file in our assets folder. We will use CSS variables to set the root color which will be light mode and then set the colors for dark and sepia mode. Then we can add some styles to our body and link tags.
 
 ```css{}[assets/main.css]
 :root {
@@ -170,7 +170,7 @@ Using the dev tools change the mode to sepia-mode and light-mode to see the effe
 </html>
 ```
 
-You can also change the colour in the console by typing:
+You can also change the color in the console by typing:
 
 ```js
 $nuxt.$colorMode.preference = 'sepia'
@@ -180,7 +180,7 @@ $nuxt.$colorMode.preference = 'sepia'
 
 ### Creating a color-mode switcher
 
-Obviously changing the mode in the dev tools is not what we want so let's create a color-mode switcher so our users can quickly change from one colour to another.
+Obviously changing the mode in the dev tools is not what we want so let's create a color-mode switcher so our users can quickly change from one color to another.
 
 Let's create a component called `ColorModePicker` and we can add a list of colors. For now we can just print out the color from our v-for.
 
@@ -230,11 +230,11 @@ Let's import our component into our index.vue page so we can see what is happeni
 </script>
 ```
 
-And in our browser under `http://localhost:3000` you will see our list of colours.
+And in our browser under `http://localhost:3000` you will see our list of colors.
 
-![list of colours](/blog/going-dark-with-nuxtjs-color-mode/list-of-colors.png)
+![list of colors](/blog/going-dark-with-nuxtjs-color-mode/list-of-colors.png)
 
-### Adding a click event to change our colours
+### Adding a click event to change our colors
 
 Then in our template we can add a click event that will make the `$colorMode.preference` equal to the color which comes from our data.
 
@@ -252,7 +252,7 @@ This is actually all you need in order for it to work. If you check in your brow
 
 <video src="/blog/going-dark-with-nuxtjs-color-mode/color-changing-text-only.mp4" autoplay loop playsinline controls></video>
 
-And if we check in the broswer we can see it works but this is super ugly. Let's tidy it up a bit.
+And if we check in the browser we can see it works but this is super ugly. Let's tidy it up a bit.
 
 ### Adding some icons
 
@@ -273,9 +273,9 @@ Then we need to add it to your `nuxt.config.js` in the buildModules section whic
 buildModules: ['@nuxtjs/svg', '@nuxtjs/color-mode']
 ```
 
-### Importing the svgs as components
+### Importing the SVGs as components
 
-We can now import these svg icons as components using the `?inline` query so that they are imported as inline svgs.
+We can now import these svg icons as components using the `?inline` query so that they are imported as inline SVGs.
 
 ```html{}[components/ColorModePicker.vue]
 <script>
@@ -297,7 +297,7 @@ We can now import these svg icons as components using the `?inline` query so tha
 
 ### Adding a dynamic component
 
-Now we can use a dynamic component which will check which icon to add depending on the colours in our data array. Lets replace the `{{color}}` text with this new component inside our `<li>`.
+Now we can use a dynamic component which will check which icon to add depending on the colors in our data array. Lets replace the `{{color}}` text with this new component inside our `<li>`.
 
 ```html{}[components/ColorModePicker.vue]
 <component :is="`icon-${color}`" />
@@ -311,7 +311,7 @@ Let's move our click event from our `<li>` to our icon component.
 
 ### Styling our icons
 
-And let's add some styles so we can see our icons. We will use scoped styling and use the class feather. If you look into your svg files you will see that our svgs have the class of feather so we can use this class to style it. We will also add a preferred and selected class so we know which one has been selected and what is the preferred one.
+And let's add some styles so we can see our icons. We will use scoped styling and use the class feather. If you look into your svg files you will see that our SVGs have the class of feather so we can use this class to style it. We will also add a preferred and selected class so we know which one has been selected and what is the preferred one.
 
 ```html{}[components/ColorModePicker.vue]
 <style scoped>
@@ -375,7 +375,7 @@ We can now add this class to our icon component. The class will call the getClas
 />
 ```
 
-And you will see in the browser the colours are being applied just as we wanted. But it is not very clear when we click the system icon what is going on.
+And you will see in the browser the colors are being applied just as we wanted. But it is not very clear when we click the system icon what is going on.
 
 ### Adding some text using the ColorScheme component
 
@@ -433,7 +433,7 @@ p {
 }
 ```
 
-And in order to centre it we can wrap our ColorModePicker component in a div with the class of container.
+And in order to center it we can wrap our ColorModePicker component in a div with the class of container.
 
 ```html{}[pages/index.vue]
 <div class="container">

--- a/content/en/blog/going-full-static.md
+++ b/content/en/blog/going-full-static.md
@@ -1,6 +1,6 @@
 ---
 title: 'Going Full Static'
-description: 'Long awaited features for Jamstack fans has been shipped in v2.13: full static export, improved smart prefetching, integrated crawler, faster re-deploy, built-in web server and new target option for config :zap:️'
+description: 'Long awaited features for JAMstack fans has been shipped in v2.13: full static export, improved smart prefetching, integrated crawler, faster re-deploy, built-in web server and new target option for config :zap:️'
 imgUrl: blog/going-full-static/main.png
 date: 2020-06-18
 authors:

--- a/content/en/blog/improve-your-developer-experience-with-nuxt-components.md
+++ b/content/en/blog/improve-your-developer-experience-with-nuxt-components.md
@@ -41,7 +41,7 @@ Here is how [Debbie O’Brien](https://twitter.com/debs_obrien) explains how it 
   - [Pattern option](#pattern-option)
   - [Default](#default)
   - [Add additional extensions](#add-additional-extensions)
-  - [Customise as per your requirement](#customise-as-per-your-requirement)
+  - [Customize as per your requirement](#customize-as-per-your-requirement)
 - [Exclusion paths](#exclusion-paths)
   - [Ignore option](#ignore-option)
   - [.nuxtignore, ignore property & ignore option:](#nuxtignore-ignore-property--ignore-option)
@@ -68,7 +68,7 @@ We will implement `@nuxt/components` on these components followed by a detailed 
 
 It’s best if you setup this [sample project](https://github.com/Krutie/nuxt-components-demo) locally to tryout options that may interest you.
 
-- **Github Repo** - [https://github.com/Krutie/nuxt-components-demo](https://github.com/Krutie/nuxt-components-demo)
+- **GitHub Repo** - [https://github.com/Krutie/nuxt-components-demo](https://github.com/Krutie/nuxt-components-demo)
 - **Demo** - [http://nuxt-components.surge.sh/](http://nuxt-components.surge.sh/)
 - **3rd Party Sample Components Repo** - [https://github.com/Krutie/Kru-Components](https://github.com/Krutie/Kru-Components)
 
@@ -128,7 +128,7 @@ export default {
 
 In addition to `path`, we can also define additional configuration to include, exclude, watch or even add prefix to components based on their location & extensions.
 
-For example, when components are imported using this module, their names are based on their filename. But you can `prefix` component names to preserve their filenames as they are and still be able to customise their component tags.
+For example, when components are imported using this module, their names are based on their filename. But you can `prefix` component names to preserve their filenames as they are and still be able to customize their component tags.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -239,7 +239,7 @@ Continue reading further to see more examples of these two options and how they 
 
 `pattern` option lets you define which type of components - from the given `path` - should be scanned and registered. Unlike `extensions`, `pattern` is defined as a **single** `String` and it must follow [glob pattern style](https://github.com/isaacs/node-glob#glob-primer).
 
-We can use pattern option as **default** or **add additional** ones or even **customise** it completely.
+We can use pattern option as **default** or **add additional** ones or even **customize** it completely.
 
 ### Default
 
@@ -269,9 +269,9 @@ export default {
 
 Above code adds `.jsx` extension to the default pattern, makes the resulting pattern look like: `**/*.{vue,js,jsx}`
 
-### Customise as per your requirement
+### Customize as per your requirement
 
-If required, you can manually specify extensions to completely customise the pattern.
+If required, you can manually specify extensions to completely customize the pattern.
 
 ```js
 // Multiple extensions
@@ -333,7 +333,7 @@ export default {
 }
 ```
 
-The impact of both `.nuxtignore` and `ignore` property is realised during build-process, and they operate project-wide, while `ignore` option operates locally and ignores files from `/components` directory.
+The impact of both `.nuxtignore` and `ignore` property is realized during build-process, and they operate project-wide, while `ignore` option operates locally and ignores files from `/components` directory.
 
 So, if you're using 1. `.nuxtignore`, 2. top-level `ignore` property, and 3. `ignore` option, then all three will be merged.
 

--- a/content/en/blog/moving-from-nuxtjs-dotenv-to-runtime-config.md
+++ b/content/en/blog/moving-from-nuxtjs-dotenv-to-runtime-config.md
@@ -42,7 +42,7 @@ It is very easy to think that your secret keys are safe by placing them somewher
 
 Isomorphic applications, otherwise known as universal applications, need to share code between both the server and the client. Babel is used to compile our modern ES6 JavaScript code down to ES5 JavaScript so that it can work across all platforms. Node.js which is an asynchronous event-driven JavaScript runtime that can be used in computers and servers outside of a browser environment, uses the module system.
 
-Using modules in Node.js is done using require, eg require('lodash'). However, browser support for modules is still incomplete and therefore we need bundling tools such as webpack to transpile these modules into code that the browsers can read. Webpack basically makes client-side development more "Node-like" with the same module system semantics. This means that a require statement or an ES6 import statement will resolve the same way. And as our applications are not only JavaScript but also HTML, CSS and images we can require these using webpack's loaders.
+Using modules in Node.js is done using require, e.g. require('lodash'). However, browser support for modules is still incomplete and therefore we need bundling tools such as webpack to transpile these modules into code that the browsers can read. Webpack basically makes client-side development more "Node-like" with the same module system semantics. This means that a require statement or an ES6 import statement will resolve the same way. And as our applications are not only JavaScript but also HTML, CSS and images we can require these using webpack's loaders.
 
 ## How environment variables work
 
@@ -184,10 +184,10 @@ async asyncData ({ $config: { baseURL } }) {
 Then instead of using env.apiUrl
 
 ```js
-const posts = await fetch(`${env.baseUrl}/posts`)
+const posts = await fetch(`${env.baseURL}/posts`)
 ```
 
-you can use baseUrl direct in your code as we have already passed this in into the config option above and therefore we don't have to reference \$config in our fetch.
+you can use baseURL direct in your code as we have already passed this in into the config option above and therefore we don't have to reference \$config in our fetch.
 
 ```js
 const posts = await fetch(`${baseURL}/posts`)

--- a/content/en/blog/nuxtjs-from-terminal-to-browser.md
+++ b/content/en/blog/nuxtjs-from-terminal-to-browser.md
@@ -1,5 +1,5 @@
 ---
-title: 'NuxtJS: From Terminal to Browser'
+title: 'Nuxt: From Terminal to Browser'
 description: How we changed the developer experience to stop switching between the terminal and browser.
 imgUrl: blog/nuxtjs-from-terminal-to-browser/main.png
 date: 2019-06-04
@@ -37,7 +37,7 @@ _ℹ️ These features are all available with [v2.8.0 release](https://github.co
 
 [![nuxt-ssr-logs-forwarding](https://res.cloudinary.com/practicaldev/image/fetch/s--bwQ8iEq2--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_66%2Cw_880/https://user-images.githubusercontent.com/904724/58566291-a3396700-8230-11e9-9dd6-09c3ff8578d2.gif)](https://res.cloudinary.com/practicaldev/image/fetch/s--bwQ8iEq2--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_66%2Cw_880/https://user-images.githubusercontent.com/904724/58566291-a3396700-8230-11e9-9dd6-09c3ff8578d2.gif)
 
-## [](#nuxtjs-vision)NuxtJS Vision
+## [](#nuxtjs-vision)Nuxt Vision
 
 The purpose to these changes is to use the terminal for commands only.
 

--- a/content/en/blog/seed-round.md
+++ b/content/en/blog/seed-round.md
@@ -18,15 +18,15 @@ Three years ago, my brother Sébastien and I were [open sourcing our code](https
 
 ### Happy "NuxtDay"
 
-Sébastien ([@Atinux](https://twitter.com/Atinux)) made his first commit for Nuxt.js on Github on October 26th 2016. The code base was born after we refactored an e-commerce website with modern open source web technologies: Vue 2, Node.js and Webpack. At the time, there was no documentation for server-side rendering Vue.js applications - we learnt through the [Hacker News example](https://github.com/vuejs/vue-hackernews-2.0) published by [Evan You](https://twitter.com/youyuxi) (Creator of Vue.js). The idea of creating a boilerplate and reusing the code base for other projects became clear once we discovered [Guillermo Rauch](https://twitter.com/rauchg)’s [introduction of Next.js](https://vercel.com/blog/next).
+Sébastien ([@Atinux](https://twitter.com/Atinux)) made his first commit for Nuxt.js on GitHub on October 26th 2016. The code base was born after we refactored an e-commerce website with modern open source web technologies: Vue 2, Node.js and Webpack. At the time, there was no documentation for server-side rendering Vue.js applications - we learnt through the [Hacker News example](https://github.com/vuejs/vue-hackernews-2.0) published by [Evan You](https://twitter.com/youyuxi) (Creator of Vue.js). The idea of creating a boilerplate and reusing the code base for other projects became clear once we discovered [Guillermo Rauch](https://twitter.com/rauchg)’s [introduction of Next.js](https://vercel.com/blog/next).
 
 ### Why the NUXT name?
 
-Once we had created the repository on Github to open source our code, we had our first challenge: find a name for our project! We tried couples of names on NPM who were already taken. In the end we landed on NUXT which was short and explicit. rEact ⇒ nExt made us realise that vUe ⇒ nUxt was a natural fit for us. It is like Next.js but for Vue.js.
+Once we had created the repository on GitHub to open source our code, we had our first challenge: find a name for our project! We tried couples of names on NPM who were already taken. In the end we landed on NUXT which was short and explicit. rEact ⇒ nExt made us realize that vUe ⇒ nUxt was a natural fit for us. It is like Next.js but for Vue.js.
 
 ### Performance, Modularity and Developers Happiness
 
-The core mission at NuxtJS is to provide front-end developers with an open source framework to build fast and high performing websites and applications based on Vue.js with as little friction as possible. Our credo is “Convention over Configuration” to help solve some of the difficulties involved in Vue.js application development. Automatic vue-router configuration based on file system detection is the first and most popular feature of the framework. With the efforts of our community and contributors around the world, over time our framework became ready for production. Every feature and bug fix since has been made with the sole purpose of improving the performance and experience for all our users. Our ultimate vision is to be a modular solution and extend the possibilities of the framework usage. These are endless!
+The core mission at NuxtJS is to provide frontend developers with an open source framework to build fast and high performing websites and applications based on Vue.js with as little friction as possible. Our credo is “Convention over Configuration” to help solve some of the difficulties involved in Vue.js application development. Automatic vue-router configuration based on file system detection is the first and most popular feature of the framework. With the efforts of our community and contributors around the world, over time our framework became ready for production. Every feature and bug fix since has been made with the sole purpose of improving the performance and experience for all our users. Our ultimate vision is to be a modular solution and extend the possibilities of the framework usage. These are endless!
 
 ## From a passion to a company.
 
@@ -36,7 +36,7 @@ Sébastien and I discovered our passion for computers and web development deep w
 
 ### The NuxtJS Company
 
-Before NuxtJS we were originally called ORION, which was established in 2017. At the time we wanted to create a number of different open source projects (ORION is a constellation of stars) and sell our services on the side whilst we had full-time jobs. However, we didn’t realise that what would ultimately become the Nuxt.js framework was going to take off so quickly and be so well-received by the developers community. After receiving amazing feedback at conferences, meet-ups and workshops we decided to go full-time on the Nuxt.js framework in January 2018. A year later we decided to rename our company NuxtJS to focus our efforts on the framework.
+Before NuxtJS we were originally called ORION, which was established in 2017. At the time we wanted to create a number of different open source projects (ORION is a constellation of stars) and sell our services on the side whilst we had full-time jobs. However, we didn’t realize that what would ultimately become the Nuxt.js framework was going to take off so quickly and be so well-received by the developers community. After receiving amazing feedback at conferences, meet-ups and workshops we decided to go full-time on the Nuxt.js framework in January 2018. A year later we decided to rename our company NuxtJS to focus our efforts on the framework.
 
 ### Open source is everywhere
 
@@ -44,13 +44,13 @@ As developers ourselves, we believe in the importance and power of open source. 
 
 ### The NuxtJS Company !== The Nuxt.js Framework
 
-[Dominik Angerer](https://twitter.com/domangerer) (Co-founder & CEO of [Storyblok](https://www.storyblok.com) and our sponsor since July 2018) introduced us with Sam Endacott and Arek Wylegalski from firstminute capital in October 2019. They understood our concerns around developing the commercial side of the business whilst staying true to the community which has helped build Nuxt.js into what it is today. We took our time with the fundraising process and made sure to evaluate the pros and cons before making the decision. After spending many weeks with the team (+ a few dinners and drinks) we decided to close a \$2m seed round for the NuxtJS company. **The Nuxt.js framework is and will always be open source and community-driven.**
+[Dominik Angerer](https://twitter.com/domangerer) (Co-founder & CEO of [Storyblok](https://www.storyblok.com) and our sponsor since July 2018) introduced us with Sam Endacott and Arek Wylegalski from firstminute capital in October 2019. They understood our concerns around developing the commercial side of the business whilst staying true to the community which has helped build Nuxt.js into what it is today. We took our time with the fundraising process and made sure to evaluate the pros and cons before making the decision. After spending many weeks with the team (+ a few dinners and drinks) we decided to close a \$2M seed round for the NuxtJS company. **The Nuxt.js framework is and will always be open source and community-driven.**
 
 ## From an idea to a website
 
 ### The intuitive Web Framework
 
-We love to create websites with Vue, but we are too lazy to configure everything over and over. Nuxt.js provides a simple and intuitive developper experience to prototype blazing fast modern web application. The goal is to decrease the number of decisions the programmer has to make and eliminate the complexity of having to configure all and each of the areas of application development. The immediate result is that you can create many more things in less time. Building a production ready website from an idea has never been so simple. If you follow the established conventions, you can develop a Nuxt.js application in much less time and with many fewer lines of code than you would need developing a similar web application in Vue.js. If, on the other hand, you want to ignore conventions, you can always replace them with your own code. However, since conventions are not arbitrary, but have been established by a community of high level programmers, it rarely does make sense to waste time overwriting them.
+We love to create websites with Vue, but we are too lazy to configure everything over and over. Nuxt.js provides a simple and intuitive developer experience to prototype blazing fast modern web application. The goal is to decrease the number of decisions the programmer has to make and eliminate the complexity of having to configure all and each of the areas of application development. The immediate result is that you can create many more things in less time. Building a production ready website from an idea has never been so simple. If you follow the established conventions, you can develop a Nuxt.js application in much less time and with many fewer lines of code than you would need developing a similar web application in Vue.js. If, on the other hand, you want to ignore conventions, you can always replace them with your own code. However, since conventions are not arbitrary, but have been established by a community of high level programmers, it rarely does make sense to waste time overwriting them.
 
 ### Modularity
 
@@ -58,13 +58,13 @@ By keeping the core light and extensible with hooks, we opened a new range of po
 
 ### Performances
 
-Performances has a huge impact on how visitors see and interact with your website. Since the beginning, performances has been in the heart of the Nuxt.js framework, allowing you to ship efficient and performant web application **by default**. We provide more than [20 optimizations](https://github.com/nuxt/nuxt.js/issues/6467) and have more in our roadmap: reducing the baseline bundle costs of the minimal app (coming with Nuxt 3 and Vue 3), image bloat reduction (lazy-loading and automatic optimisation) and smarter server-side rendering using SWR (stale-while-revalidate).
+Performances has a huge impact on how visitors see and interact with your website. Since the beginning, performances has been in the heart of the Nuxt.js framework, allowing you to ship efficient and performant web application **by default**. We provide more than [20 optimizations](https://github.com/nuxt/nuxt.js/issues/6467) and have more in our roadmap: reducing the baseline bundle costs of the minimal app (coming with Nuxt 3 and Vue 3), image bloat reduction (lazy-loading and automatic optimization) and smarter server-side rendering using SWR (stale-while-revalidate).
 
 ## Nuxtify the world
 
 ### Discovery
 
-Concepts and new features can sometimes be more difficult to explain, instead of using them. Feedback subjects since the last 3 years has been mostly about our lack of explanation and marketing. That's true. It's difficult to explain a framework that can do static site generation (SSG) or dynamic rendering (SSR) as well as optional server-side rendering with convention over configuration in **a simple sentence**. Good news, we are working on a brand new website full of Nuxt.js informations and features explanations.
+Concepts and new features can sometimes be more difficult to explain, instead of using them. Feedback subjects since the last 3 years has been mostly about our lack of explanation and marketing. That's true. It's difficult to explain a framework that can do static site generation (SSG) or dynamic rendering (SSR) as well as optional server-side rendering with convention over configuration in **a simple sentence**. Good news, we are working on a brand new website full of Nuxt.js information and features explanations.
 
 ### Academy
 
@@ -72,7 +72,7 @@ The Nuxt.js documentation is key. Our main efforts are toward on new learning re
 
 ### Community
 
-Community based materials and events (meetups, conferences and live streams) will be displayed on the new website. We plan to organise online events in the future. You can always chat with the community on our [Discord server](https://discord.nuxtjs.org), follow the Nuxt.js feed on our [Twitter account](https://twitter.com/nuxt_js) and contribute on our [GitHub repository](https://github.com/nuxt/nuxt.js). Our [Open Collective](https://opencollective.com/nuxtjs) is used for the open source work done by maintainers, contributors and developer advocates that help Nuxtify the world.
+Community based materials and events (meet-ups, conferences and live streams) will be displayed on the new website. We plan to organize online events in the future. You can always chat with the community on our [Discord server](https://discord.nuxtjs.org), follow the Nuxt.js feed on our [Twitter account](https://twitter.com/nuxt_js) and contribute on our [GitHub repository](https://github.com/nuxt/nuxt.js). Our [Open Collective](https://opencollective.com/nuxtjs) is used for the open source work done by maintainers, contributors and developer advocates that help Nuxtify the world.
 
 ## Thank you!
 

--- a/content/en/blog/understanding-how-fetch-works-in-nuxt-2-12.md
+++ b/content/en/blog/understanding-how-fetch-works-in-nuxt-2-12.md
@@ -44,7 +44,7 @@ As a result, Vuex becomes optional, but not impossible. We can still use `this.$
 
 ## Availability of fetch hook
 
-With `fetch`, we can pre-fetch the data asynchronously **in any Vue components**. It means, other than page components found in `/pages` directory, every other `.vue` components found in `/layouts` and `/components` directories can also benefit from the fetch hook.
+With `fetch`, we can prefetch the data asynchronously **in any Vue components**. It means, other than page components found in `/pages` directory, every other `.vue` components found in `/layouts` and `/components` directories can also benefit from the fetch hook.
 
 Let's see what this could mean for layout and building-block components.
 
@@ -207,7 +207,7 @@ As far as page components are concerned, new `fetch` seems way too similar to `a
 
 As of Nuxt 2.12, `asyncData` method is still an active feature. Let’s examine some of the key differences between `asyncData` and new `fetch`.
 
-### AsyncData
+### asyncData
 
 1. `asyncData` is limited to only page-level components
 2. `this` context is unavailable
@@ -291,7 +291,7 @@ export default {
 
 **Before -** Only page (route-level) components were allowed to fetch data on the server-side.
 
-**After -** Now, we can pre-fetch the data asynchronously in any Vue components.
+**After -** Now, we can prefetch the data asynchronously in any Vue components.
 
 ### 4. Call order of `fetch` hook
 
@@ -315,7 +315,7 @@ Yes we can, but only with `asyncData()` when it's about page-level component dat
 
 ## Conclusion
 
-New fetch hook brings a lot of improvements and provides more flexibility in fetching data and organising route-level & building-block components in a whole new way!
+New fetch hook brings a lot of improvements and provides more flexibility in fetching data and organizing route-level & building-block components in a whole new way!
 
 It will certainly make you think a little differently when you plan and design your new Nuxt project that requires multiple API calls within the same route.
 
@@ -323,5 +323,5 @@ I hope this article has helped you get acquainted with the new `fetch` feature. 
 
 ## What's next
 
-- Read [Sergey Bedritsky's article](/blog/build-dev-to-clone-with-nuxt-new-fetch) to see new `fetch` hook in action as he shows how to buid dev.to clone!
+- Read [Sergey Bedritsky's article](/blog/build-dev-to-clone-with-nuxt-new-fetch) to see new `fetch` hook in action as he shows how to build a dev.to clone!
 - Already missed March newsletter? [Subscribe to Nuxt newsletter](#subscribe-to-newsletter) and get latest articles and resources delivered right into your inbox.

--- a/content/en/faq/async-data-components.md
+++ b/content/en/faq/async-data-components.md
@@ -1,6 +1,6 @@
 ---
 title: Async data in components?
-description: Async data in NuxtJS components?
+description: Async data in Nuxt components?
 category: development
 position: 103
 ---

--- a/content/en/faq/auth-external-jwt.md
+++ b/content/en/faq/auth-external-jwt.md
@@ -8,11 +8,11 @@ category: development
 position: 303
 ---
 
-In auth-routes example both api and nuxt start together and use one Node.js server instance. However, sometimes we should work with external api with jsonWebToken. In this example it will be explained in a simple way.
+In the auth-routes example both the API and Nuxt start together and use one Node.js server instance. However, sometimes we want to work with an external API using a JSON web token (JWT). In this example it will be explained in a simple way.
 
-## Official `auth-module`
+## `@nuxtjs/auth`
 
-If you want to implement complex authentication flows, for example OAuth2, we suggest using the official [`auth-module`](https://github.com/nuxt-community/auth-module)
+If you want to implement more complex authentication flows, for example with OAuth 2, we suggest using [`@nuxtjs/auth`](https://github.com/nuxt-community/auth-module)
 
 ## Structure
 
@@ -103,7 +103,7 @@ export default createStore
 
 ## checking auth middlewares
 
-We can check the store for havin the accessToken in every page we need to limit access. In middleware directory we make `authenticated.js` file:
+We can check the store for having the access token in every page we need to limit access. In middleware directory we make `authenticated.js` file:
 
 ```javascript
 export default function ({ store, redirect }) {

--- a/content/en/faq/auth-routes.md
+++ b/content/en/faq/auth-routes.md
@@ -11,9 +11,9 @@ position: 302
 
 > Nuxt.js can be used to create authenticated routes easily.
 
-## Official `auth-module`
+## `@nuxtjs/auth`
 
-If you want to implement complex authentication flows, for example OAuth2, we suggest using the official [`auth-module`](https://github.com/nuxt-community/auth-module)
+If you want to implement complex authentication flows, for example OAuth 2, we suggest using [`@nuxtjs/auth`](https://github.com/nuxt-community/auth-module)
 
 ## Using Express and Sessions
 

--- a/content/en/faq/bip-deployment.md
+++ b/content/en/faq/bip-deployment.md
@@ -1,14 +1,14 @@
 ---
 title: How to deploy with Bip?
-description: How to deploy a NuxtJS app with Bip?
+description: How to deploy a Nuxt app with Bip?
 menu: Deploy on Bip
 category: deployment
 position: 204
 ---
 
-[Bip](https://bip.sh) is a commercial hosting service which provides zero downtime deployment, a global CDN, SSL, unlimited bandwidth and more for NuxtJS static websites. Plans are available on a pay as you go, per domain basis.
+[Bip](https://bip.sh) is a commercial hosting service which provides zero downtime deployment, a global CDN, SSL, unlimited bandwidth and more for Nuxt static websites. Plans are available on a pay as you go, per domain basis.
 
-The following guide will show you how to deploy your NuxtJS static site to Bip in just a couple simple steps.
+The following guide will show you how to deploy your Nuxt static site to Bip in just a couple simple steps.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ The following guide will show you how to deploy your NuxtJS static site to Bip i
 
 ## Step 1: Initial setup
 
-You'll first need a NuxtJS project ready to deploy and share with the world. If you need a project, use the [create-nuxt-app](https://github.com/nuxt/create-nuxt-app):
+You'll first need a Nuxt project ready to deploy and share with the world. If you need a project, use the [create-nuxt-app](https://github.com/nuxt/create-nuxt-app):
 
 Use Yarn to create your new project:
 
@@ -25,7 +25,7 @@ Use Yarn to create your new project:
 yarn create nuxt-app <project-name>
 ```
 
-Follow the prompts to setup your NuxtJS project. Ensure that when you reach the 'Deployment target' setting, select 'Static (Static/JAMStack hosting)'.
+Follow the prompts to setup your Nuxt project. Ensure that when you reach the 'Deployment target' setting, select 'Static (Static/JAMstack hosting)'.
 
 Once complete, move into your new directory:
 
@@ -33,13 +33,13 @@ Once complete, move into your new directory:
 cd <project-name>
 ```
 
-Next, you'll need to initialise your project with Bip. This only needs to be done once.
+Next, you'll need to initialize your project with Bip. This only needs to be done once.
 
 ```bash
 bip init
 ```
 
-Follow the prompts, where you'll be asked which domain you'd like to deploy to. Bip will detect that you're using NuxtJS, and set project settings like the source file directory automatically.
+Follow the prompts, where you'll be asked which domain you'd like to deploy to. Bip will detect that you're using Nuxt, and set project settings like the source file directory automatically.
 
 ## Step 2: Deploy
 

--- a/content/en/faq/cached-components.md
+++ b/content/en/faq/cached-components.md
@@ -1,6 +1,6 @@
 ---
 title: How to cache Vue components?
-description: How to cache Vue components in NuxtJS?
+description: How to cache Vue components in Nuxt?
 menu: How to cache Vue components?
 category: configuration
 position: 8

--- a/content/en/faq/deployment-aws-s3-cloudfront.md
+++ b/content/en/faq/deployment-aws-s3-cloudfront.md
@@ -1,15 +1,15 @@
 ---
-title: 'How to Deploy on AWS w/ S3 and Cloudfront?'
-description: Static Hosting on AWS with S3 and Cloudfront
-menu: Deploy on Aws w/ S3 and Cloudfront
+title: 'How to Deploy on AWS w/ S3 and CloudFront?'
+description: Static Hosting on AWS with S3 and CloudFront
+menu: Deploy on Aws w/ S3 and CloudFront
 category: deployment
 position: 201
 ---
 
 AWS stands for Amazon Web Services.  
-S3 is their static storage which can be configured for Static Site Hosting. Cloudfront is their CDN (content delivery network)
+S3 is their static storage which can be configured for Static Site Hosting. CloudFront is their CDN (content delivery network)
 
-Hosting a **static generated** Nuxt app on AWS w/ S3 + Cloudfront is powerful and cheap.
+Hosting a **static generated** Nuxt app on AWS w/ S3 + CloudFront is powerful and cheap.
 
 > AWS is a death by 1000 paper cuts. If we missed a step, please submit a PR to update this document.
 
@@ -28,7 +28,7 @@ We'll host super cheap with some AWS services. Briefly:
 We'll push the site like this:
 
 ```
-Nuxt Generate -> Local folder -> AWS S3 Bucket -> AWS Cloudfront CDN -> Browser
+Nuxt Generate -> Local folder -> AWS S3 Bucket -> AWS CloudFront CDN -> Browser
   [      nuxt generate       ]    [         gulp deploy          ]
   [                         deploy.sh                            ]
 ```

--- a/content/en/faq/deployment-azure-portal.md
+++ b/content/en/faq/deployment-azure-portal.md
@@ -77,7 +77,7 @@ module.exports = {
 
 **Remember to remove the references to the pkg object inside the config.**
 
-Thats it!
+That's it!
 
 For an Azure App Service deployment, make sure you set the following two environment variables (application settings) in App Service &rsaquo; Settings &rsaquo; Configuration &rsaquo; Application settings.
 
@@ -120,7 +120,7 @@ For Azure Portal you will need a `web.config` file. If not supplied, it will cre
     <!-- Visit https://azure.microsoft.com/en-us/blog/introduction-to-websockets-on-windows-azure-web-sites/ for more information on WebSocket support -->
     <webSocket enabled="false" />
     <handlers>
-      <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+      <!-- Indicates that the server.js file is a Node.js site to be handled by the iisnode module -->
       <add name="iisnode" path="server" verb="*" modules="iisnode"/>
     </handlers>
     <rewrite>
@@ -135,7 +135,7 @@ For Azure Portal you will need a `web.config` file. If not supplied, it will cre
           <action type="Rewrite" url="public{REQUEST_URI}"/>
         </rule>
 
-        <!-- All other URLs are mapped to the node.js site entry point -->
+        <!-- All other URLs are mapped to the Node.js site entry point -->
         <rule name="DynamicContent">
           <conditions>
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="True"/>
@@ -145,7 +145,7 @@ For Azure Portal you will need a `web.config` file. If not supplied, it will cre
       </rules>
     </rewrite>
 
-    <!-- 'bin' directory has no special meaning in node.js and apps can be placed in it -->
+    <!-- 'bin' directory has no special meaning in Node.js and apps can be placed in it -->
     <security>
       <requestFiltering>
         <hiddenSegments>

--- a/content/en/faq/deployment-azure-static-web-apps.md
+++ b/content/en/faq/deployment-azure-static-web-apps.md
@@ -6,7 +6,7 @@ category: deployment
 position: 203
 ---
 
-You can now deploy your static sites to Azure using Azure static web apps. You will need to have your app in Github as Azure static web apps leverages Github actions which allow you to re-build your static site on every git push.
+You can now deploy your static sites to Azure using Azure static web apps. You will need to have your app in GitHub as Azure static web apps leverages GitHub actions which allow you to re-build your static site on every git push.
 
 There are 2 things you need to configure in order to deploy your app to Azure static web apps. The first one is to modify the build command as Azure reads the build command from your package.json and for static sites we need to use the generate command.
 
@@ -33,7 +33,7 @@ The second one is to add a routes.json file which is important for catching cust
 }
 ```
 
-If you want to test out deploying to Azure static web apps, we have created a small demo application that is all setup and configured. You will just need to clone it and add it to your Github repo. You can then follow the steps on - Deploying your app with Azure Static Web Apps.
+If you want to test out deploying to Azure static web apps, we have created a small demo application that is all setup and configured. You will just need to clone it and add it to your GitHub repo. You can then follow the steps on - Deploying your app with Azure Static Web Apps.
 
 [Clone the demo app](https://github.com/debs-obrien/nuxtjs-azure-static-app)
 
@@ -43,7 +43,7 @@ If you want to test out deploying to Azure static web apps, we have created a sm
 
 1. Navigate to the [Azure Portal](https://portal.azure.com/).
 2. Click **Create a Resource** then search for **Static App** and select it.
-3. Select a subscription from the *Subscription* dropdown list or use the default one.
+3. Select a subscription from the *Subscription* drop-down list or use the default one.
 4. Click the **New** link below the *Resource group* dropdown. In *New resource group name*, type **nuxt** and click **OK**
 5. Provide a globally unique name for your app in the **Name** text box. Valid characters include `a-z`, `A-Z`, `0-9`, and `-`. The app name is used to identify the app in your list of resources therefore it is a good idea to name your app using the name of your repository.
 6. In the *Region* dropdown, choose a region closest to you.
@@ -86,9 +86,9 @@ Congrats your static site is now hosted on Azure static web apps.
 
 ## Rebuild your static app and monitoring deployment
 
-Now all you have to do is modify your code and push your changes. Pushing your changes will activate a Github action and your new site will automatically rebuild. You can monitor the workflow by clicking on the actions tab in your Github repo and you can inspect even further by selecting the last commit you made. You can then watch to see when the deploy is finished or inspect the log if you have any deployment errors.
+Now all you have to do is modify your code and push your changes. Pushing your changes will activate a GitHub action and your new site will automatically rebuild. You can monitor the workflow by clicking on the actions tab in your GitHub repo and you can inspect even further by selecting the last commit you made. You can then watch to see when the deploy is finished or inspect the log if you have any deployment errors.
 
-![Github actions screen](https://user-images.githubusercontent.com/13063165/82118249-34715880-9776-11ea-92e2-dbd21bbf7cb6.png)
+![GitHub actions screen](https://user-images.githubusercontent.com/13063165/82118249-34715880-9776-11ea-92e2-dbd21bbf7cb6.png)
 
 ## Did you know?
 

--- a/content/en/faq/deployment-cloud-run.md
+++ b/content/en/faq/deployment-cloud-run.md
@@ -1,6 +1,6 @@
 ---
 title: How to deploy on Google Cloud Run?
-description: How to deploy NuxtJS on Google Cloud Run?
+description: How to deploy Nuxt on Google Cloud Run?
 menu: Deploy on Google Cloud Run
 category: deployment
 position: 208

--- a/content/en/faq/ga.md
+++ b/content/en/faq/ga.md
@@ -1,6 +1,6 @@
 ---
 title: How to use Google Analytics?
-description: How to use Google Analytics in my NuxtJS app?
+description: How to use Google Analytics in my Nuxt app?
 category: configuration
 position: 9
 ---

--- a/content/en/faq/github-pages.md
+++ b/content/en/faq/github-pages.md
@@ -1,7 +1,7 @@
 ---
 title: How to deploy on GitHub Pages?
 description: How to deploy Nuxt.js app on GitHub Pages?
-menu: Deploy on Github
+menu: Deploy on GitHub
 category: deployment
 position: 206
 ---
@@ -83,11 +83,11 @@ You can take deployment one step further and rather than having to manually comp
 
 Before you configure the build server, you'll first need to [generate a GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token) in order to grant the build server permission to perform tasks on your behalf. Once you have created your token, keep a copy of it safe ready to use a little later on.
 
-### Github Actions
+### GitHub Actions
 
-To deploy via [Github Actions](https://github.com/features/actions), the official tool for software automation with Github, if you don't have a workflow you need to create a new one or append a new step to your existing workflow.
+To deploy via [GitHub Actions](https://github.com/features/actions), the official tool for software automation with GitHub, if you don't have a workflow you need to create a new one or append a new step to your existing workflow.
 
-It uses the [Github Pages Action](https://github.com/marketplace/actions/github-pages-action) which push the generated files from `dist` folder to your default Github Pages branch `gh-pages`.
+It uses the [GitHub Pages Action](https://github.com/marketplace/actions/github-pages-action) which pushes the generated files from the `dist` folder to your default GitHub Pages branch `gh-pages`.
 
 With an existing workflow, add the following step:
 

--- a/content/en/faq/heroku-deployment.md
+++ b/content/en/faq/heroku-deployment.md
@@ -33,7 +33,7 @@ Heroku uses a [Procfile](https://devcenter.heroku.com/articles/procfile) (name t
 web: nuxt start
 ```
 
-This will instruct run the `nuxt start` command and tell heroku to direct external HTTP traffic to it.
+This will instruct run the `nuxt start` command and tell Heroku to direct external HTTP traffic to it.
 
 Finally, we can push the app on Heroku with:
 

--- a/content/en/faq/netlify-deployment.md
+++ b/content/en/faq/netlify-deployment.md
@@ -36,7 +36,7 @@ Press the _"New site from Git"_ button on the Netlify dashboard. Authenticate wi
 1. **Build command:** `npm run build`
 1. **Publish directory:** `dist`
 
-For a single page app there is a problem with refresh as by default on netlify the site redirects to _"404 not found"_. For any pages that are not generated they will fallback to SPA mode and then if you refresh or share that link you will get Netlify's 404 page. This is because the pages that are not generated don't actually exist as they are actually a single page application so if you refesh this page you will get a 404 because the url for that page doesn't actually exist. By redirecting to the 404.html Nuxt will reload your page correctly in SPA fallback.
+For a single page app there is a problem with refresh as by default on Netlify the site redirects to _"404 not found"_. For any pages that are not generated they will fallback to SPA mode and then if you refresh or share that link you will get Netlify's 404 page. This is because the pages that are not generated don't actually exist as they are actually a single page application so if you refresh this page you will get a 404 because the url for that page doesn't actually exist. By redirecting to the 404.html Nuxt will reload your page correctly in SPA fallback.
 
 The easiest way to fix this is by adding a [generate property](/docs/2.x/configuration-glossary/configuration-generate#fallback) in your `nuxt.config` and setting `fallback: true`. Then it will fallback to the generated 404.html when in SPA mode instead of Netlify's 404 page.
 
@@ -48,13 +48,13 @@ export default {
 }
 ```
 
-If however you want to automatically apply headers and redirects of the SPA then there is a module for that, this is especially useful for when you have custom headers/redirects (in a \_headers or_redirects file):
+If however you want to automatically apply headers and redirects of the SPA then there is a module for that, this is especially useful for when you have custom headers/redirects (in a \_headers or \_redirects file):
 
 [netlify-files-module](https://github.com/nuxt-community/netlify-files-module)
 
 > For more information on Netlify redirects see the [Netlify docs](https://www.netlify.com/docs/redirects/#rewrites-and-proxying).
 
-> For simple reference on netlify redirects read blog [post](https://www.netlify.com/blog/2019/01/16/redirect-rules-for-all-how-to-configure-redirects-for-your-static-site) by Divya Sasidharan
+> For simple reference on Netlify redirects read blog [post](https://www.netlify.com/blog/2019/01/16/redirect-rules-for-all-how-to-configure-redirects-for-your-static-site) by Divya Sasidharan
 
 > Optionally, you can add additional ENV variables via the _"Advanced"_ button. These can be helpful for swapping in alternative API credentials and so on. Netlify also provides a [default ENV variables](https://www.netlify.com/docs/build-settings/#build-environment-variables) which can be read by your Nuxt.js application at build time.
 

--- a/content/en/faq/postcss-plugins.md
+++ b/content/en/faq/postcss-plugins.md
@@ -1,6 +1,6 @@
 ---
 title: How to add PostCSS plugins?
-description: How to add PostCSS plugins in NuxtJS?
+description: How to add PostCSS plugins in Nuxt?
 category: configuration
 position: 4
 ---

--- a/content/en/guides/components-glossary/pages-key.md
+++ b/content/en/guides/components-glossary/pages-key.md
@@ -10,7 +10,7 @@ position: 0
 
 - **Type:** `String` or `Function`
 
-The `key` property is propagated into `<router-view>`, which is useful to make transitions inside a dynamic page and different route. Different keys result in rerendering of page components.
+The `key` property is propagated into `<router-view>`, which is useful to make transitions inside a dynamic page and different route. Different keys result in re-rendering of page components.
 
 There are several ways to set the key. For more details, please refer to the `nuxtChildKey` prop in [the nuxt component](/docs/2.x/features/nuxt-components).
 

--- a/content/en/guides/concepts/nuxt-lifecycle.md
+++ b/content/en/guides/concepts/nuxt-lifecycle.md
@@ -120,7 +120,7 @@ When using static site generation, the server steps are only executed on build t
 This part of the lifecycle is fully executed in the browser, no matter which Nuxt.js mode you've chosen.
 
 - Receives the HTML
-- Loading assets (e.g. Javascript)
+- Loading assets (e.g. JavaScript)
 - Vue Hydration
 - Middleware
   - Global middleware

--- a/content/en/guides/concepts/static-site-generation.md
+++ b/content/en/guides/concepts/static-site-generation.md
@@ -1,6 +1,6 @@
 ---
 title: Static Site Generation
-description: With static site generation you can render your application during the build phase and deploy it to any static hosting services such as Netlify, Github pages, Vercel etc.
+description: With static site generation you can render your application during the build phase and deploy it to any static hosting services such as Netlify, GitHub pages, Vercel etc.
 position: 4
 category: concepts
 questions:
@@ -34,7 +34,7 @@ questions:
     correctAnswer: You need to regenerate your site
 ---
 
-With static site generation you can render your application during the build phase and deploy it to any static hosting services such as Netlify, Github pages, Vercel etc. This means that no server is needed in order to deploy your application.
+With static site generation you can render your application during the build phase and deploy it to any static hosting services such as Netlify, GitHub pages, Vercel etc. This means that no server is needed in order to deploy your application.
 
 ### Generating your site
 

--- a/content/en/guides/concepts/views.md
+++ b/content/en/guides/concepts/views.md
@@ -135,7 +135,7 @@ We then use the layout property with the value of 'blog' in the page where we wa
 
 <base-alert type="info">
 
-If you don't add a layout property to your page, eg `layout: 'blog'` then the `default.vue` layout will be used.
+If you don't add a layout property to your page, e.g. `layout: 'blog'`, then the `default.vue` layout will be used.
 
 </base-alert>
 

--- a/content/en/guides/configuration-glossary/configuration-build.md
+++ b/content/en/guides/configuration-glossary/configuration-build.md
@@ -225,7 +225,7 @@ You may want to extract all your CSS to a single file. There is a workaround for
 
 <base-alert>
 
-It is not recommended extracting everything into a single file. Extracting into multiple css files is better for caching and preload isolation. It can also improve page performance by downloading and resolving only those resources that are needed.
+It is not recommended to extract everything into a single file. Extracting into multiple CSS files is better for caching and preload isolation. It can also improve page performance by downloading and resolving only those resources that are needed.
 
 </base-alert>
 
@@ -545,11 +545,11 @@ export default {
 }
 ```
 
-### postcss plugins & nuxt-tailwindcss
+### postcss plugins & @nuxtjs/tailwindcss
 
-If you want to apply postcss plugin (eg. postcss-pxtorem) on the nuxt-tailwindcss configuration, you have to change order and load first tailwindcss.
+If you want to apply a postcss plugin (e.g. postcss-pxtorem) on the @nuxtjs/tailwindcss configuration, you have to change order and load tailwindcss first.
 
-**This setup have no impact on the nuxt-purgecss.**
+**This setup has no impact on nuxt-purgecss.**
 
 ```js{}[nuxt.config.js]
 import { join } from 'path'
@@ -641,7 +641,7 @@ This option is automatically set based on `mode` value if not provided.
 
 This is useful when you need to inject some variables and mixins in your pages without having to import them every time.
 
-Nuxt.js uses https://github.com/yenshih/style-resources-loader to achieve this behaviour.
+Nuxt.js uses https://github.com/yenshih/style-resources-loader to achieve this behavior.
 
 You need to specify the patterns/path you want to include for the given pre-processors: `less`, `sass`, `scss` or `stylus`
 

--- a/content/en/guides/configuration-glossary/configuration-css.md
+++ b/content/en/guides/configuration-glossary/configuration-css.md
@@ -44,7 +44,7 @@ export default {
 
 <base-alert>
 
-If you have two files with the same name eg. `main.scss` and `main.css`, and don't specify an extension in the css array entry, eg. `css: ['~/assets/css/main']`, then only one file will be loaded depending on the order of `styleExtensions`. In this case only the `css` file will be loaded and the `scss` file will be ignored because `css` comes first in the default `styleExtension` array.
+If you have two files with the same name e.g. `main.scss` and `main.css`, and don't specify an extension in the css array entry, e.g. `css: ['~/assets/css/main']`, then only one file will be loaded depending on the order of `styleExtensions`. In this case only the `css` file will be loaded and the `scss` file will be ignored because `css` comes first in the default `styleExtension` array.
 
 </base-alert>
 

--- a/content/en/guides/configuration-glossary/configuration-env.md
+++ b/content/en/guides/configuration-glossary/configuration-env.md
@@ -45,13 +45,13 @@ Then, in your pages, you can import axios like this: `import axios from '~/plugi
 
 ## Automatic injection of environment variables
 
-If you define environment variables starting with `NUXT_ENV_` in the build phase (f.ex. `NUXT_ENV_COOL_WORD=freezing nuxt build`, they'll be automatically injected into the process environment. Be aware that they'll potentially take precedence over defined variables in your `nuxt.config.js` with the same name.
+If you define environment variables starting with `NUXT_ENV_` in the build phase (e.g. `NUXT_ENV_COOL_WORD=freezing nuxt build`, they'll be automatically injected into the process environment. Be aware that they'll potentially take precedence over defined variables in your `nuxt.config.js` with the same name.
 
 ## process.env == {}
 
 Note that Nuxt uses webpack's `definePlugin` to define the environmental variable. This means that the actual `process` or `process.env` from Node.js is neither available nor defined. Each of the `env` properties defined in nuxt.config.js is individually mapped to `process.env.xxxx` and converted during compilation.
 
-Meaning, `console.log(process.env)` will output `{}` but `console.log(process.env.your_var)` will still output your value. When webpack compiles your code, it replaces all instances of `process.env.your_var` to the value you've set it to. ie: `env.test = 'testing123'`. If you use `process.env.test` in your code somewhere, it is actually translated to 'testing123'.
+Meaning, `console.log(process.env)` will output `{}` but `console.log(process.env.your_var)` will still output your value. When webpack compiles your code, it replaces all instances of `process.env.your_var` with the value you've set it to, e.g.: `env.test = 'testing123'`. If you use `process.env.test` in your code somewhere, it is actually translated to 'testing123'.
 
 before
 

--- a/content/en/guides/configuration-glossary/configuration-generate.md
+++ b/content/en/guides/configuration-glossary/configuration-generate.md
@@ -179,7 +179,7 @@ However, Nuxt allows you to configure any page you like so if you don't want to 
 fallback: 'fallbackPage.html'
 ```
 
-_Note: Multiple services (e.g. Netlify) detect a `404.html` automatically. If you configure your webserver on your own, please consult it's documentation to find out how to set up an error page (and set it to the `404.html` file)_
+_Note: Multiple services (e.g. Netlify) detect a `404.html` automatically. If you configure your web server on your own, please consult its documentation to find out how to set up an error page (and set it to the `404.html` file)_
 
 ## interval
 

--- a/content/en/guides/configuration-glossary/configuration-hooks.md
+++ b/content/en/guides/configuration-glossary/configuration-hooks.md
@@ -45,7 +45,7 @@ Internally, hooks follow a naming pattern using colons (e.g., `build:done`). For
 
 Let´s say you want to serve pages as `/portal` instead of `/`.
 
-This is maybe an edge-case, and the point of _nuxt.config.js_’ `router.base` is for when a Web server will serve Nuxt elsewhere than the domain root.
+This is maybe an edge-case, and the point of _nuxt.config.js_’ `router.base` is for when a web server will serve Nuxt elsewhere than the domain root.
 
 But when in local development, hitting _localhost_, when router.base is not / returns a 404. In order to prevent this, you can setup a Hook.
 

--- a/content/en/guides/configuration-glossary/configuration-loading-indicator.md
+++ b/content/en/guides/configuration-glossary/configuration-loading-indicator.md
@@ -24,7 +24,7 @@ loadingIndicator: {
 
 ## Built-in indicators
 
-These indicators are imported from the awesome [Spinkit](http://tobiasahlin.com/spinkit) project. You can use its demo page to preview spinners.
+These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com/spinkit) project. You can use its demo page to preview spinners.
 
 - circle
 - cube-grid
@@ -42,6 +42,6 @@ Built-in indicators support `color` and `background` options.
 
 ## Custom indicators
 
-If you need your own special indicator, a String value or Name key can also be a path to an html template of indicator source code! All of the options are passed to the template, too.
+If you need your own special indicator, a String value or Name key can also be a path to an HTML template of indicator source code! All of the options are passed to the template, too.
 
 Nuxt's built-in [source code](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) is also available if you need a base!

--- a/content/en/guides/configuration-glossary/configuration-modules.md
+++ b/content/en/guides/configuration-glossary/configuration-modules.md
@@ -8,7 +8,7 @@ position: 19
 
 - Type: `Array`
 
-> Modules are Nuxt.js extensions which can extend it's core functionality and add endless integrations. [Learn More](/docs/2.x/directory-structure/modules)
+> Modules are Nuxt.js extensions which can extend its core functionality and add endless integrations. [Learn More](/docs/2.x/directory-structure/modules)
 
 Example (`nuxt.config.js`):
 

--- a/content/en/guides/configuration-glossary/configuration-plugins.md
+++ b/content/en/guides/configuration-glossary/configuration-plugins.md
@@ -26,7 +26,7 @@ If the item is an object, the properties are:
 - src: `String` (path of the file)
 - ssr: `Boolean` (default to `true`) _If false, the file will be included only on the client-side._
 
-> The plugins property lets you add vue.js plugins easily to your main application.
+> The plugins property lets you add Vue.js plugins easily to your main application.
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/en/guides/configuration-glossary/configuration-render.md
+++ b/content/en/guides/configuration-glossary/configuration-render.md
@@ -53,7 +53,7 @@ export default {
 }
 ```
 
-In this case we use [murmurhash-native](https://github.com/royaltm/node-murmurhash-native), which is faster for larger html body sizes. Note that the `weak` option is ignored, when specifying your own hash function.
+In this case we use [murmurhash-native](https://github.com/royaltm/node-murmurhash-native), which is faster for larger HTML body sizes. Note that the `weak` option is ignored, when specifying your own hash function.
 
 ## compressor
 
@@ -62,7 +62,7 @@ In this case we use [murmurhash-native](https://github.com/royaltm/node-murmurha
 
 When providing an object, the [compression](https://www.npmjs.com/package/compression) middleware will be used (with respective options).
 
-If you want to use your own compression middleware, you can reference it directly (f.ex. `otherComp({ myOptions: 'example' })`).
+If you want to use your own compression middleware, you can reference it directly (e.g. `otherComp({ myOptions: 'example' })`).
 
 To disable compression, use `compressor: false`.
 

--- a/content/en/guides/configuration-glossary/configuration-router.md
+++ b/content/en/guides/configuration-glossary/configuration-router.md
@@ -139,7 +139,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkactiveclass](https://router.vuejs.org/api/#linkactiveclass).
+> This option is given directly to the vue-router [linkActiveClass](https://router.vuejs.org/api/#linkactiveclass).
 
 ## linkExactActiveClass
 
@@ -156,7 +156,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkexactactiveclass](https://router.vuejs.org/api/#linkexactactiveclass).
+> This option is given directly to the vue-router [linkExactActiveClass](https://router.vuejs.org/api/#linkexactactiveclass).
 
 ## linkPrefetchedClass
 
@@ -232,7 +232,7 @@ Provide custom query string parse / stringify functions. Overrides the default.
 - Type: `Boolean`
 - Default: `true`
 
-Configure `<nuxt-link>` to prefetch the _code-splitted_ page when detected within the viewport. Requires [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to be supported (see [CanIUse](https://caniuse.com/#feat=intersectionobserver)).
+Configure `<nuxt-link>` to prefetch the _code-splitted_ page when detected within the viewport. Requires [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to be supported (see [Caniuse](https://caniuse.com/#feat=intersectionobserver)).
 
 We recommend conditionally polyfilling this feature with a service like [Polyfill.io](https://polyfill.io):
 
@@ -253,8 +253,8 @@ export default {
 To disable the prefetching on a specific link, you can use the `no-prefetch` prop. Since Nuxt.js v2.10.0, you can also use the `prefetch` prop set to `false`:
 
 ```html
-<nuxt-link to="/about" no-prefetch>About page not pre-fetched</nuxt-link>
-<nuxt-link to="/about" :prefetch="false">About page not pre-fetched</nuxt-link>
+<nuxt-link to="/about" no-prefetch>About page not prefetched</nuxt-link>
+<nuxt-link to="/about" :prefetch="false">About page not prefetched</nuxt-link>
 ```
 
 To disable the prefetching on all links, set the `prefetchLinks` to `false`:
@@ -270,7 +270,7 @@ export default {
 Since Nuxt.js v2.10.0, if you have set `prefetchLinks` to `false` but you want to prefetch a specific link, you can use the `prefetch` prop:
 
 ```html
-<nuxt-link to="/about" prefetch>About page pre-fetched</nuxt-link>
+<nuxt-link to="/about" prefetch>About page prefetched</nuxt-link>
 ```
 
 ## prefetchPayloads
@@ -334,7 +334,7 @@ If this option is set to true, trailing slashes will be appended to every route.
 
 **Attention**: This option should not be set without preparation and has to be tested thoroughly. When setting `router.trailingSlash` to something else than `undefined`, the opposite route will stop working. Thus 301 redirects should be in place and you _internal linking_ has to be adapted correctly. If you set `trailingSlash` to `true`, then only `example.com/abc/` will work but not `example.com/abc`. On false, it's vice-versa
 
-### Example behaviour (with child routes)
+### Example behavior (with child routes)
 
 For a directory with this structure:
 
@@ -347,7 +347,7 @@ For a directory with this structure:
 -----| index.vue
 ```
 
-This is the behaviour for each possible setting of `trailingSlash`:
+This is the behavior for each possible setting of `trailingSlash`:
 
 <code-group>
 <code-block label="default" active>

--- a/content/en/guides/configuration-glossary/configuration-server.md
+++ b/content/en/guides/configuration-glossary/configuration-server.md
@@ -73,9 +73,9 @@ export default {
 }
 ```
 
-### Using timing api
+### Using timing API
 
-The `timing` api is also injected into the `response` on server-side when `server.time` is enabled.
+The `timing` API is also injected into the `response` on server-side when `server.time` is enabled.
 
 #### Syntax
 
@@ -84,7 +84,7 @@ res.timing.start(name, description)
 res.timing.end(name)
 ```
 
-#### Example using timing in servermiddleware
+#### Example using timing in serverMiddleware
 
 ```js
 export default function (req, res, next) {

--- a/content/en/guides/configuration-glossary/configuration-telemetry.md
+++ b/content/en/guides/configuration-glossary/configuration-telemetry.md
@@ -15,7 +15,7 @@ position: 30
 
 ## Why collect Telemetry
 
-Nuxt.js has grown a lot from it's [initial release](https://github.com/nuxt/nuxt.js/releases/tag/v0.2.0) (7 Nov 2016) and we are keep listening to [community feedback](https://github.com/nuxt/nuxt.js/issues) to improve it.
+Nuxt.js has grown a lot from its [initial release](https://github.com/nuxt/nuxt.js/releases/tag/v0.2.0) (7 Nov 2016) and we are keep listening to [community feedback](https://github.com/nuxt/nuxt.js/issues) to improve it.
 
 However, this manual process only collects feedback from a subset of users that takes the time to fill the issue template and it may have different needs or use-case than you.
 
@@ -25,7 +25,7 @@ We collect multiple events:
 
 - Command invoked (nuxt dev, nuxt build, etc)
 - Versions of Nuxt.js and Node.js
-- General machine information (MacOS/Linux/Windows and if command is run within CI, ci name)
+- General machine information (MacOS/Linux/Windows and if command is run within CI, the CI name)
 - Duration of the Webpack build and average size of the application, as well as the generation stats (when using nuxt generate)
 - What are the public dependency of your project (Nuxt modules)
 

--- a/content/en/guides/configuration-glossary/configuration-watchers.md
+++ b/content/en/guides/configuration-glossary/configuration-watchers.md
@@ -32,7 +32,7 @@ watchers: {
 }
 ```
 
-To learn more about webpack watchoptions, see the [webpack documentation](https://webpack.js.org/configuration/watch/#watchoptions).
+To learn more about webpack watchOptions, see the [webpack documentation](https://webpack.js.org/configuration/watch/#watchoptions).
 
 ### What's next
 

--- a/content/en/guides/directory-structure/assets.md
+++ b/content/en/guides/directory-structure/assets.md
@@ -57,7 +57,7 @@ questions:
     correctAnswer: '@@'
 ---
 
-The `assets` directory contains your un-compiled assets such as Stylus or Sass files, images, or fonts.
+The `assets` directory contains your uncompiled assets such as Stylus or Sass files, images, or fonts.
 
 ## Images
 
@@ -207,7 +207,7 @@ The benefits of these loaders are:
 
 `file-loader` lets you designate where to copy and place the asset file, and how to name it using version hashes for better caching. In production, you will benefit from long-term caching by default!
 
-`url-loader` allows you to conditionally inline a file as base-64 data URL if they are smaller than a given threshold. This can reduce the number of HTTP requests for trivial files. If the file is larger than the threshold, it automatically falls back to file-loader.
+`url-loader` allows you to conditionally inline files as base64 data URLs if they are smaller than a given threshold. This can reduce the number of HTTP requests for trivial files. If a file is larger than the threshold, it automatically falls back to file-loader.
 
 For these two loaders, the default configuration is:
 
@@ -233,7 +233,7 @@ For these two loaders, the default configuration is:
 ]
 ```
 
-Which means that every file below 1 KB will be inlined as base-64 data URL. Otherwise, the image/font will be copied in its corresponding folder (inside the `.nuxt` directory) with a name containing a version hash for better caching.
+Which means that every file below 1 kB will be inlined as base64 data URL. Otherwise, the image/font will be copied in its corresponding folder (inside the `.nuxt` directory) with a name containing a version hash for better caching.
 
 When launching your application with `nuxt`, your template in `pages/index.vue`:
 

--- a/content/en/guides/directory-structure/content.md
+++ b/content/en/guides/directory-structure/content.md
@@ -46,7 +46,7 @@ questions:
       - .prev-next(slug)
       - .slug()
     correctAnswer: .surround(slug)
-  - question: PrismJS classes are applied to code blocks by default?
+  - question: Prism classes are applied to code blocks by default?
     answers:
       - true
       - false
@@ -265,7 +265,7 @@ See the [content module docs](https://content.nuxtjs.org/fetching#searchfield-va
 
 ### Syntax highlighting
 
-This module automatically wraps codeblocks and applies [PrismJS](https://prismjs.com/) classes. You can also add a different PrismJS theme or disable it altogether.
+This module automatically wraps codeblocks and applies [Prism](https://prismjs.com/) classes. You can also add a different Prism theme or disable it altogether.
 
 <code-group>
   <code-block label="Yarn" active>
@@ -330,9 +330,9 @@ See the [content module docs](https://content.nuxtjs.org/writing#table-of-conten
 
 </base-alert>
 
-### Powerful QueryBuilder API (MongoDB like)
+### Powerful query builder API (MongoDB-like)
 
-The content module comes with a powerful QueryBuilder API similar to MongoDB which allows you to easily see the JSON of each directory at `http://localhost:3000/_content/`. The endpoint is accessible on GET and POST request, so you can use query params.
+The content module comes with a powerful query builder API similar to MongoDB which allows you to easily see the JSON of each directory at `http://localhost:3000/_content/`. The endpoint is accessible on GET and POST request, so you can use query params.
 
 `http://localhost:3000/_content/articles?only=title&only=description&limit=10`
 

--- a/content/en/guides/directory-structure/dist.md
+++ b/content/en/guides/directory-structure/dist.md
@@ -88,7 +88,7 @@ generate: {
 
 ### The fallback Property
 
-When deploying your site you will need to make sure the fallback html path is set correctly. It should be set as the error page so that unknown routes are rendered via Nuxt. If it is unset Nuxt.js will use the default value which is 200.html.
+When deploying your site you will need to make sure the fallback HTML path is set correctly. It should be set as the error page so that unknown routes are rendered via Nuxt. If it is unset Nuxt.js will use the default value which is 200.html.
 
 When running a single page application it makes more sense to use 200.html as it is the only file necessary as no other routes are generated.
 

--- a/content/en/guides/directory-structure/modules.md
+++ b/content/en/guides/directory-structure/modules.md
@@ -157,7 +157,7 @@ module.exports.meta = require('./package.json')
 
 ## 1) ModuleOptions
 
-`moduleOptions`: This is the object passed using the `modules` array by the user. We can use it to customize it's behavior.
+`moduleOptions`: This is the object passed using the `modules` array by the user. We can use it to customize its behavior.
 
 ### Top level options
 

--- a/content/en/guides/directory-structure/nuxt-config.md
+++ b/content/en/guides/directory-structure/nuxt-config.md
@@ -100,12 +100,12 @@ See more on the [dev property](/docs/2.x/configuration-glossary/configuration-d
 
 ### env
 
-This option lets you define environment variables that are required at build time rather than runtime such as `NODE_ENV=staging` or `VERSION=1.2.3`. However for runtime environment variables the runtime config` is preferred.
+This option lets you define environment variables that are required at build time (rather than runtime) such as `NODE_ENV=staging` or `VERSION=1.2.3`. However, for runtime environment variables `runtimeConfig` is required.
 
 ```js{}[nuxt.config.js]
 export default {
   env: {
-    baseUrl: process.env.BASE_URL
+    baseURL: process.env.BASE_URL
   }
 }
 ```

--- a/content/en/guides/directory-structure/nuxt.md
+++ b/content/en/guides/directory-structure/nuxt.md
@@ -62,7 +62,7 @@ export default {
 - The views folder contains your app template and your server error page.
 - The app.js is your main application file.
 - The client.js file is your client file needed for everything that happens client side.
-- The empty file is intentionally left empty for noop aliases
+- The empty file is intentionally left empty for no-op aliases
 - The index.js file bootstraps your application.
 - The loading.html is the file that is used when the page is loading.
 - The middleware file is where your middleware is kept

--- a/content/en/guides/directory-structure/pages.md
+++ b/content/en/guides/directory-structure/pages.md
@@ -135,7 +135,7 @@ If you've defined a file named \_slug.vue inside a folder called \_book you can 
 
 ### asyncData
 
-AsyncData is called every time before loading the component. It can be asynchronous and receives the context as an argument. The returned object will be merged with your data object.
+asyncData is called every time before loading the component. It can be asynchronous and receives the context as an argument. The returned object will be merged with your data object.
 
 ```js{}[pages/index.vue]
 export default {

--- a/content/en/guides/directory-structure/plugins.md
+++ b/content/en/guides/directory-structure/plugins.md
@@ -73,7 +73,7 @@ questions:
 
 <app-modal :src="img" :alt="imgAlt"></app-modal>
 
-The `plugins` directory contains your Javascript plugins that you want to run before instantiating the root Vue.js Application. This is the place to add Vue plugins and to inject functions or constants. Every time you need to use `Vue.use()`, you should create a file in `plugins/` and add its path to `plugins` in `nuxt.config.js`.
+The `plugins` directory contains JavaScript plugins that you want to run before instantiating the root Vue.js Application. This is the place to add Vue plugins and to inject functions or constants. Every time you need to use `Vue.use()`, you should create a file in `plugins/` and add its path to `plugins` in `nuxt.config.js`.
 
 ## External Packages
 
@@ -198,7 +198,7 @@ Vue.use(VTooltip)
 
 ### The plugins Property
 
-Then we add the file path inside the `plugins` key of our `nuxt.config.js`. The plugins property lets you add vue.js plugins easily to your main application. All the paths defined in the `plugins` property will be imported before initializing the main application.
+Then we add the file path inside the `plugins` key of our `nuxt.config.js`. The plugins property lets you add Vue.js plugins easily to your main application. All the paths defined in the `plugins` property will be imported before initializing the main application.
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/en/guides/features/configuration.md
+++ b/content/en/guides/features/configuration.md
@@ -111,7 +111,7 @@ export default {
 
 <base-alert>
 
-If you have two files with the same name eg. `main.scss` and `main.css`, and don't specify an extension in the css array entry, eg. `css: ['~/assets/css/main']`, then only one file will be loaded depending on the order of `styleExtensions`. In this case only the `css` file will be loaded and the `scss` file will be ignored because `css` comes first in the default `styleExtension` array.
+If you have two files with the same name, e.g. `main.scss` and `main.css`, and don't specify an extension in the css array entry, e.g. `css: ['~/assets/css/main']`, then only one file will be loaded depending on the order of `styleExtensions`. In this case only the `css` file will be loaded and the `scss` file will be ignored because `css` comes first in the default `styleExtension` array.
 
 </base-alert>
 

--- a/content/en/guides/features/data-fetching.md
+++ b/content/en/guides/features/data-fetching.md
@@ -1,6 +1,6 @@
 ---
 title: Data Fetching
-description: In Nuxt.js we have 2 ways of getting data from an api. We can use the fetch method or the asyncData method.
+description: In Nuxt.js we have 2 ways of getting data from an API. We can use the fetch method or the asyncData method.
 position: 4
 category: features
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/04_data_fetching?fontsize=14&hidenavigation=1&theme=dark

--- a/content/en/guides/features/file-system-routing.md
+++ b/content/en/guides/features/file-system-routing.md
@@ -124,7 +124,7 @@ router: {
 
 ## Dynamic Routes
 
-Sometimes it is not possible to know the name of the route such as when we make a call to an api to get a list of users or blog posts. We call these dynamic routes. To create a dynamic route you need to add an underscore before the .vue file name or before the name of the directory. You can name the file or directory anything you want but you must prefix it with an underscore.
+Sometimes it is not possible to know the name of the route such as when we make a call to an API to get a list of users or blog posts. We call these dynamic routes. To create a dynamic route you need to add an underscore before the .vue file name or before the name of the directory. You can name the file or directory anything you want but you must prefix it with an underscore.
 
 This file tree:
 

--- a/content/en/guides/features/live-preview.md
+++ b/content/en/guides/features/live-preview.md
@@ -22,7 +22,7 @@ export default function ({ query, enablePreview }) {
 ```
 
 <base-alert>
-EnablePreview is only available in the context object of plugins. Previews are handled client-side and
+`enablePreview` is only available in the context object of plugins. Previews are handled client-side and
 thus the plugin should be run on the client: preview.client.js
 </base-alert>
 

--- a/content/en/guides/features/loading.md
+++ b/content/en/guides/features/loading.md
@@ -235,7 +235,7 @@ export default {
 
 ## Built-in indicators
 
-These indicators are imported from awesome [Spinkit](http://tobiasahlin.com/spinkit) project. You can check out its demo page to preview the spinners. In order to use one of these spinners all you have to do is add it's name to the name property. No need to import or install anything. Here is a list of built in indicators you can use.
+These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com/spinkit) project. You can check out its demo page to preview the spinners. In order to use one of these spinners all you have to do is add its name to the name property. No need to import or install anything. Here is a list of built in indicators you can use.
 
 - circle
 - cube-grid
@@ -253,7 +253,7 @@ Built-in indicators support `color` and `background` options.
 
 ## Custom indicators
 
-If you need your own special indicator, a String value or Name key can also be a path to a html template of indicator source code! All of the options are passed to the template, too.
+If you need your own special indicator, a String value or Name key can also be a path to an HTML template of indicator source code! All of the options are passed to the template, too.
 
 Nuxt's built-in [source code](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) is also available if you need a base!
 

--- a/content/en/guides/features/nuxt-components.md
+++ b/content/en/guides/features/nuxt-components.md
@@ -249,7 +249,7 @@ If you want to know more about `<RouterLink>`, feel free to read the [Vue Route
 
 ## prefetchLinks
 
-Nuxt.js automatically includes smart prefetching. That means it detects when a link is visible, either in the viewport or when scrolling and prefetches the JavaScript for those pages so that they are ready when the user clicks the link. Nuxt.js only loads the resources when the browser isn't busy and skips prefetching if your connection is offline or if you only have 2g connection.
+Nuxt.js automatically includes smart prefetching. That means it detects when a link is visible, either in the viewport or when scrolling and prefetches the JavaScript for those pages so that they are ready when the user clicks the link. Nuxt.js only loads the resources when the browser isn't busy and skips prefetching if your connection is offline or if you only have 2G connection.
 
 <base-alert type="info">
 
@@ -262,8 +262,8 @@ Check out this article to learn more about [smart prefetching](/blog/introducing
 However sometimes you may want to disable prefetching on some links if your page has a lot of JavaScript or you have a lot of different pages that would be prefetched or you have a lot of third party scripts that need to be loaded. To disable the prefetching on a specific link, you can use the `no-prefetch` prop. Since Nuxt.js v2.10.0, you can also use the `prefetch` prop set to `false`
 
 ```html
-<NuxtLink to="/about" no-prefetch>About page not pre-fetched</NuxtLink>
-<NuxtLink to="/about" :prefetch="false">About page not pre-fetched</NuxtLink>
+<NuxtLink to="/about" no-prefetch>About page not prefetched</NuxtLink>
+<NuxtLink to="/about" :prefetch="false">About page not prefetched</NuxtLink>
 ```
 
 ### Disable prefetching globally
@@ -281,7 +281,7 @@ export default {
 Since Nuxt.js v2.10.0, if you have to set `prefetchLinks` to `false` but you want to prefetch a specific link, you can use the `prefetch` prop:
 
 ```html
-<NuxtLink to="/about" prefetch>About page pre-fetched</NuxtLink>
+<NuxtLink to="/about" prefetch>About page prefetched</NuxtLink>
 ```
 
 ## Link Classes
@@ -366,7 +366,7 @@ Then you can add the styles for that class.
 
 ```css
 .nuxt-link-prefetched {
-  color: orangeRed;
+  color: orangered;
 }
 ```
 

--- a/content/en/guides/get-started/installation.md
+++ b/content/en/guides/get-started/installation.md
@@ -9,8 +9,8 @@ csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/
 ## Prerequisites
 
 - [node](https://nodejs.org) - at least v10.13 _We recommend you have the latest LTS version installed._
-- A text editor, we recommend [VSCode](https://code.visualstudio.com/) with the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension or [WebStorm](https://www.jetbrains.com/webstorm/)
-- A terminal, we recommend using VSCode's [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal) or [Webstorm terminal](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
+- A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension or [WebStorm](https://www.jetbrains.com/webstorm/)
+- A terminal, we recommend using VS Code's [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal) or [WebStorm terminal](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
 ## Using create-nuxt-app
 

--- a/content/en/guides/internals-glossary/context.md
+++ b/content/en/guides/internals-glossary/context.md
@@ -75,7 +75,7 @@ Alias of `route.query`.
 
 `env` (_Object_)
 
-Environment variables set in `nuxt.config.js`, see [env api](/docs/2.x/configuration-glossary/configuration-env).
+Environment variables set in `nuxt.config.js`, see [env API](/docs/2.x/configuration-glossary/configuration-env).
 
 ### isDev
 

--- a/content/en/guides/internals-glossary/nuxt-render.md
+++ b/content/en/guides/internals-glossary/nuxt-render.md
@@ -12,7 +12,7 @@ position: 10
   2. [Response](https://nodejs.org/api/http.html#http_class_http_serverresponse)
 - Returns: `Promise`
 
-> You can use Nuxt.js as a middleware with `nuxt.render` for your node.js server.
+> You can use Nuxt.js as a middleware with `nuxt.render` for your Node.js server.
 
 Example with [Express](https://github.com/expressjs/express):
 


### PR DESCRIPTION
* use their preferred names/capitalisation for companies/projects
* where multiple options are valid, standardise on the most common within docs
* use US rather than UK English
* prefer `e.g.` to `eg.`
* fix some typos