### PR TITLE
docs(id): translate internals glossary to Indonesian

### DIFF
--- a/content/id/guides/internals-glossary/$nuxt.md
+++ b/content/id/guides/internals-glossary/$nuxt.md
@@ -20,7 +20,7 @@ Untuk mempelajari lebih lanjut mengenai pembantu Nuxt.js lihat [bagian context a
 ```html{}[layouts/default.vue]
 <template>
   <div>
-    <div v-if="$nuxt.isOffline">You are offline</div>
+    <div v-if="$nuxt.isOffline">Anda sedang offline</div>
     <nuxt />
   </div>
 </template>
@@ -29,7 +29,7 @@ Untuk mempelajari lebih lanjut mengenai pembantu Nuxt.js lihat [bagian context a
 ## Menyegarkan data halaman
 
 - `refresh()`
-  - Jika Anda hanya ingin menyegarkan data yang disediakan oleh asyncData atau fetch
+  - Jika Anda hanya ingin menyegarkan data yang disediakan oleh `asyncData` atau `fetch`
 
 ```html{}[example.vue]
 <template>

--- a/content/id/guides/internals-glossary/$nuxt.md
+++ b/content/id/guides/internals-glossary/$nuxt.md
@@ -1,0 +1,70 @@
+---
+title: '$nuxt: Pembantu Nuxt.js'
+description: $nuxt adalah pembantu yang dirancang untuk meningkatkan pengalaman pengguna.
+category: internals-glossary
+position: 2
+---
+
+`$nuxt` adalah pembantu yang dirancang untuk meningkatkan pengalaman pengguna.
+Untuk mempelajari lebih lanjut mengenai pembantu Nuxt.js lihat [bagian context and helpers dalam bab Konsep](/docs/2.x/concepts/context-helpers#nuxt-the-nuxtjs-helper)
+
+## Pemeriksa koneksi
+
+- `isOffline`
+  - Tipe: `Boolean`
+  - Deskripsi: `true` saat koneksi internet pengguna menjadi offline
+- `isOnline`
+  - Tipe: `Boolean`
+  - Deskripsi: Kebalikan dari `isOffline`
+
+```html{}[layouts/default.vue]
+<template>
+  <div>
+    <div v-if="$nuxt.isOffline">You are offline</div>
+    <nuxt />
+  </div>
+</template>
+```
+
+## Menyegarkan data halaman
+
+- `refresh()`
+  - Jika Anda hanya ingin menyegarkan data yang disediakan oleh asyncData atau fetch
+
+```html{}[example.vue]
+<template>
+  <div>
+    <div>{{ content }}</div>
+    <button @click="refresh">Refresh</button>
+  </div>
+</template>
+
+<script>
+  export default {
+    asyncData() {
+      return { content: 'Created at: ' + new Date() }
+    },
+    methods: {
+      refresh() {
+        this.$nuxt.refresh()
+      }
+    }
+  }
+</script>
+```
+
+## Mengontrol loading bar
+
+- `$loading`
+  - Jika Anda ingin mengontrol _loading bar_ Nuxt secara terprogram
+
+```js{}[]
+export default {
+  mounted() {
+    this.$nextTick(() => {
+      this.$nuxt.$loading.start()
+      setTimeout(() => this.$nuxt.$loading.finish(), 500)
+    })
+  }
+}
+```

--- a/content/id/guides/internals-glossary/context.md
+++ b/content/id/guides/internals-glossary/context.md
@@ -1,0 +1,164 @@
+---
+title: 'The Context'
+description: `context` menyediakan objek/parameter tambahan dari Nuxt yang biasanya tidak tersedia untuk komponen Vue. `context` tersedia di lifecycle Nuxt khusus seperti `asyncData`, `plugins`, `middlewares`, `modules`, dan `store/nuxtServerInit`.
+menu: The Context
+category: internals-glossary
+position: 1
+---
+
+`context` menyediakan objek/parameter tambahan dari Nuxt untuk komponen Vue dan tersedia di _lifecycle_ Nuxt khusus seperti [`asyncData`](/docs/2.x/features/data-fetching#async-data), [`fetch`](/docs/2.x/features/data-fetching), [`plugins`](/docs/2.x/directory-structure/plugins), [`middleware`](/docs/2.x/directory-structure/middleware#router-middleware) dan [`nuxtServerInit`](/docs/2.x/directory-structure/store#the-nuxtserverinit-action).
+
+> _Catatan: "Context" yang kami rujuk di sini jangan sampai tertukar dengan objek `context` yang tersedia di [`Vuex Actions`](https://vuex.vuejs.org/guide/actions.html). Keduanya tidak berhubungan._
+
+```js
+function (context) {
+  // Kunci universal
+  const {
+    app,
+    store,
+    route,
+    params,
+    query,
+    env,
+    isDev,
+    isHMR,
+    redirect,
+    error,
+    $config
+  } = context
+  // Sisi server
+  if (process.server) {
+    const { req, res, beforeNuxtRender } = context
+  }
+  // Sisi pengguna
+  if (process.client) {
+    const { from, nuxtState } = context
+  }
+}
+```
+
+## Universal keys
+
+Kunci-kunci ini tersedia di sisi pengguna dan sisi server.
+
+### app
+
+`app` (_NuxtAppOptions_)
+
+Opsi _root instance_ Vue yang menyertakan semua _plugin_ Anda. Misalnya, saat menggunakan `i18n`, anda dapat mengakses `$i18n` melalui `context.app.i18n`.
+
+### store
+
+`store` ([_Vuex Store_](https://vuex.vuejs.org/api/#vuex-store-instance-properties))
+
+_Instance_ Vuex Store. **Hanya tersedia apabila [vuex store](/docs/2.x/directory-structure/store) telah diatur**.
+
+### route
+
+`route` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+
+_Instance_ rute Vue Router.
+
+### params
+
+`params` (_Object_)
+
+Alias dari `route.params`.
+
+### query
+
+`query` (_Object_)
+
+Alias dari `route.query`.
+
+### env
+
+`env` (_Object_)
+
+_Environment variables_ yang diatur di `nuxt.config.js`, lihat [env API](/docs/2.x/configuration-glossary/configuration-env).
+
+### isDev
+
+`isDev` (_Boolean_)
+
+Boolean yang memberi tahu Anda jika Anda berada di mode pengembang, berguna untuk _caching_ beberapa data dalam produksi.
+
+### isHMR
+
+`isHMR` (_Boolean_)
+
+Boolean yang memberi tahu Anda jika metode/_middleware_ dipanggil dari _hot module replacement_ webpack (_bernilai true hanya di sisi pengguna dalam mode pengembang_).
+
+### redirect
+
+`redirect` (_Function_)
+
+Gunakan metode ini untuk mengarahkan penggunake rute lain, kode statusnya digunakan di sisi server, secara _default_ `302`. `redirect([status,] path [, query])`.
+
+Contoh:
+
+```js{}[]
+redirect(302, '/login')
+redirect({ name: 'slug', params: { slug: mySlug } })
+redirect('https://vuejs.org')
+```
+
+Lihat [dokumen Vue Router](https://github.com/vuejs/vue-router/blob/64d60c01920405f0b93e00a401c73868b08ee6e5/types/router.d.ts#L161-L169) info lebih lanjut mengenai properti `Location`.
+
+<base-alert type="info">
+
+`redirect` atau `error` tidak mungkin untuk digunakan di [client-side Nuxt plugin](/docs/2.x/directory-structure/plugins#client-or-server-side-only) karena kesalahan pada _hydration_ (konten pengguna akan berbeda dari yang diharapkan dari server).
+
+Solusi yang benar adalah dengan menggunakan `window.onNuxtReady(() => { window.$nuxt.$router.push('/your-route') })`
+
+</base-alert>
+
+### error
+
+`error` (_Function_)
+
+Gunakan metode ini untuk menampilkan halaman kesalahan: `error(params)`. `params` harus memiliki properti `statusCode` dan `message`.
+
+### `$config`
+
+`$config` (_Object_)
+
+[Runtime config](/docs/2.x/configuration-glossary/configuration-runtime-config) yang sebenarnya.
+
+## Server-side keys
+
+Kunci-kunci ini hanya tersedia di sisi server.
+
+### req
+
+`req` ([_http.Request_](https://nodejs.org/api/http.html#http_class_http_incomingmessage))
+
+Permintaan dari server Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _request_ dapat berbeda bergantung pada _framework_ yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
+
+### Res
+
+`res` ([_http.Response_](https://nodejs.org/api/http.html#http_class_http_serverresponse))
+
+Tanggapan dari server Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _response_ dapat berbeda bergantung pada _framework_ yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
+
+### beforeNuxtRender
+
+`beforeNuxtRender(fn)` (_Function_)
+
+Gunakan metode ini untuk memperbarui variabel `__NUXT__` yang dimuat di sisi pengguna, `fn` (dapat secara asinkron) dipanggil dengan `{ Components, nuxtState }`, lihat [contoh](https://github.com/nuxt/nuxt.js/blob/cf6b0df45f678c5ac35535d49710c606ab34787d/test/fixtures/basic/pages/special-state.vue).
+
+## Client-side keys
+
+Kunci-kunci ini hanya tersedia di sisi pengguna.
+
+### from
+
+`from` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+
+Dari mana rute berasal.
+
+### nuxtState
+
+`nuxtState` _(Object)_
+
+Keadaan Nuxt, berguna untuk _plugin_ yang menggunakan `beforeNuxtRender` untuk mendapatkan keadaan Nuxt pada sisi pengguna sebelum _hydration_. **Hanya tersedia dalam mode `universal`**.

--- a/content/id/guides/internals-glossary/context.md
+++ b/content/id/guides/internals-glossary/context.md
@@ -93,7 +93,7 @@ Boolean yang memberi tahu Anda jika metode/_middleware_ dipanggil dari _hot modu
 
 `redirect` (_Function_)
 
-Gunakan metode ini untuk mengarahkan penggunake rute lain, kode statusnya digunakan di sisi server, secara _default_ `302`. `redirect([status,] path [, query])`.
+Gunakan metode ini untuk mengarahkan pengguna ke rute lain, kode statusnya digunakan di sisi peladen, secara bawaan `302`. `redirect([status,] path [, query])`.
 
 Contoh:
 
@@ -133,13 +133,13 @@ Kunci-kunci ini hanya tersedia di sisi server.
 
 `req` ([_http.Request_](https://nodejs.org/api/http.html#http_class_http_incomingmessage))
 
-Permintaan dari server Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _request_ dapat berbeda bergantung pada _framework_ yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
+Permintaan dari server Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _request_ dapat berbeda bergantung pada kerangka kerja yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
 
 ### Res
 
 `res` ([_http.Response_](https://nodejs.org/api/http.html#http_class_http_serverresponse))
 
-Tanggapan dari server Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _response_ dapat berbeda bergantung pada _framework_ yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
+Tanggapan dari server Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _response_ dapat berbeda bergantung pada kerangka kerja yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
 
 ### beforeNuxtRender
 

--- a/content/id/guides/internals-glossary/context.md
+++ b/content/id/guides/internals-glossary/context.md
@@ -26,7 +26,7 @@ function (context) {
     error,
     $config
   } = context
-  // Sisi server
+  // Sisi peladen
   if (process.server) {
     const { req, res, beforeNuxtRender } = context
   }
@@ -39,7 +39,7 @@ function (context) {
 
 ## Universal keys
 
-Kunci-kunci ini tersedia di sisi pengguna dan sisi server.
+Kunci-kunci ini tersedia di sisi pengguna dan sisi peladen.
 
 ### app
 
@@ -107,7 +107,7 @@ Lihat [dokumen Vue Router](https://github.com/vuejs/vue-router/blob/64d60c019204
 
 <base-alert type="info">
 
-`redirect` atau `error` tidak mungkin untuk digunakan di [client-side Nuxt plugin](/docs/2.x/directory-structure/plugins#client-or-server-side-only) karena kesalahan pada _hydration_ (konten pengguna akan berbeda dari yang diharapkan dari server).
+`redirect` atau `error` tidak mungkin untuk digunakan di [client-side Nuxt plugin](/docs/2.x/directory-structure/plugins#client-or-server-side-only) karena kesalahan pada _hydration_ (konten pengguna akan berbeda dari yang diharapkan dari peladen).
 
 Solusi yang benar adalah dengan menggunakan `window.onNuxtReady(() => { window.$nuxt.$router.push('/your-route') })`
 
@@ -127,19 +127,19 @@ Gunakan metode ini untuk menampilkan halaman kesalahan: `error(params)`. `params
 
 ## Server-side keys
 
-Kunci-kunci ini hanya tersedia di sisi server.
+Kunci-kunci ini hanya tersedia di sisi peladen.
 
 ### req
 
 `req` ([_http.Request_](https://nodejs.org/api/http.html#http_class_http_incomingmessage))
 
-Permintaan dari server Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _request_ dapat berbeda bergantung pada kerangka kerja yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
+Permintaan dari peladen Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _request_ dapat berbeda bergantung pada kerangka kerja yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
 
 ### Res
 
 `res` ([_http.Response_](https://nodejs.org/api/http.html#http_class_http_serverresponse))
 
-Tanggapan dari server Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _response_ dapat berbeda bergantung pada kerangka kerja yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
+Tanggapan dari peladen Node.js. Apabila Nuxt digunakan sebagai _middleware_, objek _response_ dapat berbeda bergantung pada kerangka kerja yang Anda gunakan.<br>**Tidak tersedia melalui `nuxt generate`**.
 
 ### beforeNuxtRender
 

--- a/content/id/guides/internals-glossary/internals-module-container.md
+++ b/content/id/guides/internals-glossary/internals-module-container.md
@@ -62,12 +62,12 @@ Mendaftarkan plugin menggunakan `addTemplate` dan menambahkannya ke larik `plugi
 ```js
 this.addPlugin({
   src: path.resolve(__dirname, 'templates/foo.js'),
-  fileName: 'foo.server.js' // [opsional] hanya sertakan di bundel server
+  fileName: 'foo.server.js' // [opsional] hanya sertakan di bundel peladen
   options: moduleOptions
 })
 ```
 
-**Catatan:** Anda dapat menggunakan _modifiers_ `mode` atau `.client` dan `.server` dengan opsi `fileName` untuk menggunakan plugin hanya di sisi pengguna atau server. (Lihat [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin) untuk semua opsi yang tersedia)
+**Catatan:** Anda dapat menggunakan _modifiers_ `mode` atau `.client` dan `.server` dengan opsi `fileName` untuk menggunakan plugin hanya di sisi pengguna atau peladen. (Lihat [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin) untuk semua opsi yang tersedia)
 
 Jika Anda menentukan `fileName`, Anda juga dapat mengonfigurasi _path_ untuk `fileName`, sehingga Anda dapat memilih struktur direktori di dalam direktori `.nuxt` untuk mencegah nama yang sama:
 

--- a/content/id/guides/internals-glossary/internals-module-container.md
+++ b/content/id/guides/internals-glossary/internals-module-container.md
@@ -1,0 +1,111 @@
+---
+title: 'Kelas ModuleContainer'
+description: Kelas ModuleContainer Nuxt
+menu: Module Container
+category: internals-glossary
+position: 6
+---
+
+- Sumber: **[core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/module.js)**
+
+Semua [modul](/docs/2.x/directory-structure/modules) akan dipanggil di dalam konteks _instance_ `ModuleContainer`.
+
+## Tapable plugins
+
+Anda dapat mendaftarkan _hooks_ pada siklus hidup Nuxt tertentu.
+
+```js
+nuxt.moduleContainer.plugin('ready', async moduleContainer => {
+  // Lakukan ini setelah semua modul sudah siap
+})
+```
+
+Di dalam konteks [modul](/docs/2.x/directory-structure/modules) Anda dapat menggunakan ini sebagai gantinya:
+
+```js
+this.plugin('ready', async moduleContainer => {
+  // Lakukan ini setelah semua modul sudah siap
+})
+```
+
+| Plugin  | Argumen       | Kapan                                                 |
+| ------- | --------------- | ---------------------------------------------------- |
+| `ready` | moduleContainer | Semua modul di `nuxt.config.js` telah diinisialisasi |
+
+## Metode
+
+### addVendor (vendor)
+
+**Tidak berlaku karena `vendor` tidak digunakan lagi**
+
+Menambahkan ke `options.build.vendor` dan menerapkan filter unik.
+
+### addTemplate (template)
+
+- **template**: `String` atau `Object`
+  - `src`
+  - `options`
+  - `fileName`
+
+Memuat template yang diberikan menggunakan [template lodash](https://lodash.com/docs/4.17.4#template) saat membangun ke `buildDir` proyek (`.nuxt`).
+
+Jika `fileName` tidak tersedia atau `template` adalah string, nama berkas target diubah secara default ke `[dirName].[fileName].[pathHash].[ext]`.
+
+Metode ini mengembalikan objek _final_ `{ dst, src, options }`.
+
+### addPlugin (template)
+
+- **template**: Properti objek (`src`, `options`, `fileName`, `mode`).
+
+Mendaftarkan plugin menggunakan `addTemplate` dan menambahkannya ke _array_ `plugins[]`.
+
+```js
+this.addPlugin({
+  src: path.resolve(__dirname, 'templates/foo.js'),
+  fileName: 'foo.server.js' // [opsional] hanya sertakan di bundel server
+  options: moduleOptions
+})
+```
+
+**Catatan:** Anda dapat menggunakan _modifiers_ `mode` atau `.client` dan `.server` dengan opsi `fileName` untuk menggunakan plugin hanya di sisi pengguna atau server. (Lihat [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin) untuk semua opsi yang tersedia)
+
+Jika Anda menentukan `fileName`, Anda juga dapat mengonfigurasi _path_ untuk `fileName`, sehingga Anda dapat memilih struktur folder di dalam folder `.nuxt` folder untuk mencegah nama yang sama:
+
+```js
+{
+  fileName: path.join('folder', 'foo.client.js'), // akan menghasilkan `.nuxt/folder/foo.client.js`
+}
+```
+
+### addServerMiddleware (middleware)
+
+Mendorong _middleware_ ke [options.serverMiddleware](/docs/2.x/configuration-glossary/configuration-servermiddleware).
+
+### extendBuild (fn)
+
+Mempermudah perluasan _build config_ webpack dengan merangkai fungsi [options.build.extend](/docs/2.x/configuration-glossary/configuration-build#extend).
+
+### extendRoutes (fn)
+
+Mempermudah perluasan rute dengan merangkai fungsi [options.build.extendRoutes](/docs/2.x/configuration-glossary/configuration-router#extendroutes).
+
+### addModule (moduleOpts, requireOnce)
+
+Fungsi asinkron
+
+Mendaftarkan modul. `moduleOpts` dapat berupa _string_ atau _array_ (`[src, options]`). Jika `requireOnce` adalah `true` dan modul menghasilkan `meta`, itu mencegah pendaftaran modul yang sama dua kali.
+
+### requireModule (moduleOpts)
+
+Fungsi asinkron
+
+Jalan pintas untuk `addModule(moduleOpts, true)`
+
+## Hooks
+
+Anda dapat mendaftarkan _hooks_ pada siklus hidup Nuxt tertentu.
+
+| Hook             | Argumen                  | Kapan                                                                                  |
+| ---------------- | -------------------------- | ------------------------------------------------------------------------------------- |
+| `modules:before` | (moduleContainer, options) | Dipanggil sebelum membuat kelas ModuleContainer, berguna untuk meng-_overload_ metode dan opsi. |
+| `modules:done`   | (moduleContainer)          | Dipanggil setelah semua modul dimuat.                                             |

--- a/content/id/guides/internals-glossary/internals-module-container.md
+++ b/content/id/guides/internals-glossary/internals-module-container.md
@@ -47,9 +47,9 @@ Menambahkan ke `options.build.vendor` dan menerapkan filter unik.
   - `options`
   - `fileName`
 
-Memuat template yang diberikan menggunakan [template lodash](https://lodash.com/docs/4.17.4#template) saat membangun ke `buildDir` proyek (`.nuxt`).
+Memuat templat yang diberikan menggunakan [templat lodash](https://lodash.com/docs/4.17.4#template) saat membangun ke `buildDir` proyek (`.nuxt`).
 
-Jika `fileName` tidak tersedia atau `template` adalah string, nama berkas target diubah secara default ke `[dirName].[fileName].[pathHash].[ext]`.
+Jika `fileName` tidak tersedia atau `template` adalah _string_, nama berkas target diubah secara bawaan ke `[dirName].[fileName].[pathHash].[ext]`.
 
 Metode ini mengembalikan objek _final_ `{ dst, src, options }`.
 
@@ -57,7 +57,7 @@ Metode ini mengembalikan objek _final_ `{ dst, src, options }`.
 
 - **template**: Properti objek (`src`, `options`, `fileName`, `mode`).
 
-Mendaftarkan plugin menggunakan `addTemplate` dan menambahkannya ke _array_ `plugins[]`.
+Mendaftarkan plugin menggunakan `addTemplate` dan menambahkannya ke larik `plugins[]`.
 
 ```js
 this.addPlugin({
@@ -69,7 +69,7 @@ this.addPlugin({
 
 **Catatan:** Anda dapat menggunakan _modifiers_ `mode` atau `.client` dan `.server` dengan opsi `fileName` untuk menggunakan plugin hanya di sisi pengguna atau server. (Lihat [plugins](/docs/2.x/directory-structure/plugins#name-conventional-plugin) untuk semua opsi yang tersedia)
 
-Jika Anda menentukan `fileName`, Anda juga dapat mengonfigurasi _path_ untuk `fileName`, sehingga Anda dapat memilih struktur folder di dalam folder `.nuxt` folder untuk mencegah nama yang sama:
+Jika Anda menentukan `fileName`, Anda juga dapat mengonfigurasi _path_ untuk `fileName`, sehingga Anda dapat memilih struktur direktori di dalam direktori `.nuxt` untuk mencegah nama yang sama:
 
 ```js
 {

--- a/content/id/guides/internals-glossary/internals-nuxt.md
+++ b/content/id/guides/internals-glossary/internals-nuxt.md
@@ -1,0 +1,28 @@
+---
+title: 'Kelas Nuxt'
+description: Kelas Inti Nuxt
+menu: Kelas Nuxt
+category: internals-glossary
+position: 4
+---
+
+- Sumber: **[core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)**
+
+Ini adalah wadah inti yang memungkinkan semua modul dan kelas berkomunikasi satu sama lain. Semua modul memiliki akses ke _instance_ Nuxt dengan menggunakan `this.nuxt`.
+
+## Hooks
+
+Anda dapat mendaftarkan _hook_ pada _life cycle_ tertentu.
+
+```js
+nuxt.hook('ready', async nuxt => {
+  // Kode Anda
+})
+```
+
+| Plugin | Argumen | Kapan |
+| --- | --- | --- |
+| `ready` | (nuxt) | Nuxt siap bekerja (`ModuleContainer` dan `Renderer` sudah siap). |
+| `error` | (error) | Kesalahan yang tidak teratasi saat memanggil _hook_. |
+| `close` | (nuxt) | _Instance_ Nuxt ditutup dengan baik. |
+| `listen` | (server, {host, port}) | Server **internal** Nuxt mulai berjalan. (Menggunakan `nuxt start` atau `nuxt dev`). |

--- a/content/id/guides/internals-glossary/internals-nuxt.md
+++ b/content/id/guides/internals-glossary/internals-nuxt.md
@@ -25,4 +25,4 @@ nuxt.hook('ready', async nuxt => {
 | `ready` | (nuxt) | Nuxt siap bekerja (`ModuleContainer` dan `Renderer` sudah siap). |
 | `error` | (error) | Kesalahan yang tidak teratasi saat memanggil _hook_. |
 | `close` | (nuxt) | _Instance_ Nuxt ditutup dengan baik. |
-| `listen` | (server, {host, port}) | Server **internal** Nuxt mulai berjalan. (Menggunakan `nuxt start` atau `nuxt dev`). |
+| `listen` | (server, {host, port}) | Peladen **internal** Nuxt mulai berjalan. (Menggunakan `nuxt start` atau `nuxt dev`). |

--- a/content/id/guides/internals-glossary/internals-renderer.md
+++ b/content/id/guides/internals-glossary/internals-renderer.md
@@ -1,0 +1,27 @@
+---
+title: 'Kelas Renderer'
+description: Kelas Renderer Nuxt
+menu: Renderer
+category: internals-glossary
+position: 5
+---
+
+- Sumber: **[vue-renderer/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-renderer/src/renderer.js)**
+
+Kelas ini mengekspor _middleware connect_ yang menangani dan melayani semua permintaan SSR dan aset.
+
+## Hooks
+
+Anda dapat mendaftarkan _hook_ pada _life cycle_ tertentu.
+
+
+| Hook | Argumen | Kapan |
+| --- | --- | --- |
+| `render:before` | (renderer, options) | Sebelum menyiapkan _middleware_ dan sumber daya untuk kelas _Renderer_, berguna untuk _overload_ beberapa metode dan opsi. |
+| `render:setupMiddleware` | (app) _connect instance_ | Sebelum Nuxt menambahkan _middleware_-nya. Anda dapat menggunakannya untuk mendaftarkan _middleware_ pada sisi server. |
+| `render:errorMiddleware` | (app) _connect instance_ | Sebelum menambahkan _middleware_ galat Nuxt, berguna untuk menambahkan _middleware_ Anda sendiri sebelum menggunakan _middleware_ Nuxt. Lihat [Modul Sentry](https://github.com/nuxt-community/sentry-module/blob/v4.0.3/lib/module.js#L151) untuk info lebih lanjut. |
+| `render:resourcesLoaded` | (resources) | Dipanggil setelah sumber daya untuk _renderer_ dimuat (_client manifest_, _server bundle_, dll). |
+| `render:done` | (renderer) | _Middleware_ SSR dan semua sumber daya sudah siap (_Renderer_ sudah siap) |
+| `render:routeContext` | (context.nuxt) | Setiap kali rute yang dimuat di sisi server dan sebelum _hook_ `render:route`. Dipanggil sebelum mengubah konteks Nuxt menjadi `window.__NUXT__`, berguna untuk menambahkan data yang dapat Anda ambil di sisi pengguna. |
+| `render:route` | (url, result, context) | Setiap kali rute yang dimuat di sisi server. Dipanggil sebelum mengirim kembali permintaan ke peramban. |
+| `render:routeDone` | (url, result, context) | Setiap kali rute yang dimuat di sisi server. Dipanggil setelah tanggapan berhasil dikirim ke peramban. |

--- a/content/id/guides/internals-glossary/internals-renderer.md
+++ b/content/id/guides/internals-glossary/internals-renderer.md
@@ -18,10 +18,10 @@ Anda dapat mendaftarkan _hook_ pada _life cycle_ tertentu.
 | Hook | Argumen | Kapan |
 | --- | --- | --- |
 | `render:before` | (renderer, options) | Sebelum menyiapkan _middleware_ dan sumber daya untuk kelas _Renderer_, berguna untuk _overload_ beberapa metode dan opsi. |
-| `render:setupMiddleware` | (app) _connect instance_ | Sebelum Nuxt menambahkan _middleware_-nya. Anda dapat menggunakannya untuk mendaftarkan _middleware_ pada sisi server. |
+| `render:setupMiddleware` | (app) _connect instance_ | Sebelum Nuxt menambahkan _middleware_-nya. Anda dapat menggunakannya untuk mendaftarkan _middleware_ pada sisi peladen. |
 | `render:errorMiddleware` | (app) _connect instance_ | Sebelum menambahkan _middleware_ galat Nuxt, berguna untuk menambahkan _middleware_ Anda sendiri sebelum menggunakan _middleware_ Nuxt. Lihat [Modul Sentry](https://github.com/nuxt-community/sentry-module/blob/v4.0.3/lib/module.js#L151) untuk info lebih lanjut. |
 | `render:resourcesLoaded` | (resources) | Dipanggil setelah sumber daya untuk _renderer_ dimuat (_client manifest_, _server bundle_, dll). |
 | `render:done` | (renderer) | _Middleware_ SSR dan semua sumber daya sudah siap (_Renderer_ sudah siap) |
-| `render:routeContext` | (context.nuxt) | Setiap kali rute yang dimuat di sisi server dan sebelum _hook_ `render:route`. Dipanggil sebelum mengubah konteks Nuxt menjadi `window.__NUXT__`, berguna untuk menambahkan data yang dapat Anda ambil di sisi pengguna. |
-| `render:route` | (url, result, context) | Setiap kali rute yang dimuat di sisi server. Dipanggil sebelum mengirim kembali permintaan ke peramban. |
-| `render:routeDone` | (url, result, context) | Setiap kali rute yang dimuat di sisi server. Dipanggil setelah tanggapan berhasil dikirim ke peramban. |
+| `render:routeContext` | (context.nuxt) | Setiap kali rute yang dimuat di sisi peladen dan sebelum _hook_ `render:route`. Dipanggil sebelum mengubah konteks Nuxt menjadi `window.__NUXT__`, berguna untuk menambahkan data yang dapat Anda ambil di sisi pengguna. |
+| `render:route` | (url, result, context) | Setiap kali rute yang dimuat di sisi peladen. Dipanggil sebelum mengirim kembali permintaan ke peramban. |
+| `render:routeDone` | (url, result, context) | Setiap kali rute yang dimuat di sisi peladen. Dipanggil setelah tanggapan berhasil dikirim ke peramban. |


### PR DESCRIPTION
### Overview
This is part of #549 

### Changes
Translate `guides/internals-glossary` to Indonesian

- [x] context.md
- [x] internals-module-container.md
- [x] internals-nuxt.md
- [x] internals-renderer.md