### PR TITLE
docs(zh) update translation：content/zh/guides/get-start

### DIFF
--- a/content/zh/guides/get-started/commands.md
+++ b/content/zh/guides/get-started/commands.md
@@ -1,0 +1,193 @@
+---
+title: 命令与部署
+description: Nuxt.js自带一组有用的命令，用于部署开发和生产环境。
+position: 4
+category: get-started
+---
+
+Nuxt.js 自带一组有用的命令，用于部署开发和生产环境。
+
+## 使用`package.json`
+
+你需要将这些命令放在`package.json`文件里:
+
+```json
+"scripts": {
+  "dev": "nuxt",
+  "build": "nuxt build",
+  "start": "nuxt start",
+  "generate": "nuxt generate"
+}
+```
+
+然后，你可以通过`yarn <command>` 或 `npm run <command>`来启动命令。(例如： `yarn dev` / `npm run dev`).
+
+## 开发环境
+
+以开发模式来启动 Nuxt [热更新模块](https://webpack.js.org/concepts/hot-module-replacement/) 运行在`http://localhost:3000`上:
+
+<code-group>
+
+  <code-block label="Yarn" active>
+
+```bash
+yarn dev
+```
+
+  </code-block>
+
+  <code-block label="NPM">
+
+```bash
+npm run dev
+```
+
+  </code-block>
+</code-group>
+
+## 命令列表
+
+您可以根据[部署目标](/docs/2.x/features/deployment-targets)运行不同的命令
+
+### 部署目标: `server`服务器端渲染 (默认值)
+
+- **nuxt dev** - 启动开发环境服务器。
+- **nuxt build** - 使用 webpack 构建和优化应用，使其可以应用于生产环境。
+- **nuxt start** - 启动生产环境服务器（运行`nuxt build`之后）。将其用于诸如 Heroku，Digital Ocean 等的 Node.js 托管。
+
+### 部署目标: `static`静态应用托管
+
+- **nuxt dev** - 启动开发环境服务器。
+- **nuxt generate** - 构建应用（如果需要），将为每个页面生成 HTML 文件，并静态导出到`dist/`目录下（用于静态托管）。
+- **nuxt start** - 像静态主机一样运行`dist/`目录（Netlify，Vercel，Surge 等），非常适合在部署前进行测试。
+
+## 生产环境部署
+
+Nuxt.js 让你可以在服务器部署或静态应用部署之间进行选择。
+
+### 服务端渲染应用部署
+
+为了部署 SSR(Server Side Rendering 服务器端渲染)应用，可以使用`target：server`，其中 server 是默认值。
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn build
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+npm run build
+```
+
+  </code-block>
+</code-group>
+
+Nuxt.js 将创建一个`.nuxt`目录，其中的所有内容都可以部署在你的托管服务器上。
+
+<base-alert type="info">
+
+我们建议将`.nuxt`放在`.npmignore`或`.gitignore`文件中。
+
+</base-alert>
+
+构建应用程序后，可以使用`start`命令查看应用的生产环境版本。
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn start
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+npm run start
+```
+
+  </code-block>
+</code-group>
+
+### 静态应用部署（预渲染）
+
+Nuxt.js 使你能够在任何静态主机上托管您的 Web 应用。
+
+要部署一个静态应用的站点，请确保在您的`nuxt.config.js`中有配置`target：static`（需要 Nuxt> = 2.13)
+
+```js{}[nuxt.config.js]
+export default {
+  target: 'static'
+}
+```
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn generate
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+npm run generate
+```
+
+  </code-block>
+</code-group>
+
+Nuxt.js 将创建一个`dist/`目录，其中的所有内容都可以部署在静态托管服务上。
+
+从 v2.13 开始，Nuxt 安装了一个爬虫，当使用`nuxt generate`命令时，他会搜索你的链接标签并生成相对应的路由。
+
+<base-alert>
+
+**警告:** 使用的 Nuxt 版本 <= v2.12 时，`generate`命令将忽略动态路由 [API Configuration generate](/docs/2.x/configuration-glossary/configuration-generate)
+
+</base-alert>
+
+<base-alert type="info">
+
+使用 `nuxt generate` 静态化应用的时候, 传给 [asyncData()](/docs/2.x/features/data-fetching#async-data) 和 [fetch()](/docs/2.x/directory-structure/store) 方法的[context](/docs/2.x/internals-glossary/context) 对象不会包含 `req` 和 `res` 两个属性。
+
+</base-alert>
+
+#### **错误状态**
+
+若要在页面遇到错误时, 通过返回非零状态码来让 CI/CD 部署或编译失败, 可以使用`--fail-on-error`参数。
+
+tips: 这个功能在`v2.14`版本测试下来有[问题](https://github.com/nuxt/nuxt.js/pull/7948)，并不会打断编译，需要等后续官方修复。所以建议在上线前需要在测试环境做好完整测试。
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn generate --fail-on-error
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+npm run generate --fail-on-error
+```
+
+  </code-block>
+
+</code-group>
+
+## 下一步？
+
+<base-alert type="next">
+
+阅读我们的[FAQ](/faq) 查找有关当下流行的部署托管的示例。
+
+</base-alert>
+
+</div>

