### PR TITLE
docs: update runtimeConfig example to show dynamic baseURL

### DIFF
--- a/content/en/blog/moving-from-nuxtjs-dotenv-to-runtime-config.md
+++ b/content/en/blog/moving-from-nuxtjs-dotenv-to-runtime-config.md
@@ -107,7 +107,7 @@ Also this can be a better replacement for `.env.example` and the default values 
 ```js{}[nuxt.config.js]
 export default {
   publicRuntimeConfig: {
-    baseURL: 'https://dev.nuxtjs.org' || 'https://nuxtjs.org'
+    baseURL: process.env.NODE_ENV === production ? 'https://nuxtjs.org' : 'https://dev.nuxtjs.org'
   }
 }
 ```

--- a/content/en/blog/moving-from-nuxtjs-dotenv-to-runtime-config.md
+++ b/content/en/blog/moving-from-nuxtjs-dotenv-to-runtime-config.md
@@ -107,7 +107,7 @@ Also this can be a better replacement for `.env.example` and the default values 
 ```js{}[nuxt.config.js]
 export default {
   publicRuntimeConfig: {
-    baseURL: process.env.NODE_ENV === production ? 'https://nuxtjs.org' : 'https://dev.nuxtjs.org'
+    baseURL: process.env.NODE_ENV === 'production' ? 'https://nuxtjs.org' : 'https://dev.nuxtjs.org'
   }
 }
 ```


### PR DESCRIPTION
I may be missing something, but a boolean expression with 2 strings doesn't make a lot of sense, does it? My best guess (and @danielroe in the nuxt discord) was that this example wants to provide different urls depending of production-env or not. Then again why mentioning `.env.example` in the first place? 

So basically this PR is not inteded to provide the best solution, but more to start a conversation.