### PR TITLE
Update FR website

### DIFF
--- a/content/en/video-courses/build-a-job-board-with-laravel-graphql-nuxt-and-apollo.md
+++ b/content/en/video-courses/build-a-job-board-with-laravel-graphql-nuxt-and-apollo.md
@@ -1,0 +1,9 @@
+---
+title: 'Build a Job Board with Laravel, GraphQL, Nuxt and Apollo'
+description: Learn while you build a GraphQL API with Laravel Lighthouse, then build a Nuxt frontend with Apollo to consume it. All styled with Tailwind.
+img: build-job-board-with-nuxt
+platform: Code Course
+link: https://codecourse.com/courses/build-a-job-board-with-laravel-graphql-nuxt-and-apollo
+position: 5
+type: premium
+---

--- a/content/en/video-courses/building-application-with-vue-&-nuxt.md
+++ b/content/en/video-courses/building-application-with-vue-&-nuxt.md
@@ -1,0 +1,9 @@
+---
+title: 'Building Applications with Vue & Nuxt'
+description: Build dynamic web applications with Vue and Nuxt! Throughout the course you’ll build out a variety of projects leveraging the tools in the Vue ecosystem including the Vue CLI, Nuxt, Vuex Store, and more.
+img: building-applications-with-vue-and-nuxt
+platform: Frontend Masters
+link: https://frontendmasters.com/courses/vue-nuxt-apps/
+position: 4
+type: premium
+---

--- a/content/en/video-courses/create-a-news-app-with-vuejs-and-nuxt.md
+++ b/content/en/video-courses/create-a-news-app-with-vuejs-and-nuxt.md
@@ -1,0 +1,9 @@
+---
+title: 'Create a News App with Vue.js and Nuxt'
+description: You will learn how to create dynamic pages for each section of your application and load, store, display, filter, and style the data. Then end result will be a News app with multiple category pages, comments for each section, and user pages.
+img: create-news-app-with-vue-and-nuxt
+platform: egghead
+link: https://egghead.io/courses/create-a-news-app-with-vue-js-and-nuxt
+position: 9
+type: free
+---

--- a/content/en/video-courses/get-started-with-nuxt.md
+++ b/content/en/video-courses/get-started-with-nuxt.md
@@ -1,0 +1,9 @@
+---
+title: 'Get Started with Nuxt'
+description: Learn the essentials for how to build and deploy a Nuxt site including dnyamic routes, data fetching, SEO, lazy loading, global styles and transitions as well as how to generate and deploy your Nuxt app.
+img: get-started-with-nuxt
+platform: Jamstack Explorers
+link: https://explorers.netlify.com/learn/get-started-with-nuxt
+position: 2
+type: free
+---

--- a/content/en/video-courses/learn-nuxt-with-debbie.md
+++ b/content/en/video-courses/learn-nuxt-with-debbie.md
@@ -1,0 +1,9 @@
+---
+title: 'Learn Nuxt with Debbie'
+description: A playlist of YouTube videos covering all things Nuxt including short videos and live streams.
+img: learn-nuxt-with-debbie
+platform: YouTube
+link: https://www.youtube.com/c/DebbieOBrien
+position: 3
+type: free
+---

--- a/content/en/video-courses/learn-nuxtjs-by-building-a-real-world-app.md
+++ b/content/en/video-courses/learn-nuxtjs-by-building-a-real-world-app.md
@@ -1,0 +1,9 @@
+---
+title: 'Learn Nuxt.js by Building a Real World App'
+description: Learn how to build robust, modern websites with Nuxt from scratch. Or improve your website performance, code quality, while making better use of the framework.
+img: mastering-nuxt
+platform: Mastering Nuxt
+link: https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=navbar_link
+position: 1
+type: premium
+---

--- a/content/en/video-courses/nuxt.js-vuejs-on-steroids.md
+++ b/content/en/video-courses/nuxt.js-vuejs-on-steroids.md
@@ -1,0 +1,9 @@
+---
+title: 'Nuxt.js - Vue.js on Steroids'
+description: Build highly engaging Vue JS apps with Nuxt.js. Nuxt adds easy server-side-rendering and a folder-based config approach.
+img: nuxt-vue-steroids
+platform: Udemy
+link: https://www.udemy.com/course/nuxtjs-vuejs-on-steroids/
+position: 6
+type: premium
+---

