### PR TITLE
docs: add example complex store structure

### DIFF
--- a/content/en/guides/directory-structure/store.md
+++ b/content/en/guides/directory-structure/store.md
@@ -210,6 +210,38 @@ export default {
 }
 ```
 
+A complex store setup file/folder structure might look as follows (in `store/`)
+
+```
+ store
+   |_modules
+     |_shop
+       |_cart
+         |_actions.js
+         |_getters.js
+         |_mutations.js
+         |_state.js
+       |_products
+         |_itemsGroup1
+           |_actions.js
+           |_getters.js
+           |_mutations.js
+           |_state.js
+         |_itemsGroup2
+           |_actions.js
+           ...
+           |_state.js
+         |_actions.js
+         |_getters.js
+         |_mutations.js
+         |_state.js
+   |_index.js (containing plugins and other additional elements, see below)
+   |_actions.js (being the root actions, contains nuxtServerInit)
+   |_getters.js (being the root getters)
+   |_mutations.js (being the root mutations)
+   |_state.js (being the root state)
+```
+
 ## Plugins in the Store
 
 You can add additional plugins to the store by putting them into the `store/index.js` file:

--- a/content/en/guides/directory-structure/store.md
+++ b/content/en/guides/directory-structure/store.md
@@ -210,36 +210,25 @@ export default {
 }
 ```
 
-A complex store setup file/folder structure might look as follows (in `store/`)
+### Example folder structure
+
+A complex store setup file/folder structure might look like this:
 
 ```
- store
-   |_modules
-     |_shop
-       |_cart
-         |_actions.js
-         |_getters.js
-         |_mutations.js
-         |_state.js
-       |_products
-         |_itemsGroup1
-           |_actions.js
-           |_getters.js
-           |_mutations.js
-           |_state.js
-         |_itemsGroup2
-           |_actions.js
-           ...
-           |_state.js
-         |_actions.js
-         |_getters.js
-         |_mutations.js
-         |_state.js
-   |_index.js (containing plugins and other additional elements, see below)
-   |_actions.js (being the root actions, contains nuxtServerInit)
-   |_getters.js (being the root getters)
-   |_mutations.js (being the root mutations)
-   |_state.js (being the root state)
+ store/
+--| index.js
+--| ui.js
+--| shop/
+----| cart/
+------| actions.js
+------| getters.js
+------| mutations.js
+------| state.js
+----| products/
+------| mutations.js
+------| state.js
+------| itemsGroup1/
+--------| state.js
 ```
 
 ## Plugins in the Store


### PR DESCRIPTION
Added extended file structure representation for full store use on complex projects. If someone could confirm whether the "modules" folder is still required for modules to work under nuxt (essential store/shop/cart/actions.js vs store/modules/shop/cart/actions.js), that would be great.