### PR TITLE
Fix error in example code in creating-blog-with-nuxt-content.md

### DIFF
--- a/content/en/blog/creating-blog-with-nuxt-content.md
+++ b/content/en/blog/creating-blog-with-nuxt-content.md
@@ -695,7 +695,7 @@ Passing in `$content` and `params` to the context in our `asyncData` function we
 <script>
   export default {
     async asyncData({ $content, params }) {
-      const articles = await $content('articles', params.slug)
+      const articles = await $content('articles')
         .only(['title', 'description', 'img', 'slug', 'author'])
         .sortBy('createdAt', 'asc')
         .fetch()


### PR DESCRIPTION
In the "List all the blog posts" section, it was passing `params.slug` into `$content()`, but that's not applicable to listing pages.
And it was making my code fail as I was following along, which can take time to track down for a newbie.