--- a/content/en/video-courses/nuxtjs-fundamentals.md
+++ b/content/en/video-courses/nuxtjs-fundamentals.md
@@ -1,0 +1,9 @@
+---
+title: 'Nuxt.js Fundamentals'
+description: Learn the fundamentals of Nuxt.js in this course that we created together with the founders of Nuxt. The course covers what you need to know from scaffolding to deploying your first Nuxt.js application.
+img: nuxt-fundamentals
+platform: Vue School
+link: https://vueschool.io/courses/nuxtjs-fundamentals?friend=nuxt&utm_source=Nuxtjs.org&utm_medium=Link&utm_content=Courses&utm_campaign=nuxtjs-fundamentals
+position: 8
+type: free
+---

--- a/content/en/video-courses/scaling-vue-with-nuxtjs.md
+++ b/content/en/video-courses/scaling-vue-with-nuxtjs.md
@@ -1,0 +1,9 @@
+---
+title: 'Scaling Vue with Nuxt.js'
+description: Once you are comfortable with Vue, learning a framework like Nuxt allows you to create production-ready web apps which follow best practices.
+img: scaling-vue-with-nuxt
+platform: Vue Mastery
+link: https://www.vuemastery.com/courses/scaling-vue-with-nuxt-js/why-use-nuxt
+position: 7
+type: premium
+---

--- a/content/fr/video-courses/build-a-job-board-with-laravel-graphql-nuxt-and-apollo.md
+++ b/content/fr/video-courses/build-a-job-board-with-laravel-graphql-nuxt-and-apollo.md
@@ -1,0 +1,9 @@
+---
+title: "Créer un tableau d'offres d'emploi avec Laravel, GraphQL, Nuxt et Apollo"
+description: Apprenez en construisant une API GraphQL avec Laravel Lighthouse, puis creez un frontend avec Nuxt et Apollo pour la consommer. Tout cela avec Tailwind.
+img: build-job-board-with-nuxt
+platform: Code Course
+link: https://codecourse.com/courses/build-a-job-board-with-laravel-graphql-nuxt-and-apollo
+position: 5
+type: premium
+---

--- a/content/fr/video-courses/building-application-with-vue-&-nuxt.md
+++ b/content/fr/video-courses/building-application-with-vue-&-nuxt.md
@@ -1,0 +1,9 @@
+---
+title: 'Créez des applications avec Vue & Nuxt'
+description: Créez des applications web dynamiques avec Vue et Nuxt ! Tout au long du cours, vous élaborerez divers projets en utilisant les outils de l'écosystème Vue, notamment le Vue CLI, Nuxt, Vuex Store et bien d'autres.
+img: building-applications-with-vue-and-nuxt
+platform: Frontend Masters
+link: https://frontendmasters.com/courses/vue-nuxt-apps/
+position: 4
+type: premium
+---

--- a/content/fr/video-courses/create-a-news-app-with-vuejs-and-nuxt.md
+++ b/content/fr/video-courses/create-a-news-app-with-vuejs-and-nuxt.md
@@ -1,0 +1,9 @@
+---
+title: "Créer une application d'actualités avec Vue.js et Nuxt"
+description: "Vous apprendrez à créer des pages dynamiques pour chaque section de votre application et à charger, stocker, afficher, filtrer et styliser les données. Le résultat final sera une application d'actualités avec plusieurs pages de catégories, des commentaires pour chaque section et des pages utilisateur."
+img: create-news-app-with-vue-and-nuxt
+platform: egghead
+link: https://egghead.io/courses/create-a-news-app-with-vue-js-and-nuxt
+position: 9
+type: gratuit
+---

--- a/content/fr/video-courses/get-started-with-nuxt.md
+++ b/content/fr/video-courses/get-started-with-nuxt.md
@@ -1,0 +1,9 @@
+---
+title: 'Commencez avec Nuxt'
+description: Apprenez les bases de la création et du déploiement d'un site Nuxt, y compris les routes dynamiques, la récupération de données, le référencement, le lazy loading, les styles, les transitions globales, ainsi que la génération et le déploiement de votre application Nuxt.
+img: get-started-with-nuxt
+platform: Jamstack Explorers
+link: https://explorers.netlify.com/learn/get-started-with-nuxt
+position: 2
+type: gratuit
+---

