### PR TITLE
Update documentation about nested directories components

### DIFF
--- a/content/en/guides/directory-structure/components.md
+++ b/content/en/guides/directory-structure/components.md
@@ -187,6 +187,6 @@ components: {
 And now in your template you can use `AwesomeButton` instead of `BaseFooButton`.
 
 ```html{}[pages/index.vue]
-<FooButton />
+<AwesomeButton />
 ```
 <base-alert type="next">Learn more about the [components module](/blog/improve-your-developer-experience-with-nuxt-components).</base-alert>

--- a/content/en/guides/directory-structure/components.md
+++ b/content/en/guides/directory-structure/components.md
@@ -178,15 +178,15 @@ components: {
     '~/components', // shortcut to { path: '~/components' }
       {
         path: '~/components/base/foo/',
-        prefix: 'awesome'
+        prefix: 'foo'
       }
   ]
 }
 ```
 
-And now in your template you can use `AwesomeButton` instead of `BaseFooButton`.
+And now in your template you can use `FooButton` instead of `BaseFooButton`.
 
 ```html{}[pages/index.vue]
-<AwesomeButton />
+<FooButton />
 ```
 <base-alert type="next">Learn more about the [components module](/blog/improve-your-developer-experience-with-nuxt-components).</base-alert>

--- a/content/en/guides/directory-structure/components.md
+++ b/content/en/guides/directory-structure/components.md
@@ -163,7 +163,7 @@ The component name will be based on its own path directory and filename. Therefo
 <BaseFooButton />
 ```
 
-However, if you want to use custom prefix, then you can use the `prefix` option in `nuxt.config` to add a prefix to all components in a specific folder.
+However, if you want to use custom directory strcture that should not be part of component name, can explicitly specify these directories: 
 
 ```bash
 components/

--- a/content/en/guides/directory-structure/components.md
+++ b/content/en/guides/directory-structure/components.md
@@ -153,46 +153,40 @@ If you have components in nested directories such as:
 ```bash
 components/
   base/
-    Button.vue
+      foo/
+         Button.vue
 ```
 
-The component name will be based on its own filename. Therefore, the component will be:
+The component name will be based on its own path directory and filename. Therefore, the component will be:
 
 ```html
-<button />
+<BaseFooButton />
 ```
 
-We recommend you use the directory name in the filename for clarity:
+However, if you want to use custom prefix, then you can use the `prefix` option in `nuxt.config` to add a prefix to all components in a specific folder.
 
 ```bash
 components/
   base/
-    BaseButton.vue
-```
-
-However, if you want to keep the filename as `Button.vue`, then you can use the `prefix` option in `nuxt.config` to add a prefix to all components in a specific folder.
-
-```bash
-components/
-  base/
-   Button.vue
+      foo/
+         Button.vue
 ```
 
 ```bash{}[nuxt.config.js]
 components: {
   dirs: [
-    '~/components',
+    '~/components', // shortcut to { path: '~/components' }
       {
-        path: '~/components/base/',
-        prefix: 'Base'
+        path: '~/components/base/foo/',
+        prefix: 'awesome'
       }
   ]
 }
 ```
 
-And now in your template you can use `BaseButton` instead of `Button` without having to make changes to the name of your `Button.vue` file.
+And now in your template you can use `AwesomeButton` instead of `BaseFooButton`.
 
 ```html{}[pages/index.vue]
-<BaseButton />
+<FooButton />
 ```
 <base-alert type="next">Learn more about the [components module](/blog/improve-your-developer-experience-with-nuxt-components).</base-alert>

--- a/content/en/guides/directory-structure/components.md
+++ b/content/en/guides/directory-structure/components.md
@@ -175,11 +175,8 @@ components/
 ```bash{}[nuxt.config.js]
 components: {
   dirs: [
-    '~/components', // shortcut to { path: '~/components' }
-      {
-        path: '~/components/base/foo/',
-        prefix: 'foo'
-      }
+    '~/components',
+    '~/components/base'
   ]
 }
 ```


### PR DESCRIPTION
Migration nuxt/component v1 to v2 makes a great feature about nested directories, starting `nuxt@2.15` using `@nuxt/component v2`. [nested directories nuxt component](https://github.com/nuxt/components#nested-components)

at first, I got problem at nuxt production that update nuxt/component to v2. Many component that not called directly.

I think nuxt-newbie will get this problem when learn it for the first time, so i decide to edit documentation about this update.

I edit documentation about nuxt [nested directories component](https://nuxtjs.org/docs/2.x/directory-structure/components#nested-directories) relate to new update @nuxt/component version 2.