### PR TITLE
docs(fr): Deleted duplicate installation methods

### DIFF
--- a/content/fr/guides/get-started/installation.md
+++ b/content/fr/guides/get-started/installation.md
@@ -12,11 +12,11 @@ csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/
 - Un éditeur de texte, nous recommandons [VSCode](https://code.visualstudio.com/) avec l'extension [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) ou [WebStorm](https://www.jetbrains.com/webstorm/)
 - Un terminal, nous vous recommandons d'utiliser [le terminal intégré de VSCode](https://code.visualstudio.com/docs/editor/integrated-terminal) ou le [terminal de Webstorm](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
-## En utilisant create-nuxt-app
+## Utiliser create-nuxt-app
 
-Pour commencer rapidement, vous pouvez utiliser [create-nuxt-app](https://github.com/nuxt/create-nuxt-app).
+Pour créer rapidement un nouveau projet, nous pouvons utiliser [create-nuxt-app](https://github.com/nuxt/create-nuxt-app).
 
-Assurez-vous que npx est installé (npx est livré par défaut depuis npm 5.2.0) ou npm v6.1 ou yarn.
+Il faut vérifier que `npx` est installé (npx est livré par défaut depuis npm v5.2.0) ou npm v6.1 ou yarn.
 
 <code-group>
   <code-block label="Yarn" active>
@@ -43,9 +43,9 @@ npm init nuxt-app <project-name>
 
 </code-group>
 
-Il vous posera quelques questions (nom, options Nuxt, framework UI, TypeScript, linter, framework de test, etc). Pour en savoir plus sur toutes les options voir [Create Nuxt app](https://github.com/nuxt/create-nuxt-app/blob/master/README.md).
+Quelques questions nous seront posées (nom, options Nuxt, framework UI, TypeScript, linter, framework de test, etc.). Pour en savoir plus sur toutes les options voir [Create Nuxt App](https://github.com/nuxt/create-nuxt-app/blob/master/README.md).
 
-Une fois toutes les questions répondues, il installera toutes les dépendances. L'étape suivante consiste à accéder au dossier du projet et à le lancer :
+Quand on y aura répondu, toutes les dépendances seront installées. La prochaine étape est de naviguer dans le répertoire et de démarrer notre application:
 
 <code-group>
   <code-block label="Yarn" active>
@@ -66,7 +66,7 @@ npm run dev
   </code-block>
 </code-group>
 
-L'application s'exécute maintenant sur [http://localhost:3000](http://localhost:3000). Well done!
+Notre application est maintenant en cours d'exécution sur [http://localhost:3000](http://localhost:3000).
 
 <base-alert type="info">
 
@@ -232,57 +232,3 @@ Si nous créons un répertoire nommé `more-fun` et ajoutons un fichier `index.v
 <app-modal>
   <code-sandbox :src="csb_link"></code-sandbox>
 </app-modal>
-
-## Utiliser create-nuxt-app
-
-Pour créer rapidement un nouveau projet, nous pouvons utiliser [create-nuxt-app](https://github.com/nuxt/create-nuxt-app).
-
-Il faut vérifier que `npx` est installé (npx est embarqué par défaut depuis npm v5.2.0) ou npm v6.1 ou yarn.
-
-<code-group>
-  <code-block label="Yarn" active>
-
-```bash
-yarn create nuxt-app <project-name>
-```
-
-  </code-block>
-  <code-block label="npx">
-
-```bash
-npx create-nuxt-app <project-name>
-```
-
-  </code-block>
-    <code-block label="npm">
-
-```bash
-npm init nuxt-app <project-name>
-```
-
-  </code-block>
-
-</code-group>
-
-Quelques questions nous seront posées (nom, options Nuxt, framework UI, TypeScript, linter, framework de test, etc.), quand on y aura répondu, toutes les dépendances seront installées. La prochaine étape est de naviguer dans le répertoire et de démarrer notre application:
-
-<code-group>
-  <code-block label="Yarn" active>
-
-```bash
-cd <project-name>
-yarn dev
-```
-
-  </code-block>
-  <code-block label="npm">
-
-```bash
-cd <project-name>
-npm run dev
-```
-
-  </code-block>
-</code-group>
-
-Notre application est maintenant en cours d'exécution sur [http://localhost:3000](http://localhost:3000).


### PR DESCRIPTION
There were two exact same installation methods using create-nuxt-app. Last one looking a bit better so I replaced the first one with it.