--- a/content/fr/video-courses/learn-nuxt-with-debbie.md
+++ b/content/fr/video-courses/learn-nuxt-with-debbie.md
@@ -1,0 +1,9 @@
+---
+title: 'Apprenez Nuxt avec Debbie'
+description: Une playlist de vidéos YouTube couvrant tout ce qui concerne Nuxt, y compris de courtes vidéos et des flux en direct.
+img: learn-nuxt-with-debbie
+platform: YouTube
+link: https://www.youtube.com/c/DebbieOBrien
+position: 3
+type: gratuit
+---

--- a/content/fr/video-courses/learn-nuxtjs-by-building-a-real-world-app.md
+++ b/content/fr/video-courses/learn-nuxtjs-by-building-a-real-world-app.md
@@ -1,0 +1,8 @@
+---
+title: 'Apprendre Nuxt.js en developpant une application réelle'
+description: Apprenez à créer des sites web robustes et modernes avec Nuxt en partant de zéro. Améliorez les performances de votre site web, la qualité du code, tout en faisant un meilleur usage du framework.
+img: mastering-nuxt
+platform: Mastering Nuxt
+link: https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=navbar_link
+type: premium
+---

--- a/content/fr/video-courses/nuxt.js-vuejs-on-steroids.md
+++ b/content/fr/video-courses/nuxt.js-vuejs-on-steroids.md
@@ -1,0 +1,9 @@
+---
+title: 'Nuxt.js - Vue.js sur stéroïdes'
+description: Construisez des applications engageante avec Vue JS et Nuxt.js. Nuxt ajoute un rendu facile côté serveur et une approche de configuration basée sur les dossiers.
+img: nuxt-vue-steroids
+platform: Udemy
+link: https://www.udemy.com/course/nuxtjs-vuejs-on-steroids/
+position: 6
+type: premium
+---

--- a/content/fr/video-courses/nuxtjs-fundamentals.md
+++ b/content/fr/video-courses/nuxtjs-fundamentals.md
@@ -1,0 +1,9 @@
+---
+title: 'Nuxt.js Fundamentals'
+description: Learn the fundamentals of Nuxt.js in this course that we created together with the founders of Nuxt. The course covers what you need to know from scaffolding to deploying your first Nuxt.js application.
+img: nuxt-fundamentals
+platform: Vue School
+link: https://vueschool.io/courses/nuxtjs-fundamentals?friend=nuxt&utm_source=Nuxtjs.org&utm_medium=Link&utm_content=Courses&utm_campaign=nuxtjs-fundamentals
+position: 8
+type: gratuit
+---

--- a/content/fr/video-courses/scaling-vue-with-nuxtjs.md
+++ b/content/fr/video-courses/scaling-vue-with-nuxtjs.md
@@ -1,0 +1,9 @@
+---
+title: 'Faire évoluer Vue avec Nuxt.js'
+description: Une fois que vous êtes à l'aise avec Vue, l'apprentissage d'un framework comme Nuxt vous permet de créer des applications web prêtes à la production qui suivent les meilleures pratiques.
+img: scaling-vue-with-nuxt
+platform: Vue Mastery
+link: https://www.vuemastery.com/courses/scaling-vue-with-nuxt-js/why-use-nuxt
+position: 7
+type: premium
+---

