### PR TITLE
docs(assets): update code reference

### DIFF
--- a/content/en/guides/directory-structure/assets.md
+++ b/content/en/guides/directory-structure/assets.md
@@ -223,7 +223,7 @@ For these two loaders, the default configuration is:
     loader: this.resolveModule('url-loader'),
     options: {
       esModule: false,
-      limit: 1000,
+      limit: 1000, // 1kB
       name: 'img/[name].[contenthash:7].[ext]'
     }
   }]
@@ -234,7 +234,7 @@ For these two loaders, the default configuration is:
     loader: this.resolveModule('url-loader'),
     options: {
        esModule: false,
-       limit: 1000,
+       limit: 1000, // 1kB
        name: 'fonts/[name].[contenthash:7].[ext]'
     }
   }]

--- a/content/en/guides/directory-structure/assets.md
+++ b/content/en/guides/directory-structure/assets.md
@@ -216,25 +216,39 @@ The benefits of these loaders are:
 For these two loaders, the default configuration is:
 
 ```js
-// https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/config/base.js#L297-L316
-;[
-  {
-    test: /\.(png|jpe?g|gif|svg|webp)$/,
-    loader: 'url-loader',
-    query: {
-      limit: 1000, // 1kB
-      name: 'img/[name].[hash:7].[ext]'
+// https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/config/base.js#L382-L411
+{
+  test: /\.(png|jpe?g|gif|svg|webp|avif)$/i,
+  use: [{
+    loader: this.resolveModule('url-loader'),
+    options: {
+      esModule: false,
+      limit: 1000,
+      name: 'img/[name].[contenthash:7].[ext]'
     }
-  },
-  {
-    test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
-    loader: 'url-loader',
-    query: {
-      limit: 1000, // 1kB
-      name: 'fonts/[name].[hash:7].[ext]'
+  }]
+},
+{
+  test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/i,
+  use: [{
+    loader: this.resolveModule('url-loader'),
+    options: {
+       esModule: false,
+       limit: 1000,
+       name: 'fonts/[name].[contenthash:7].[ext]'
     }
-  }
-]
+  }]
+},
+{
+  test: /\.(webm|mp4|ogv)$/i,
+  use: [{
+    loader: this.resolveModule('file-loader'),
+    options: {
+      esModule: false,
+      name: 'videos/[name].[contenthash:7].[ext]'
+    }
+  }]
+}
 ```
 
 Which means that every file below 1 kB will be inlined as base64 data URL. Otherwise, the image/font will be copied in its corresponding folder (inside the `.nuxt` directory) with a name containing a version hash for better caching.

--- a/content/en/guides/directory-structure/assets.md
+++ b/content/en/guides/directory-structure/assets.md
@@ -242,7 +242,7 @@ For these two loaders, the default configuration is:
 {
   test: /\.(webm|mp4|ogv)$/i,
   use: [{
-    loader: this.resolveModule('file-loader'),
+    loader: 'file-loader',
     options: {
       esModule: false,
       name: 'videos/[name].[contenthash:7].[ext]'

--- a/content/en/guides/directory-structure/assets.md
+++ b/content/en/guides/directory-structure/assets.md
@@ -231,7 +231,7 @@ For these two loaders, the default configuration is:
 {
   test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/i,
   use: [{
-    loader: this.resolveModule('url-loader'),
+    loader: 'url-loader',
     options: {
        esModule: false,
        limit: 1000, // 1kB

--- a/content/en/guides/directory-structure/assets.md
+++ b/content/en/guides/directory-structure/assets.md
@@ -220,7 +220,7 @@ For these two loaders, the default configuration is:
 {
   test: /\.(png|jpe?g|gif|svg|webp|avif)$/i,
   use: [{
-    loader: this.resolveModule('url-loader'),
+    loader: 'url-loader',
     options: {
       esModule: false,
       limit: 1000, // 1kB


### PR DESCRIPTION
Code reference for url-loader and file-loader was outdated and still referenced the already removed file `lib/builder/webpack/base.js` with last commit `c1e0d174319f209bbfa4d34cfd2e17e82f45537` on October 18, 2018.

I've taken the liberty to evaluate `Object.assign(this.loaders.xxx, { name: this.getFileName('xxx')})` since I think that referencing [build.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/config/src/config/build.js#L15-L27) would only serve to confuse the reader.

I've also added the `file-loader` code, since the explanation above stated

> For **these two loaders**, the default configuration is:

Not sure if the intent was to show both `url-loader` and `file-loader` or `url-loader` only.