### PR TITLE
ci: fix cypress tests (add trailing slash)

### DIFF
--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -6,7 +6,7 @@ describe('The Home Page links', () => {
     cy.get('a[data-cy="get-started"]')
       .click()
     cy.url().should('include', '/docs/2.x/get-started/installation')
-    cy.visit('/docs/2.x/get-started/installation')
+    cy.visit('/docs/2.x/get-started/installation/')
   })
 
   it('github stars links to the right page', () => {
@@ -36,7 +36,7 @@ describe('The Home Page links', () => {
   it('checks to see if the sponsor button links to the sponsor page', () => {
     cy.get('a[data-cy="sponsors"]').click()
     cy.url().should('include', '/sponsor-nuxtjs')
-    cy.visit('/sponsor-nuxtjs')
+    cy.visit('/sponsor-nuxtjs/')
   })
 
 

--- a/cypress/integration/modal-image.spec.js
+++ b/cypress/integration/modal-image.spec.js
@@ -1,6 +1,6 @@
 describe('It checks to see if the modals works', () => {
   it('successfully opens checks for image and closes the image modal', () => {
-    cy.visit('/docs/2.x/concepts/context-helpers')
+    cy.visit('/docs/2.x/concepts/context-helpers/')
     cy.get('[data-cy="modal-image"]').click({ force: true })
     cy.get('[data-cy="modal-open"]')
       .should('be.visible')

--- a/cypress/integration/prev-next.spec.js
+++ b/cypress/integration/prev-next.spec.js
@@ -1,6 +1,6 @@
 describe('It checks to see if prev and next work for the guides ', () => {
   beforeEach(() => {
-    cy.visit('/docs/2.x/get-started/routing')
+    cy.visit('/docs/2.x/get-started/routing/')
   })
   it('checks the previous link', () => {
     cy.get('[data-cy="prev"]').click()

--- a/cypress/integration/toc.spec.js
+++ b/cypress/integration/toc.spec.js
@@ -1,6 +1,6 @@
 describe('It checks to see if the toc at top of guides works ', () => {
   beforeEach(() => {
-    cy.visit('/docs/2.x/get-started/installation')
+    cy.visit('/docs/2.x/get-started/installation/')
   })
   it('checks the table of contents anchor', () => {
     cy.get('[data-cy="toc"]').first().click()


### PR DESCRIPTION
(Trailing slash behaviour for local `nuxt start` changed in https://github.com/nuxt/nuxt.js/pull/8398.)

closes #1171