--- a/i18n/fr-FR.js
+++ b/i18n/fr-FR.js
@@ -304,6 +304,16 @@ module.exports = {
       internals: 'Mécanismes'
     },
     examples: {
+      routing: 'Routage',
+      dataFetching: 'Data Fetching',
+      assetManagement: 'Gestion d\'assets',
+      transitions: 'Transitions',
+      seo: 'SEO',
+      loading: 'Chargement',
+      miscellaneous: 'Divers',
+      middleware: 'Middleware',
+      plugins: 'Plugins',
+      modules: 'Modules',
       essentials: 'Essentiels',
       customization: 'Personnalisation',
       advanced: 'Avancé'

--- a/i18n/fr-FR.js
+++ b/i18n/fr-FR.js
@@ -26,9 +26,9 @@ module.exports = {
         slug: 'examples'
       },
       {
-        name: 'FAQ',
+        name: 'Ressources',
         icon: 'resources',
-        slug: 'faq'
+        slug: 'resources'
       },
       {
         name: 'Blog',
@@ -38,8 +38,7 @@ module.exports = {
       {
         name: 'Cours Video',
         icon: 'video',
-        href:
-          'https://masteringnuxt.com?friend=nuxt&utm_source=Nuxtjs.org&utm_medium=Link&utm_content=Navbar&utm_content=prelaunch'
+        slug: 'video-courses'
       }
     ],
     search: {

--- a/pages/video-courses.vue
+++ b/pages/video-courses.vue
@@ -85,128 +85,63 @@ import PlayCircleIcon from '~/assets/icons/play-circle.svg?inline'
 import MeteorIcon from '~/assets/icons/meteor.svg?inline'
 
 export default {
+  async asyncData({ $content, app }) {
+    let courses = []
+
+    try {
+      courses = await $content(app.i18n.defaultLocale, 'video-courses')
+        .only([
+          'slug',
+          'title',
+          'position',
+          'menu',
+          'category',
+          'type',
+          'img',
+          'description',
+          'platform',
+          'link'
+        ])
+        .sortBy('position')
+        .fetch()
+
+      if (app.i18n.locale !== app.i18n.defaultLocale) {
+        const newCourses = await $content(app.i18n.locale, 'video-courses')
+          .only([
+            'slug',
+            'title',
+            'position',
+            'menu',
+            'category',
+            'type',
+            'img',
+            'description',
+            'platform',
+            'link'
+          ])
+          .sortBy('position')
+          .fetch()
+        courses = courses.map(course => {
+          const newCourse = newCourses.find(
+            newCourse => newCourse.slug === course.slug
+          )
+
+          return newCourse || course
+        })
+      }
+    } catch (e) {}
+
+    return {
+      courses
+    }
+  },
   components: {
     ThemesIllustration,
     PlayCircleIcon,
     MeteorIcon
   },
   data() {
-    return {
-      courses: [
-        {
-          title: 'Learn Nuxt.js by Building a Real World App',
-          description:
-            'Learn how to build robust, modern websites with Nuxt from scratch. Or improve your website performance, code quality, while making better use of the framework.',
-          link:
-            'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=navbar_link',
-          img: 'mastering-nuxt',
-          platform: 'Mastering Nuxt',
-          type: 'premium'
-        },
-        {
-          title: 'Get Started with Nuxt',
-          description:
-            'Learn the essentials for how to build and deploy a Nuxt site including dnyamic routes, data fetching, SEO, lazy loading, global styles and transitions as well as how to generate and deploy your Nuxt app.',
-          link: 'https://explorers.netlify.com/learn/get-started-with-nuxt',
-          img: 'get-started-with-nuxt',
-          platform: 'Jamstack Explorers',
-          type: 'free'
-        },
-        {
-          title: 'Learn Nuxt with Debbie',
-          description:
-            'A playlist of YouTube videos covering all things Nuxt including short videos and live streams.',
-          link: 'https://www.youtube.com/c/DebbieOBrien',
-          img: 'learn-nuxt-with-debbie',
-          platform: 'YouTube',
-          type: 'free'
-        },
-        {
-          title: 'Building Applications with Vue & Nuxt',
-          description:
-            'Build dynamic web applications with Vue and Nuxt! Throughout the course you’ll build out a variety of projects leveraging the tools in the Vue ecosystem including the Vue CLI, Nuxt, Vuex Store, and more.',
-          link: 'https://frontendmasters.com/courses/vue-nuxt-apps/',
-          img: 'building-applications-with-vue-and-nuxt',
-          platform: 'Frontend Masters',
-          type: 'premium'
-        },
-        {
-          title: 'Build a Job Board with Laravel, GraphQL, Nuxt and Apollo',
-          description:
-            'Learn while you build a GraphQL API with Laravel Lighthouse, then build a Nuxt frontend with Apollo to consume it. All styled with Tailwind.',
-          link:
-            'https://codecourse.com/courses/build-a-job-board-with-laravel-graphql-nuxt-and-apollo',
-          img: 'build-job-board-with-nuxt',
-          platform: 'Code Course',
-          type: 'premium'
-        },
-
-        {
-          title: 'Nuxt.js - Vue.js on Steroids',
-          description:
-            'Build highly engaging Vue JS apps with Nuxt.js. Nuxt adds easy server-side-rendering and a folder-based config approach.',
-          link: 'https://www.udemy.com/course/nuxtjs-vuejs-on-steroids/',
-          img: 'nuxt-vue-steroids',
-          platform: 'Udemy',
-          type: 'premium'
-        },
-        {
-          title: 'Scaling Vue with Nuxt.js',
-          description:
-            'Once you are comfortable with Vue, learning a framework like Nuxt allows you to create production-ready web apps which follow best practices.',
-          link:
-            'https://www.vuemastery.com/courses/scaling-vue-with-nuxt-js/why-use-nuxt',
-          img: 'scaling-vue-with-nuxt',
-          platform: 'Vue Mastery',
-          type: 'premium'
-        },
-        {
-          title: 'Nuxt.js Fundamentals',
-          description:
-            'Learn the fundamentals of Nuxt.js in this course that we created together with the founders of Nuxt. The course covers what you need to know from scaffolding to deploying your first Nuxt.js application.',
-          link:
-            'https://vueschool.io/courses/nuxtjs-fundamentals?friend=nuxt&utm_source=Nuxtjs.org&utm_medium=Link&utm_content=Courses&utm_campaign=nuxtjs-fundamentals',
-          img: 'nuxt-fundamentals',
-          platform: 'Vue School',
-          type: 'free'
-        },
-        {
-          title: 'Create a News App with Vue.js and Nuxt',
-          description:
-            'You will learn how to create dynamic pages for each section of your application and load, store, display, filter, and style the data. Then end result will be a News app with multiple category pages, comments for each section, and user pages.',
-          link:
-            'https://egghead.io/courses/create-a-news-app-with-vue-js-and-nuxt',
-          img: 'create-news-app-with-vue-and-nuxt',
-          platform: 'egghead',
-          type: 'free'
-        }
-        // {
-        //   title: 'Build a Server Rendered Vue.js App with Nuxt and Vuex',
-        //   description:
-        //     'This course will start with an empty app and walk through how to use Vue.js for building the app, Nuxt.js for organizing the app, and Vuex for managing state.',
-        //   link:
-        //     'https://egghead.io/courses/build-a-server-rendered-vue-js-app-with-nuxt-and-vuex',
-        //   img: 'build-server-rendered-app-with-nuxt',
-        //   platform: 'egghead'
-        // },
-        // {
-        //   title: 'Async Data with Nuxt.js',
-        //   description:
-        //     'Learn how to manage asynchronous data and render your application server-side with Nuxt.js.',
-        //   link:
-        //     'https://vueschool.io/courses/async-data-with-nuxtjs?friend=nuxt&utm_source=Nuxtjs.org&utm_medium=Link&utm_content=Courses&utm_campaign=async-data',
-        //   img: 'async-data-with-nuxtjs'
-        // },
-        // {
-        //   title: 'Static Site Generation with Nuxt.js',
-        //   description:
-        //     'Learn how to generate static websites (pre-rendering) with Nuxt.js to improve both performance and SEO while eliminating hosting costs.',
-        //   link:
-        //     'https://vueschool.io/courses/static-site-generation-with-nuxtjs?friend=nuxt&utm_source=Nuxtjs.org&utm_medium=Link&utm_content=Courses&utm_campaign=static-site-generation',
-        //   img: 'static-site-generation-with-nuxtjs'
-        // }
-      ]
-    }
+    return {}
   },
   head() {
     const title = this.$t('video-courses.meta.title')


### PR DESCRIPTION
# FR FAQ item
FR menu had the faq item that didn't exist anymore. Replace it with the "ressources" page

# Video courses item
In EN There was a page with many video.  
In FR, the page was only redirection to the nuxtmastering courses website.
I replace the menu item to link to the new page.
Aiming to allow traduction, i replace the json that was use for listing video by a new content section with ` .md` file and consume it in the template.

# i18 translation
Add some minor translation to the example catagory.

# Examples section
I wanted to notice that i get some "issues" on my local env.
The exemple menu item was not working when i'm in dev mode.
Only the menu item (when i directly go /examples all seems to work).
I tested it in FR & EN.
This "bug" was only in dev mode (when i generate / start all was working fine)
