### PR TITLE
Add note about ERR_REDIRECT to the docs

### DIFF
--- a/content/en/guides/internals-glossary/context.md
+++ b/content/en/guides/internals-glossary/context.md
@@ -115,9 +115,9 @@ A valid workaround would be using `window.onNuxtReady(() => { window.$nuxt.$rout
 
 <base-alert type="info>
 
-A client-side call to `redirect` always throws the error `ERR_REDIRECT`. This is to block Nuxt from doing any tasks between the time redirect call happens until browser starts navigation.
+A client-side call to `redirect` always throws the error `ERR_REDIRECT`. This is to block Nuxt from doing any tasks between the time redirect call happens until the browser starts navigation.
 
-To avoid an unexpected flash of an error page after this call, make sure to return the `redirect()` call when used in `asyncData()`. This will gracefully handle the default error. See [issue 8594](https://github.com/nuxt/nuxt.js/issues/8594#issuecomment-754120298).
+To avoid an unexpected flash of an error page, make sure to return the `redirect()` when used in `asyncData()`. This will gracefully handle the error. See [issue 8594](https://github.com/nuxt/nuxt.js/issues/8594#issuecomment-754120298).
 
 </base-alert>
 

--- a/content/en/guides/internals-glossary/context.md
+++ b/content/en/guides/internals-glossary/context.md
@@ -113,7 +113,7 @@ A valid workaround would be using `window.onNuxtReady(() => { window.$nuxt.$rout
 
 </base-alert>
 
-<base-alert type="info>
+<base-alert type="info">
 
 A client-side call to `redirect` always throws the error `ERR_REDIRECT`. This is to block Nuxt from doing any tasks between the time redirect call happens until the browser starts navigation.
 

--- a/content/en/guides/internals-glossary/context.md
+++ b/content/en/guides/internals-glossary/context.md
@@ -113,6 +113,14 @@ A valid workaround would be using `window.onNuxtReady(() => { window.$nuxt.$rout
 
 </base-alert>
 
+<base-alert type="info>
+
+A client-side call to `redirect` always throws the error `ERR_REDIRECT`. This is to block Nuxt from doing any tasks between the time redirect call happens until browser starts navigation.
+
+To avoid an unexpected flash of an error page after this call, make sure to return the `redirect()` call when used in `asyncData()`. This will gracefully handle the default error. See [issue 8594](https://github.com/nuxt/nuxt.js/issues/8594#issuecomment-754120298).
+
+</base-alert>
+
 ### error
 
 `error` (_Function_)


### PR DESCRIPTION
See this issue https://github.com/nuxt/nuxt.js/issues/8594 where I pointed out that throwing `ERR_REDIRECT` was not intuitive behavior. This documentation update should help to explain why this happens, and how to avoid issues with it.

Feel free to squash this if you decide to add it. The last 2 commits are typo fixes.