--- a/content/zh/guides/get-started/conclusion.md
+++ b/content/zh/guides/get-started/conclusion.md
@@ -1,0 +1,93 @@
+---
+title: 结语
+description: 恭喜你~！现在，你已经创建了自己的第一个Nuxt.js应用，现在你可以将自己视为Nuxter了，但是要学习的东西太多了，使用Nuxt.js可以做的事情还很多。 以下是一些建议
+position: 5
+category: get-started
+questions:
+  - question: What is the name of the directory you need to have for Nuxt.js to work?
+    answers:
+      - nuxt
+      - pages
+      - index
+    correctAnswer: pages
+  - question: What is the name of your project ID file?
+    answers:
+      - package.vue
+      - package.json
+      - package.js
+    correctAnswer: package.json
+  - question: What is the command you type in the terminal to launch your Nuxt.js project?
+    answers:
+      - npm dev
+      - npm run dev
+      - nuxt dev
+    correctAnswer: npm run dev
+  - question: What is the address in the browser where you can see your page in development mode?
+    answers:
+      - http://localhost:3000/
+      - http://localhost:3000/project-name:3000
+      - http://localhost:3000/nuxt:3000/
+    correctAnswer: http://localhost:3000/
+  - question: Where do you put your configuration in?
+    answers:
+      - nuxt.config.json
+      - config.js
+      - nuxt.config.js
+    correctAnswer: nuxt.config.js
+  - question: Which directory is not suitable for `.vue` files?
+    answers:
+      - pages
+      - static
+      - components
+    correctAnswer: static
+  - question: In which directory do you put your styles?
+    answers:
+      - styles
+      - components
+      - assets
+    correctAnswer: assets
+  - question: In which directory do we put a robots.txt or favicon?
+    answers:
+      - assets
+      - components
+      - static
+    correctAnswer: static
+  - question: What component do we use to navigate between pages?
+    answers:
+      - '<Nuxt>'
+      - '<RouterLink>'
+      - '<NuxtLink>'
+    correctAnswer: '<NuxtLink>'
+  - question: '`<NuxtLink>` is used for internal links that belong to the Nuxt.js app?'
+    answers:
+      - True
+      - False
+    correctAnswer: True
+---
+
+恭喜你~！现在，你已经创建了自己的第一个 Nuxt.js 应用，现在你可以将自己视为 Nuxter 了，但是要学习的东西太多了，使用 Nuxt.js 可以做的事情还很多。 以下是一些建议：
+
+<base-alert type="next">
+
+查看 [Concepts book](../concepts/views)
+
+</base-alert>
+
+<base-alert type="next">
+
+使用 [asyncData](/docs/2.x/features/data-fetching#async-data)
+
+</base-alert>
+
+<base-alert type="next">
+
+在不同的 [Rendering modes](/docs/2.x/features/rendering-modes)渲染模式之间进行选择
+
+</base-alert>
+
+<base-alert type="star">
+
+到目前为止，您是否喜欢 Nuxt.js？ 不要忘记在 GitHub 上为我们的项目加个[star](https://github.com/nuxt/nuxt.js)✨
+</base-alert>
+
+<quiz :questions="questions"></quiz>

--- a/content/zh/guides/get-started/directory-structure.md
+++ b/content/zh/guides/get-started/directory-structure.md
@@ -1,0 +1,92 @@
+---
+title: 目录结构
+description: 默认的Nuxt.js应用结构旨在为小型和大型的应用提供一个良好的起点。开发者可以随意组织自己的应用程序，也可以在需要时创建其他目录。
+position: 3
+category: get-started
+csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/03_directory_structure?fontsize=14&hidenavigation=1&theme=dark
+---
+
+默认的 Nuxt.js 应用结构旨在为小型和大型的应用提供一个良好的起点。开发者可以随意组织自己的应用程序，也可以在需要时创建其他目录。
+
+现在让我们创建项目中尚不存在的目录和文件。
+
+```bash
+mkdir components assets static
+touch nuxt.config.js
+```
+
+这些是构建 Nuxt.js 应用时使用的主要目录和文件。你将在下面找到每个说明。
+
+<base-alert type="info">
+
+要使用 Nuxt.js 项目中的功能，需要用指定用这些名称来创建目录。
+
+</base-alert>
+
+## 目录
+
+### `pages`目录
+
+`page`目录包含应用的视图和路由。正如在上一章中学到的那样，Nuxt.js 读取此目录中的所有`.vue`文件并使用它们创建应用路由。
+
+<base-alert type="next">
+
+了解更多关于 [pages directory](/docs/2.x/directory-structure/pages)
+
+</base-alert>
+
+### `components`目录
+
+`components`目录是放置你所有`Vue.js`组件的位置，然后将这些组件导入到你的页面中。
+
+使用 Nuxt.js，可以创建组件并将其自动导入到`.vue`文件中，这意味着无需在`<script>`部分中手动导入它们。 一旦将组件设置为`true`，Nuxt.js 将扫描并自动导入这些文件。
+
+<base-alert type="next">
+
+了解更多关于 [components directory](/docs/2.x/directory-structure/components)
+
+</base-alert>
+
+### `assets`目录
+
+`assets`目录可以放置未编译的依赖，例如样式，图像或字体。
+
+<base-alert type="next">
+
+了解更多关于 [assets directory](/docs/2.x/directory-structure/assets)
+
+</base-alert>
+
+### `static`目录
+
+`static`目录则直接映射到服务器根目录，可以放置必须保留名称后缀的文件（例如：`robots.txt`）或着不太会更改的文件（例如:`favicon.ico`）
+
+<base-alert type="next">
+
+了解更多关于 [static directory](/docs/2.x/directory-structure/static)
+
+</base-alert>
+
+### `nuxt.config.js`文件
+
+`nuxt.config.js`是 Nuxt.js 唯一的应用配置文件。如果要添加模块或覆盖默认设置，则可以在此处应用更改。
+
+<base-alert type="next">
+
+了解更多关于 [nuxt.config.js file](/docs/2.x/directory-structure/nuxt-config)
+
+</base-alert>
+
+### `package.json`文件
+
+`package.json`文件包含有关应用的所有依赖关系和使用方法。
+
+## 有关项目结构的更多信息
+
+还有更多有用的目录和文件，比如[content](/docs/2.x/directory-structure/content), [layouts](/docs/2.x/directory-structure/layouts), [middleware](/docs/2.x/directory-structure/middleware), [modules](/docs/2.x/directory-structure/modules), [plugins](/docs/2.x/directory-structure/plugins) 和 [store](/docs/2.x/directory-structure/store)。由于它们对小型的应用来说并不是必需的，因此这里不介绍它们。
+
+<base-alert type="next">
+
+要详细了解所有有关目录的信息，请随时阅读[Directory Structure book](/docs/2.x/directory-structure/nuxt).
+
+</base-alert>

--- a/content/zh/guides/get-started/installation.md
+++ b/content/zh/guides/get-started/installation.md
@@ -1,0 +1,233 @@
+---
+title: 安装
+description: 在这，你将知道如何通过4个步骤来运行Nuxt.js项目。
+position: 1
+category: get-started
+csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/01_installation?fontsize=14&hidenavigation=1&theme=dark
+---
+
+## 准备工具
+
+- [node](https://nodejs.org) - 最低版本 v10.13，建议您安装最新的 LTS 版本。
+- IDE(文本编辑器)，建议使用 [VS Code](https://code.visualstudio.com/) 并配合[Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) 插件，或者使用[WebStorm](https://www.jetbrains.com/webstorm/)。
+- 终端，建议使用 VS Code 的 [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal)或者 [WebStorm terminal](https://www.jetbrains.com/help/webstorm/terminal-emulator.html)。
+
+## 用 create-nuxt-app 快速开启项目
+
+想要快速开启项目，你可以使用[create-nuxt-app](https://github.com/nuxt/create-nuxt-app)。
+
+确保你已安装 npx（自 NPM 5.2.0 起默认安装 npx）或 npm v6.1 或 yarn。
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn create nuxt-app <project-name>
+```
+
+  </code-block>
+  <code-block label="NPX">
+
+```bash
+npx create-nuxt-app <project-name>
+```
+
+  </code-block>
+    <code-block label="NPM">
+
+```bash
+npm init nuxt-app <project-name>
+```
+
+  </code-block>
+
+</code-group>
+
+启动项目后，将会提供给你一些启动选项，如（名称，Nuxt 选项，UI 框架，TypeScript，lint，测试框架等）。要了解有关所有选项的更多信息，请参阅 [Create Nuxt app](https://github.com/nuxt/create-nuxt-app/blob/master/README.md)。
+
+选择完所有选项后，将安装所有依赖项。安装完后，`cd`到项目文件夹下启动：
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+cd <project-name>
+yarn dev
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+cd <project-name>
+npm run dev
+```
+
+  </code-block>
+</code-group>
+
+项目现在运行在 [http://localhost:3000](http://localhost:3000)上，干的漂亮 XD！
+
+<base-alert type="info">
+
+使用 Nuxt.js 的另一种方法是使用[CodeSandbox](https://template.nuxtjs.org) ，这是一个可以快速使用 Nuxt.js 和/或与他人共享代码的好方法。
+
+</base-alert>
+
+## 手动安装
+
+从头开始创建 Nuxt.js 项目仅需要一个文件和一个目录。
+
+我们将使用终端创建目录和文件，并使用你选择的编辑器来创建它们。
+
+### 设置你的项目
+
+使用项目名称创建一个空目录，然后`cd`到目录内：
+
+```bash
+mkdir <project-name>
+cd <project-name>
+```
+
+_用你的项目名替换 `<project-name>`_
+
+创建`package.json`文件:
+
+```bash
+touch package.json
+```
+
+在你的`package.json`文件内写入:
+
+```json{}[package.json]
+{
+  "name": "my-app",
+  "scripts": {
+    "dev": "nuxt",
+    "build": "nuxt build",
+    "generate": "nuxt generate",
+    "start": "nuxt start"
+  }
+}
+```
+
+`scripts`定义了 Nuxt.js 命令，这些命令将通过命令 npm run <command>或 yarn <command>启动。
+
+#### **什么是 package.json 文件?**
+
+`package.json`像是你项目的 ID 卡，它包含了所有项目依赖项以及其他更多内容。 如果你不知道 package.json 文件是什么，我们强烈建议你先快速阅读 NPM 文档[NPM documentation](https://docs.npmjs.com/creating-a-package-json-file)。
+
+### 安装 Nuxt
+
+一旦创建了`package.json`，就可以通过`npm`或`yarn`将`Nuxt`添加到您的项目中，如下所示：
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn add nuxt
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+npm install nuxt
+```
+
+  </code-block>
+</code-group>
+
+此命令会将`nuxt`作为依赖项添加到项目里，并添加到`package.json`文件中。同时还将创建`node_modules`目录，该目录将存储所有已安装的软件包和依赖项。
+
+<base-alert type="info">
+
+`yarn.lock`或`package-lock.json`也将被一起创建，它们可以确保在项目中安装的 npm 包具有一致的安装和兼容依赖项。
+
+</base-alert>
+
+### 开始写你的第一个页面
+
+Nuxt.js 将`pages`目录中的每个`*.vue`文件转换为应用的路由。
+
+在你的项目中创建`page`目录：
+
+```bash
+mkdir pages
+```
+
+然后，在`pages`目录下创建`index.vue`文件。
+
+```bash
+touch pages/index.vue
+```
+
+将这个页面命名为`index.vue`是非常重要的，因为这将是打开 Nuxt 应用时显示的默认主页。
+
+在编辑器中打开`index.vue`文件并添加以下内容：
+
+```html{}[pages/index.vue]
+<template>
+  <h1>Hello world!</h1>
+</template>
+```
+
+### 运行项目
+
+通过在终端中输入以下命令（之一）来运行项目：
+
+<code-group>
+  <code-block label="Yarn" active>
+
+```bash
+yarn dev
+```
+
+  </code-block>
+  <code-block label="NPM">
+
+```bash
+npm run dev
+```
+
+  </code-block>
+</code-group>
+
+<base-alert type="info">
+
+使用`dev`命令，使应用运行在开发模式。
+
+</base-alert>
+
+现在项目运行在 **[http://localhost:3000](http://localhost:3000/).**
+
+打开你的浏览器，并在终端中点击链接，你就能看到我们在上一步中复制的文本“Hello World”。
+
+<base-alert type="info">
+
+在开发模式下启动 Nuxt.js 时，它将能监听大多数目录中的文件更改。因此，例如在启动时无需重新启动应用程序。
+如：添加新页面
+
+</base-alert>
+
+<base-alert type="warning">
+
+当运行 dev 命令时，将会创建.nuxt 文件夹。此文件夹应从版本控制中忽略。你可以通过在文件夹根目录创建`.gitignore`文件并添加.nuxt 来忽略文件。
+
+查看更多有关[.gitignore](https://git-scm.com/docs/gitignore)的信息。
+
+</base-alert>
+
+### 更进一步（Bonus step）
+
+在`pages`目录下，创建一个文件命名`fun.vue`。
+
+添加`<template></template>`标签并起一个有趣的标题。
+
+然后回到浏览器，并打开你的新页面 **[http://localhost:3000/fun](http://localhost:3000/fun).**
+
+<base-alert type="info">
+
+创建一个名为`more-fun`的目录，并将`index.vue`文件放入其中。这和创建`more-fun.vue`文件有一样的效果。
+
+</base-alert>

--- a/content/zh/guides/get-started/routing.md
+++ b/content/zh/guides/get-started/routing.md
@@ -1,0 +1,53 @@
+---
+title: 路由
+description: 大多数网站不会只有一页。 例如主页，关于页面，联系页面等。为了显示这些页面，我们需要一个路由来管理。
+position: 2
+category: get-started
+csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/02_routing?fontsize=14&hidenavigation=1&theme=dark
+---
+
+## 自动配置路由
+
+大多数网站会有多个页面（例如：主页，关于页面，联系页面等）。为了显示这些页面，我们需要一个路由来管理。这就是`vue-router`的来源。在使用 Vue 应用时，必须创建一个配置文件（即`router.js`）并将所有路由手动添加到里面。
+
+Nuxt.js 会根据`page`目录中的`.vue`文件自动生成`vue-router`配置。这意味着你无需再编写路由配置！ Nuxt.js 还为你提供了所有路由的自动代码拆分功能。
+
+换而言之，要在应用中使用路由，你要做的就是在`page`文件夹内创建`.vue`文件就行了。
+
+<base-alert type="next">
+
+了解更多有关[Routing](/docs/2.x/features/file-system-routing)
+
+</base-alert>
+
+## 导航
+
+要在应用的页面之间导航，你需要使用[NuxtLink](/docs/2.x/features/nuxt-components#the-nuxtlink-component)组件。该组件包含在 Nuxt.js 中，因此不必像使用其他组件那样引入它。 它类似于 HTML 的`<a>`标签，不同的是`nuxt`使用了`to="/about"`而不是使用`href="/about"`。如果你以前使用过`vue-router`，则可以用`<NuxtLink>`替换掉`<RouterLink>`。
+
+一个简单的例子，在`pages`文件夹内的`index.vue`文件使用`<NuxtLink>`跳转到主页
+
+```html{}[pages/index.vue]
+<template>
+  <NuxtLink to="/">Home page</NuxtLink>
+</template>
+```
+
+对于所有你站点内页面的链接，请使用`<NuxtLink>`。如果您有指向其他网站的链接，则应使用`<a>`标记。 参见以下示例：
+
+```html{}[pages/index.vue]
+<template>
+  <main>
+    <h1>Home page</h1>
+    <NuxtLink to="/about">
+      About (internal link that belongs to the Nuxt App)
+    </NuxtLink>
+    <a href="https://nuxtjs.org">External Link to another page</a>
+  </main>
+</template>
+```
+
+<base-alert type="next">
+
+了解更多有关 [NuxtLink component](/docs/2.x/features/nuxt-components#the-nuxtlink-component).
+
+</base-alert>

--- a/content/zh/guides/get-started/upgrading.md
+++ b/content/zh/guides/get-started/upgrading.md
@@ -1,0 +1,41 @@
+---
+title: 升级
+description: 升级Nuxt.js很快，但是更新package.json有点复杂。
+position: 6
+category: get-started
+---
+
+> 升级 Nuxt.js 很快，但是更新 package.json 有点复杂
+
+如果要升级到 Nuxt v2.14，并想使用静态托管，则需要在你的`nuxt.config. js`文件中添加[target:static](/docs/2.x/features/deployment-targets#static-hosting))，以使 generate 命令正常工作。
+
+```js{}[nuxt.config.js]
+export default {
+  target: 'static'
+}
+```
+
+## 开始升级
+
+查看发行说明中要升级的版本，以了解该特定版本是否还有其他说明。
+更新在 package.json 文件中为 nuxt 软件包指定的版本。
+完成此步骤后，说明会有所不同，具体取决于您使用的是 Yarn 还是 NPM。 Yarn 是与 Nuxt 一起使用的首选软件包管理器，因为它是针对测试编写的开发工具。
+
+1. 查看[release notes](/docs/release-notes)中要升级的版本，以了解该特定版本是否还有其他说明。
+2. 更新在`package.json`文件中为`nuxt`包指定的版本。
+
+完成此步骤后，说明会有所不同，具体取决于您使用的是 Yarn 还是 NPM。 _[Yarn](https://yarnpkg.com/en/docs/usage) 是与 Nuxt 一起使用的首选软件包管理器，因为它是针对测试编写的开发工具。_
+
+## Yarn
+
+3. 删除`yarn.lock`文件
+4. 删除`node_modules`文件夹
+5. 运行`yarn`命令
+6. 安装完成并运行测试后，也请考虑升级其他依赖项。可以使用`yarn outdated`命令。
+
+## NPM
+
+3. 删除`yarn.lock`文件
+4. 删除`node_modules`文件夹
+5. 运行`npm install`命令
+6. 安装完成并运行测试后，也请考虑升级其他依赖项。可以使用`npm outdated`命令。


### PR DESCRIPTION
Updated this part: get-started

📝 guides -> get-started
 - [x]  commands
 - [x]  conclusion.md
 - [x]  directory-structure.md
 - [x]  installation.md
 - [x]  routing.md
 - [x]  upgrading.md