### PR TITLE
fix: reenable @nuxt/eslint-module

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -57,8 +57,7 @@ export default {
   },
   buildModules: [
     // https://github.com/nuxt-community/eslint-module
-    // Disabled, waiting for https://github.com/nuxt-community/eslint-module/pull/46 to be released
-    // '@nuxtjs/eslint-module',
+    '@nuxtjs/eslint-module',
     // https://github.com/nuxt-community/color-mode-module
     '@nuxtjs/color-mode',
     // https://github.com/nuxt-community/netlify-files-module


### PR DESCRIPTION
Because https://github.com/nuxt-community/eslint-module/pull/46 was fixed and had been released in version 3.0.1. Now in nuxtjs.org is using @nuxtjs/eslint-module version 3.0.2 that we can reenable from now.