### PR TITLE
Added just a small info tab about global CSS files

### DIFF
--- a/content/en/guides/directory-structure/assets.md
+++ b/content/en/guides/directory-structure/assets.md
@@ -157,6 +157,7 @@ You can use local fonts by adding them to your assets folder. Once they have bee
   src: url('~assets/fonts/DMSans-Bold.ttf') format('truetype');
 }
 ```
+<base-alert type="info">CSS files are not automatically loaded. Add them using the [CSS config property](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-css/).</base-alert>
 
 <base-alert type="next">
 


### PR DESCRIPTION
Nuxt makes most of the things automatically so I was thinking that people may think that global CSS files are loaded automatically. Which is not true. This makes it clear.