### PR TITLE
docs(context-helpers): specify the three boolean values in process

### DIFF
--- a/content/en/guides/concepts/context-helpers.md
+++ b/content/en/guides/concepts/context-helpers.md
@@ -238,7 +238,7 @@ window.onNuxtReady(() => {
 
 ## Process helpers
 
-Nuxt.js injects three boolean values into the global `process` object which will help you to determine whether your app was rendered on the server or fully on the client, as well as checking for static site generation. These helpers are available across your application and are commonly used in `asyncData` userland code.
+Nuxt.js injects three boolean values (`client`, `server`, and `static`) into the global `process` object which will help you to determine whether your app was rendered on the server or fully on the client, as well as checking for static site generation. These helpers are available across your application and are commonly used in `asyncData` userland code.
 
 ```html{}[pages/about.vue]
 <template>


### PR DESCRIPTION
While reading the [context helpers guide](https://nuxtjs.org/docs/2.x/concepts/context-helpers), it is mentioned that there are three boolean values injected to the global process. However, only one boolean value was mentioned: `process.client`.

I was curious what the other two were, so I viewed the source code and based on `packages/types/app/index.d.ts`, I inferred that the other two were `server` and `static`.