### PR TITLE
fix: remove recursive component reference in `<AdsBlock>`

### DIFF
--- a/components/organisms/AdsBlock.vue
+++ b/components/organisms/AdsBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <AdsBlock v-if="$store.state.adBlocked" />
+  <AdBlock v-if="$store.state.adBlocked" />
   <AdsCarbon v-else-if="displayCarbon" />
   <AdsCodeFund v-else :fallback.sync="displayCarbon" />
 </template>


### PR DESCRIPTION
Fix the recursive load of the AdsBlock component

Probably caused by a typo because the component that needs to be loaded seems to be AdBlock, without the extra s.