### PR TITLE
docs: update node version in github-pages workflow

### DIFF
--- a/content/en/guides/deployment/github-pages.md
+++ b/content/en/guides/deployment/github-pages.md
@@ -167,7 +167,7 @@ Finally, create a `.travis.yml` configuration file in the root of your repositor
 ```yaml
 language: node_js
 node_js:
-  - '8'
+  - '12'
 
 cache:
   directories:
@@ -220,8 +220,8 @@ Next, in the root of your repository, create an `appveyor.yml` configuration fil
 
 ```yaml
 environment:
-  # Nuxt requires node v8 minimum
-  nodejs_version: '8'
+  # Nuxt requires node v12 minimum
+  nodejs_version: '12'
   # Encrypt sensitive data (https://ci.appveyor.com/tools/encrypt)
   github_access_token:
     secure: ENCRYPTED_GITHUB_ACCESS_TOKEN

--- a/content/fr/faq/github-pages.md
+++ b/content/fr/faq/github-pages.md
@@ -136,7 +136,7 @@ Finally, create a `.travis.yml` configuration file in the root of your repositor
 ```yaml
 language: node_js
 node_js:
-  - '8'
+  - '12'
 
 cache:
   directories:
@@ -189,8 +189,8 @@ Next, in the root of your repository, create an `appveyor.yml` configuration fil
 
 ```yaml
 environment:
-  # Nuxt requires node v8 minimum
-  nodejs_version: '8'
+  # Nuxt requires node v12 minimum
+  nodejs_version: '12'
   # Encrypt sensitive data (https://ci.appveyor.com/tools/encrypt)
   github_access_token:
     secure: ENCRYPTED_GITHUB_ACCESS_TOKEN

--- a/content/ja/faq/github-pages.md
+++ b/content/ja/faq/github-pages.md
@@ -136,7 +136,7 @@ npm run deploy
 ```yaml
 language: node_js
 node_js:
-  - '8'
+  - '12'
 
 cache:
   directories:
@@ -189,8 +189,8 @@ git push origin
 
 ```yaml
 environment:
-  # Nuxt には最低でも node v8 が必要
-  nodejs_version: '8'
+  # Nuxt には最低でも node v12 が必要
+  nodejs_version: '12'
   # 暗号化したセンシティブなデータ (https://ci.appveyor.com/tools/encrypt)
   github_access_token:
     secure: ENCRYPTED_GITHUB_ACCESS_TOKEN

--- a/content/zh/faq/github-pages.md
+++ b/content/zh/faq/github-pages.md
@@ -140,7 +140,7 @@ npm run deploy
 ```yaml
 language: node_js
 node_js:
-  - '8'
+  - '12'
 
 cache:
   directories:
@@ -193,8 +193,8 @@ git push origin
 
 ```yaml
 environment:
-  # Nuxt requires node v8 minimum
-  nodejs_version: '8'
+  # Nuxt requires node v12 minimum
+  nodejs_version: '12'
   # Encrypt sensitive data (https://ci.appveyor.com/tools/encrypt)
   github_access_token:
     secure: ENCRYPTED_GITHUB_ACCESS_TOKEN


### PR DESCRIPTION
Caused by https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/utils/dependencies.js#L11

```
const nodeVersion = '>=12.0.0';

if (!semver.satisfies(process.version, nodeVersion)) {
  consola__default['default'].warn(`You are using an unsupported version of Node.js (${process.version}). It is recommended to use the latest LTS version (https://nodejs.org/en/about/releases)`);
}
```