### PR TITLE
chore: update master -> main for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["@nuxtjs"],
-  "baseBranches": ["master"],
+  "baseBranches": ["main"],
   "ignoreDeps": ["sass-loader"],
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
The default branch of `nuxt.js.org` has changed from `master` to `main`.
Update `baseBranched` in renovation.json.