### PR TITLE
Fix alias typo

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-alias.md
+++ b/content/en/guides/configuration-glossary/configuration-alias.md
@@ -29,7 +29,7 @@ export default {
   alias: {
     'images': resolve(__dirname, './assets/images'),
     'style': resolve(__dirname, './assets/style'),
-    'data': resolve(__dirname, './assets/other/data)'
+    'data': resolve(__dirname, './assets/other/data')
   }
 }
 ```


### PR DESCRIPTION
'data': resolve(__dirname, './assets/other/data') should be 'data': resolve(__dirname, './assets/other/data)'
We should swap the position of the single quotation mark and closing parenthesis in the end