### PR TITLE
docs(id): translation for configuration guides (runtime-config -> ssr)

### DIFF
--- a/content/id/guides/configuration-glossary/configuration-runtime-config.md
+++ b/content/id/guides/configuration-glossary/configuration-runtime-config.md
@@ -6,7 +6,7 @@ category: configuration-glossary
 position: 25
 ---
 
-Konfigurasi _runtime_ memperbolehkan Anda untuk meneruskan konfigurasi dan variabel lingkungan pada konteks Nuxt. Anda dapat membaca [panduan konfigurasi runtime](/docs/2.x/directory-structure/nuxt-config#runtimeconfig) untuk mengetahui informasi lebih lanjut mengenai penggunaan konfigurasi _runtime_
+Konfigurasi _runtime_ memperbolehkan Anda untuk meneruskan konfigurasi dan variabel lingkungan pada konteks Nuxt. Anda dapat membaca [panduan konfigurasi runtime](/docs/2.x/directory-structure/nuxt-config#runtimeconfig) untuk mengetahui informasi lebih lanjut mengenai penggunaan konfigurasi _runtime_.
 
 ## `publicRuntimeConfig`
 

--- a/content/id/guides/configuration-glossary/configuration-runtime-config.md
+++ b/content/id/guides/configuration-glossary/configuration-runtime-config.md
@@ -1,0 +1,21 @@
+---
+title: 'Properti RuntimeConfig'
+description: RuntimeConfig memperbolehkan Anda untuk meneruskan konfigurasi dan variabel lingkungan yang dinamis pada konteks Nuxt
+menu: runtimeConfig
+category: configuration-glossary
+position: 25
+---
+
+Konfigurasi _runtime_ memperbolehkan Anda untuk meneruskan konfigurasi dan variabel lingkungan pada konteks Nuxt. Anda dapat membaca [panduan konfigurasi runtime](/docs/2.x/directory-structure/nuxt-config#runtimeconfig) untuk mengetahui informasi lebih lanjut mengenai penggunaan konfigurasi _runtime_
+
+## `publicRuntimeConfig`
+
+- Tipe data: `Object`
+
+Nilai dari objek ini **dapat diakses oleh klien dan peladen** melalui `$config`.
+
+## `privateRuntimeConfig`
+
+- Tipe data: `Object`
+
+Nilai dari objek ini **hanya dapat diakses oleh peladen** melalui `$config`. Nilai dari objek ini akan mengganti nilai `publicRuntimeConfig` untuk peladen.

--- a/content/id/guides/configuration-glossary/configuration-ssr.md
+++ b/content/id/guides/configuration-glossary/configuration-ssr.md
@@ -12,7 +12,7 @@ position: 28.1
   - `true`: Mengaktifkan _server-side rendering_
   - `false`: Menonaktifkan _server-side rendering_ (Nuxt hanya akan menyediakan _client-side rendering_)
 
-> Anda dapat menyetel opsi ini ke `false` ketika Anda **hanya menginginkan _client-side rendering_** 
+> Anda dapat menyetel opsi ini ke `false` ketika Anda **hanya menginginkan _client-side rendering_**.
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/id/guides/configuration-glossary/configuration-ssr.md
+++ b/content/id/guides/configuration-glossary/configuration-ssr.md
@@ -1,0 +1,27 @@
+---
+title: 'Properti ssr'
+description: Mengubah nilai dari ssr milik Nuxt.js
+menu: ssr
+category: configuration-glossary
+position: 28.1
+---
+
+- Tipe data: `boolean`
+- Nilai asali: `true`
+- Nilai yang diizinkan:
+  - `true`: Mengaktifkan _server-side rendering_
+  - `false`: Menonaktifkan _server-side rendering_ (Nuxt hanya akan menyediakan _client-side rendering_)
+
+> Anda dapat menyetel opsi ini ke `false` ketika Anda **hanya menginginkan _client-side rendering_** 
+
+```js{}[nuxt.config.js]
+export default {
+  ssr: false // Menonaktifkan server-side rendering
+}
+```
+
+<base-alert type="next">
+
+Sebelumnya, opsi `mode` digunakan untuk menonaktifkan atau mengaktifkan _server-side rendering_. Berikut merupakan [dokumentasi dari `mode`](/docs/2.x/configuration-glossary/configuration-mode).
+
+</base-alert>


### PR DESCRIPTION
## Overview

This is a part of #549.
This pull request provides Indonesian translation for 2 files in `guides -> configuration-glossary`. Details provided below.

## Changes

Provides translation for the following files:

- [x] `configuration-runtime-config.md`
- [x] `configuration-ssr.md`