### PR TITLE
docs(fr): Add a missing brace

### DIFF
--- a/content/fr/guides/features/data-fetching.md
+++ b/content/fr/guides/features/data-fetching.md
@@ -298,7 +298,7 @@ export default {
 ```html{}[pages/posts/_id.vue]
 <template>
   <div>
-    <h1>{{ post.title }</h1>
+    <h1>{{ post.title }}</h1>
     <p>{{ post.description }}</p>
   </div>
 </template>


### PR DESCRIPTION
Old code
```html
<h1>{{ post.title }</h1>
```

New Code
```html
<h1>{{ post.title }}</h1>
```