### PR TITLE
Fixed hydration error

### DIFF
--- a/content/en/guides/deployment/nginx-proxy.md
+++ b/content/en/guides/deployment/nginx-proxy.md
@@ -89,6 +89,9 @@ server {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
         add_header X-Frame-Options "SAMEORIGIN";
 
+        error_page 420 = @nodejs;
+        if ( $is_args ) { return 420; }
+
         try_files $uri $uri/index.html @proxy; # for generate.subFolders: true
         # try_files $uri $uri.html @proxy; # for generate.subFolders: false
     }


### PR DESCRIPTION
Fix hydration error. If there is $ is_args we force to forward to nodejs

If the query string changes the content using a request to the server, then we will receive an error:
"Failed to execute 'appendChild' on 'Node': This node type does not support this method"
https://github.com/nuxt/nuxt.js/issues/5800
