### PR TITLE
Fix broken links

### DIFF
--- a/content/es/guides/features/deployment-targets.md
+++ b/content/es/guides/features/deployment-targets.md
@@ -40,7 +40,7 @@ export default {
 **Ejecutando nuxt dev con el destino estático va a mejorar la experiencia de desarrollo:**
 
 - Elimina `req` & `res` de `context`
-- Retrocede al renderizado en cliente cuando hay un 404, errores y redirecciones [ver SPA fallback](/docs/2.x//concepts/static-site-generation#spa-fallback)
+- Retrocede al renderizado en cliente cuando hay un 404, errores y redirecciones [ver SPA fallback]((/docs/2.x/concepts/static-site-generation#spa-fallback)
 - `$route.query` siempre será igual a `{}` en el renderizado server-side
 - `process.static` es `true`
 

--- a/content/es/guides/features/deployment-targets.md
+++ b/content/es/guides/features/deployment-targets.md
@@ -40,7 +40,7 @@ export default {
 **Ejecutando nuxt dev con el destino estático va a mejorar la experiencia de desarrollo:**
 
 - Elimina `req` & `res` de `context`
-- Retrocede al renderizado en cliente cuando hay un 404, errores y redirecciones [ver SPA fallback](/guides/concepts/static-site-generation#spa-fallback)
+- Retrocede al renderizado en cliente cuando hay un 404, errores y redirecciones [ver SPA fallback](/docs/2.x//concepts/static-site-generation#spa-fallback)
 - `$route.query` siempre será igual a `{}` en el renderizado server-side
 - `process.static` es `true`
 

--- a/content/fr/guides/components-glossary/pages-fetch.md
+++ b/content/fr/guides/components-glossary/pages-fetch.md
@@ -12,7 +12,7 @@ Avec l'arrivée de la `v2.12` de Nuxt.js, nous avons droit à un nouveau hook di
 
 <base-alert>
 
-`fetch(context)` a été déprécié, à la place on peut utiliser un [middleware anonyme](/docs/2.x//components-glossary/pages-middleware#anonymous-middleware) dans la page: `middleware(context)`
+`fetch(context)` a été déprécié, à la place on peut utiliser un [middleware anonyme]((/docs/2.x/components-glossary/pages-middleware#anonymous-middleware) dans la page: `middleware(context)`
 
 </base-alert>
 
@@ -45,7 +45,7 @@ export default {
 }
 ```
 
-On peut accéder au [context](/docs/2.x//internals-glossary/context) de Nuxt.js à l'intérieur du hook `fetch` en utilisant `this.$nuxt.context`.
+On peut accéder au [context]((/docs/2.x/internals-glossary/context) de Nuxt.js à l'intérieur du hook `fetch` en utilisant `this.$nuxt.context`.
 
 ### Options
 

--- a/content/fr/guides/components-glossary/pages-fetch.md
+++ b/content/fr/guides/components-glossary/pages-fetch.md
@@ -12,7 +12,7 @@ Avec l'arrivée de la `v2.12` de Nuxt.js, nous avons droit à un nouveau hook di
 
 <base-alert>
 
-`fetch(context)` a été déprécié, à la place on peut utiliser un [middleware anonyme](/guides/components-glossary/pages-middleware#anonymous-middleware) dans la page: `middleware(context)`
+`fetch(context)` a été déprécié, à la place on peut utiliser un [middleware anonyme](/docs/2.x//components-glossary/pages-middleware#anonymous-middleware) dans la page: `middleware(context)`
 
 </base-alert>
 
@@ -45,7 +45,7 @@ export default {
 }
 ```
 
-On peut accéder au [context](/guides/internals-glossary/context) de Nuxt.js à l'intérieur du hook `fetch` en utilisant `this.$nuxt.context`.
+On peut accéder au [context](/docs/2.x//internals-glossary/context) de Nuxt.js à l'intérieur du hook `fetch` en utilisant `this.$nuxt.context`.
 
 ### Options
 

--- a/content/fr/guides/components-glossary/pages-key.md
+++ b/content/fr/guides/components-glossary/pages-key.md
@@ -12,7 +12,7 @@ position: 3
 
 La propriété `key` est propagée dans le `<router-view>`, ce qui est utile pour faire des transitions dans une route dynamique et avec une route différente. Des clés différentes résulteront en un re-render des composants de la page.
 
-Il y a plusieurs façons de définir la clé. Pour plus de détails, veuillez vous référer à la propriété `nuxtChildKey` dans le [composant nuxt](/guides/features/nuxt-components).
+Il y a plusieurs façons de définir la clé. Pour plus de détails, veuillez vous référer à la propriété `nuxtChildKey` dans le [composant nuxt](/docs/2.x//features/nuxt-components).
 
 ```js
 export default {

--- a/content/fr/guides/components-glossary/pages-key.md
+++ b/content/fr/guides/components-glossary/pages-key.md
@@ -12,7 +12,7 @@ position: 3
 
 La propriété `key` est propagée dans le `<router-view>`, ce qui est utile pour faire des transitions dans une route dynamique et avec une route différente. Des clés différentes résulteront en un re-render des composants de la page.
 
-Il y a plusieurs façons de définir la clé. Pour plus de détails, veuillez vous référer à la propriété `nuxtChildKey` dans le [composant nuxt](/docs/2.x//features/nuxt-components).
+Il y a plusieurs façons de définir la clé. Pour plus de détails, veuillez vous référer à la propriété `nuxtChildKey` dans le [composant nuxt]((/docs/2.x/features/nuxt-components).
 
 ```js
 export default {

--- a/content/fr/guides/components-glossary/pages-loading.md
+++ b/content/fr/guides/components-glossary/pages-loading.md
@@ -12,7 +12,7 @@ position: 5
 
 Par défaut, Nuxt.js utilise son propre composant pour afficher une barre de progression entre les routes.
 
-Vous pouvez la désactiver ou la personnaliser à travers les [options de configuration du chargement](/docs/2.x//configuration-glossary/configuration-loading), mais aussi la désactiver seulement sur des pages spécifiques en passant la propriété `loading` à false:
+Vous pouvez la désactiver ou la personnaliser à travers les [options de configuration du chargement]((/docs/2.x/configuration-glossary/configuration-loading), mais aussi la désactiver seulement sur des pages spécifiques en passant la propriété `loading` à false:
 
 ```html
 <template>

--- a/content/fr/guides/components-glossary/pages-loading.md
+++ b/content/fr/guides/components-glossary/pages-loading.md
@@ -12,7 +12,7 @@ position: 5
 
 Par défaut, Nuxt.js utilise son propre composant pour afficher une barre de progression entre les routes.
 
-Vous pouvez la désactiver ou la personnaliser à travers les [options de configuration du chargement](/guides/configuration-glossary/configuration-loading), mais aussi la désactiver seulement sur des pages spécifiques en passant la propriété `loading` à false:
+Vous pouvez la désactiver ou la personnaliser à travers les [options de configuration du chargement](/docs/2.x//configuration-glossary/configuration-loading), mais aussi la désactiver seulement sur des pages spécifiques en passant la propriété `loading` à false:
 
 ```html
 <template>

--- a/content/fr/guides/components-glossary/pages-scrolltotop.md
+++ b/content/fr/guides/components-glossary/pages-scrolltotop.md
@@ -26,4 +26,4 @@ Par défaut, Nuxt.js défile tout en haut lorsque l'on va sur une autre page, ma
 
 Inversement, on peut passer `scrollToTop` à `false` sur les routes parent.
 
-Si l'on souhaite écraser le comportement du défilement par défaut de Nuxt, veuillez vous référer à l'[option scrollBehavior](/docs/2.x//configuration-glossary/configuration-router#scrollbehavior).
+Si l'on souhaite écraser le comportement du défilement par défaut de Nuxt, veuillez vous référer à l'[option scrollBehavior]((/docs/2.x/configuration-glossary/configuration-router#scrollbehavior).

--- a/content/fr/guides/components-glossary/pages-scrolltotop.md
+++ b/content/fr/guides/components-glossary/pages-scrolltotop.md
@@ -26,4 +26,4 @@ Par défaut, Nuxt.js défile tout en haut lorsque l'on va sur une autre page, ma
 
 Inversement, on peut passer `scrollToTop` à `false` sur les routes parent.
 
-Si l'on souhaite écraser le comportement du défilement par défaut de Nuxt, veuillez vous référer à l'[option scrollBehavior](/guides/configuration-glossary/configuration-router#scrollbehavior).
+Si l'on souhaite écraser le comportement du défilement par défaut de Nuxt, veuillez vous référer à l'[option scrollBehavior](/docs/2.x//configuration-glossary/configuration-router#scrollbehavior).

--- a/content/fr/guides/components-glossary/pages-validate.md
+++ b/content/fr/guides/components-glossary/pages-validate.md
@@ -10,7 +10,7 @@ position: 9
 
 - **Type:** `Function` ou `Async Function`
 
-`validate` est appelé avant chaque navigation sur une nouvelle route. Il sera appelé une fois côté serveur: lors de la première requête à l'application Nuxt et côté client: lors de la navigation sur d'autres routes . Cette méthode prend l'objet [`context`](/docs/2.x//internals-glossary/context) en tant qu'argument.
+`validate` est appelé avant chaque navigation sur une nouvelle route. Il sera appelé une fois côté serveur: lors de la première requête à l'application Nuxt et côté client: lors de la navigation sur d'autres routes . Cette méthode prend l'objet [`context`]((/docs/2.x/internals-glossary/context) en tant qu'argument.
 
 ```js
 validate({ params, query, store }) {
@@ -48,7 +48,7 @@ export default {
 }
 ```
 
-On peut aussi vérifier de la data dans notre [store](/docs/2.x//directory-structure/store) (remplie par exemple par [`nuxtServerInit`](/docs/2.x//directory-structure/store#the-nuxtserverinit-action) avant l'action):
+On peut aussi vérifier de la data dans notre [store]((/docs/2.x/directory-structure/store) (remplie par exemple par [`nuxtServerInit`]((/docs/2.x/directory-structure/store#the-nuxtserverinit-action) avant l'action):
 
 ```js
 export default {

--- a/content/fr/guides/components-glossary/pages-validate.md
+++ b/content/fr/guides/components-glossary/pages-validate.md
@@ -10,7 +10,7 @@ position: 9
 
 - **Type:** `Function` ou `Async Function`
 
-`validate` est appelé avant chaque navigation sur une nouvelle route. Il sera appelé une fois côté serveur: lors de la première requête à l'application Nuxt et côté client: lors de la navigation sur d'autres routes . Cette méthode prend l'objet [`context`](/guides/internals-glossary/context) en tant qu'argument.
+`validate` est appelé avant chaque navigation sur une nouvelle route. Il sera appelé une fois côté serveur: lors de la première requête à l'application Nuxt et côté client: lors de la navigation sur d'autres routes . Cette méthode prend l'objet [`context`](/docs/2.x//internals-glossary/context) en tant qu'argument.
 
 ```js
 validate({ params, query, store }) {
@@ -48,7 +48,7 @@ export default {
 }
 ```
 
-On peut aussi vérifier de la data dans notre [store](/guides/directory-structure/store) (remplie par exemple par [`nuxtServerInit`](/guides/directory-structure/store#the-nuxtserverinit-action) avant l'action):
+On peut aussi vérifier de la data dans notre [store](/docs/2.x//directory-structure/store) (remplie par exemple par [`nuxtServerInit`](/docs/2.x//directory-structure/store#the-nuxtserverinit-action) avant l'action):
 
 ```js
 export default {

--- a/content/fr/guides/components-glossary/pages-watchquery.md
+++ b/content/fr/guides/components-glossary/pages-watchquery.md
@@ -34,6 +34,6 @@ export default {
 
 <base-alert>
 
-**Warning**: Le nouveau hook `fetch` (disponible depuis la version 2.12) n'est pas affecté par `watchQuery`. Pour plus d'informations, se référer aux [changements sur la surveillance des query strings](/docs/2.x//features/data-fetching#the-fetch-hook).
+**Warning**: Le nouveau hook `fetch` (disponible depuis la version 2.12) n'est pas affecté par `watchQuery`. Pour plus d'informations, se référer aux [changements sur la surveillance des query strings]((/docs/2.x/features/data-fetching#the-fetch-hook).
 
 </base-alert>

--- a/content/fr/guides/components-glossary/pages-watchquery.md
+++ b/content/fr/guides/components-glossary/pages-watchquery.md
@@ -34,6 +34,6 @@ export default {
 
 <base-alert>
 
-**Warning**: Le nouveau hook `fetch` (disponible depuis la version 2.12) n'est pas affecté par `watchQuery`. Pour plus d'informations, se référer aux [changements sur la surveillance des query strings](/guides/features/data-fetching#the-fetch-hook).
+**Warning**: Le nouveau hook `fetch` (disponible depuis la version 2.12) n'est pas affecté par `watchQuery`. Pour plus d'informations, se référer aux [changements sur la surveillance des query strings](/docs/2.x//features/data-fetching#the-fetch-hook).
 
 </base-alert>

--- a/content/fr/guides/concepts/context-helpers.md
+++ b/content/fr/guides/concepts/context-helpers.md
@@ -48,7 +48,7 @@ questions:
 
 <app-modal :src="img" :alt="imgAlt"></app-modal>
 
-L'object `context` est disponible dans des fonctions spécifiques de Nuxt comme [asyncData](/docs/2.x//features/data-fetching#async-data), [plugins](/docs/2.x//directory-structure/plugins), [middleware](/docs/2.x//directory-structure/middleware) et [nuxtServerInit](/docs/2.x//directory-structure/store#the-nuxtserverinit-action). Le contexte fournit des informations _additionnelles_ et souvent optionnelles de la requête envoyée à l'application.
+L'object `context` est disponible dans des fonctions spécifiques de Nuxt comme [asyncData]((/docs/2.x/features/data-fetching#async-data), [plugins]((/docs/2.x/directory-structure/plugins), [middleware]((/docs/2.x/directory-structure/middleware) et [nuxtServerInit]((/docs/2.x/directory-structure/store#the-nuxtserverinit-action). Le contexte fournit des informations _additionnelles_ et souvent optionnelles de la requête envoyée à l'application.
 
 Tout d'abord, le contexte est utilisé pour permettre un accès aux autres parties d'une application Nuxt.js, comme par exemple un store Vuex ou l'instance `connect` sous-jacente. Ainsi, nous avons les objets `req` et `res` disponibles dans le contexte du côté serveur et le `store` de toujours disponible. Avec le temps, le contexte fût étendu avec plein d'autres variables bien pratiques et de raccourcis. Ainsi, nous avons accès au fonctionnalités du HMR en mode `development`, la `route` actuelle, les `params` de la page, la `query` (URL), ainsi que la possibilité d'avoir accès à des variables d'environment à travers le contexte. En plus de cela, les modules de fonctions et les helpers peuvent être exposés à travers le contexte pour être disponibles sur les deux - côté client et serveur.
 
@@ -89,7 +89,7 @@ Le _context_ dont nous parlons ici ne doit pas être confondu avec l'objet `cont
 
 </base-alert>
 
-Découvrez davantage de propriétés disponibles dans le contexte dans le [Glossaire des propriétés internes](/docs/2.x//internals-glossary/context)
+Découvrez davantage de propriétés disponibles dans le contexte dans le [Glossaire des propriétés internes]((/docs/2.x/internals-glossary/context)
 
 ## Exemples
 

--- a/content/fr/guides/concepts/context-helpers.md
+++ b/content/fr/guides/concepts/context-helpers.md
@@ -48,7 +48,7 @@ questions:
 
 <app-modal :src="img" :alt="imgAlt"></app-modal>
 
-L'object `context` est disponible dans des fonctions spécifiques de Nuxt comme [asyncData](/guides/features/data-fetching#async-data), [plugins](/guides/directory-structure/plugins), [middleware](/guides/directory-structure/middleware) et [nuxtServerInit](/guides/directory-structure/store#the-nuxtserverinit-action). Le contexte fournit des informations _additionnelles_ et souvent optionnelles de la requête envoyée à l'application.
+L'object `context` est disponible dans des fonctions spécifiques de Nuxt comme [asyncData](/docs/2.x//features/data-fetching#async-data), [plugins](/docs/2.x//directory-structure/plugins), [middleware](/docs/2.x//directory-structure/middleware) et [nuxtServerInit](/docs/2.x//directory-structure/store#the-nuxtserverinit-action). Le contexte fournit des informations _additionnelles_ et souvent optionnelles de la requête envoyée à l'application.
 
 Tout d'abord, le contexte est utilisé pour permettre un accès aux autres parties d'une application Nuxt.js, comme par exemple un store Vuex ou l'instance `connect` sous-jacente. Ainsi, nous avons les objets `req` et `res` disponibles dans le contexte du côté serveur et le `store` de toujours disponible. Avec le temps, le contexte fût étendu avec plein d'autres variables bien pratiques et de raccourcis. Ainsi, nous avons accès au fonctionnalités du HMR en mode `development`, la `route` actuelle, les `params` de la page, la `query` (URL), ainsi que la possibilité d'avoir accès à des variables d'environment à travers le contexte. En plus de cela, les modules de fonctions et les helpers peuvent être exposés à travers le contexte pour être disponibles sur les deux - côté client et serveur.
 
@@ -89,7 +89,7 @@ Le _context_ dont nous parlons ici ne doit pas être confondu avec l'objet `cont
 
 </base-alert>
 
-Découvrez davantage de propriétés disponibles dans le contexte dans le [Glossaire des propriétés internes](/guides/internals-glossary/context)
+Découvrez davantage de propriétés disponibles dans le contexte dans le [Glossaire des propriétés internes](/docs/2.x//internals-glossary/context)
 
 ## Exemples
 

--- a/content/fr/guides/concepts/nuxt-lifecycle.md
+++ b/content/fr/guides/concepts/nuxt-lifecycle.md
@@ -141,7 +141,7 @@ De la même façon que pour la partie _client_, tout se passe dans le navigateur
 
 <base-alert type="info">
 
-Se référer au chapitre sur les composants pour plus d'informations sur [`<NuxtLink>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component).
+Se référer au chapitre sur les composants pour plus d'informations sur [`<NuxtLink>`]((/docs/2.x/features/nuxt-components#the-nuxtlink-component).
 
 </base-alert>
 
@@ -159,7 +159,7 @@ Se référer au chapitre sur les composants pour plus d'informations sur [`<Nuxt
 
 <base-alert type="next">
 
-Plus d'informations dans le [recueil sur les features](/docs/2.x//features/rendering-modes).
+Plus d'informations dans le [recueil sur les features]((/docs/2.x/features/rendering-modes).
 
 </base-alert>
 

--- a/content/fr/guides/concepts/nuxt-lifecycle.md
+++ b/content/fr/guides/concepts/nuxt-lifecycle.md
@@ -141,7 +141,7 @@ De la même façon que pour la partie _client_, tout se passe dans le navigateur
 
 <base-alert type="info">
 
-Se référer au chapitre sur les composants pour plus d'informations sur [`<NuxtLink>`](/guides/features/nuxt-components#the-nuxtlink-component).
+Se référer au chapitre sur les composants pour plus d'informations sur [`<NuxtLink>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component).
 
 </base-alert>
 
@@ -159,7 +159,7 @@ Se référer au chapitre sur les composants pour plus d'informations sur [`<Nuxt
 
 <base-alert type="next">
 
-Plus d'informations dans le [recueil sur les features](/guides/features/rendering-modes).
+Plus d'informations dans le [recueil sur les features](/docs/2.x//features/rendering-modes).
 
 </base-alert>
 

--- a/content/fr/guides/concepts/server-side-rendering.md
+++ b/content/fr/guides/concepts/server-side-rendering.md
@@ -99,6 +99,6 @@ Le navigateur reçoit la page avec le HTML généré depuis le serveur. Le conte
 
 ### Étape 3: Du navigateur au navigateur
 
-Naviguer entre les pages à l'aide de [`<NuxtLink>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component) est fait du côté client afin que nous n'ayons pas besoin de faire une requête au serveur, sauf si nous faisons un rafraîchissement manuel de notre navigateur.
+Naviguer entre les pages à l'aide de [`<NuxtLink>`]((/docs/2.x/features/nuxt-components#the-nuxtlink-component) est fait du côté client afin que nous n'ayons pas besoin de faire une requête au serveur, sauf si nous faisons un rafraîchissement manuel de notre navigateur.
 
 <quiz :questions="questions"></quiz>

--- a/content/fr/guides/concepts/server-side-rendering.md
+++ b/content/fr/guides/concepts/server-side-rendering.md
@@ -99,6 +99,6 @@ Le navigateur reçoit la page avec le HTML généré depuis le serveur. Le conte
 
 ### Étape 3: Du navigateur au navigateur
 
-Naviguer entre les pages à l'aide de [`<NuxtLink>`](/guides/features/nuxt-components#the-nuxtlink-component) est fait du côté client afin que nous n'ayons pas besoin de faire une requête au serveur, sauf si nous faisons un rafraîchissement manuel de notre navigateur.
+Naviguer entre les pages à l'aide de [`<NuxtLink>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component) est fait du côté client afin que nous n'ayons pas besoin de faire une requête au serveur, sauf si nous faisons un rafraîchissement manuel de notre navigateur.
 
 <quiz :questions="questions"></quiz>

--- a/content/fr/guides/concepts/static-site-generation.md
+++ b/content/fr/guides/concepts/static-site-generation.md
@@ -38,7 +38,7 @@ Avec la génération statique nous pouvons générer notre application durant la
 
 ### Générer notre site
 
-Lorsque nous déployons notre site avec [target:static](/docs/2.x//features/deployment-targets#static-hosting), toutes nos pages `.vue` seront générées dans des fichiers HTML et JavaScript. Tous les calls aux API seront faits et mis en cache dans un répertoire nommé `static` à l'intérieur de notre contenu généré pour le côté client, ainsi il n'y aura pas besoin de faire d'appels à notre API par la suite.
+Lorsque nous déployons notre site avec [target:static]((/docs/2.x/features/deployment-targets#static-hosting), toutes nos pages `.vue` seront générées dans des fichiers HTML et JavaScript. Tous les calls aux API seront faits et mis en cache dans un répertoire nommé `static` à l'intérieur de notre contenu généré pour le côté client, ainsi il n'y aura pas besoin de faire d'appels à notre API par la suite.
 
 ### Étape 1: Du navigateur au CDN
 
@@ -50,7 +50,7 @@ Le CDN va envoyer le HTML préalablement généré, ainsi que le JavaScript et t
 
 ### Étape 3: du navigateur au navigateur
 
-Naviguer entre les pages à l'aide de [`<NuxtLink>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component) est fait du côté client afin que nous n'ayons pas besoin de refaire une requête au CDN et les appels à l'API seront chargés à partir du répertoire des ressources mis en cache et ce même si nous rafraîchissez manuellement notre page.
+Naviguer entre les pages à l'aide de [`<NuxtLink>`]((/docs/2.x/features/nuxt-components#the-nuxtlink-component) est fait du côté client afin que nous n'ayons pas besoin de refaire une requête au CDN et les appels à l'API seront chargés à partir du répertoire des ressources mis en cache et ce même si nous rafraîchissez manuellement notre page.
 
 ### Solution de secours: la SPA
 
@@ -58,7 +58,7 @@ Les pages qui auront été exclues de la génération en utilisant la propriét�
 
 <base-alert type="next">
 
-Pour en savoir davantage sur la [propriété `generate`](/docs/2.x//configuration-glossary/configuration-generate#exclude)
+Pour en savoir davantage sur la [propriété `generate`]((/docs/2.x/configuration-glossary/configuration-generate#exclude)
 
 </base-alert>
 
@@ -68,6 +68,6 @@ Afin de récupérer le nouveau contenu sur notre site à partir de l'API, nous a
 
 ### Mode de prévisualisation
 
-Le mode de prévisualisation va appeler notre API ou notre CMS afin que nous puissions voir les changements en live avant de déployer. Se référer au [mode de prévisualisation](/docs/2.x//features/live-preview) pour activer cette fonctionnalité.
+Le mode de prévisualisation va appeler notre API ou notre CMS afin que nous puissions voir les changements en live avant de déployer. Se référer au [mode de prévisualisation]((/docs/2.x/features/live-preview) pour activer cette fonctionnalité.
 
 <quiz :questions="questions"></quiz>

--- a/content/fr/guides/concepts/static-site-generation.md
+++ b/content/fr/guides/concepts/static-site-generation.md
@@ -38,7 +38,7 @@ Avec la génération statique nous pouvons générer notre application durant la
 
 ### Générer notre site
 
-Lorsque nous déployons notre site avec [target:static](/guides/features/deployment-targets#static-hosting), toutes nos pages `.vue` seront générées dans des fichiers HTML et JavaScript. Tous les calls aux API seront faits et mis en cache dans un répertoire nommé `static` à l'intérieur de notre contenu généré pour le côté client, ainsi il n'y aura pas besoin de faire d'appels à notre API par la suite.
+Lorsque nous déployons notre site avec [target:static](/docs/2.x//features/deployment-targets#static-hosting), toutes nos pages `.vue` seront générées dans des fichiers HTML et JavaScript. Tous les calls aux API seront faits et mis en cache dans un répertoire nommé `static` à l'intérieur de notre contenu généré pour le côté client, ainsi il n'y aura pas besoin de faire d'appels à notre API par la suite.
 
 ### Étape 1: Du navigateur au CDN
 
@@ -50,7 +50,7 @@ Le CDN va envoyer le HTML préalablement généré, ainsi que le JavaScript et t
 
 ### Étape 3: du navigateur au navigateur
 
-Naviguer entre les pages à l'aide de [`<NuxtLink>`](/guides/features/nuxt-components#the-nuxtlink-component) est fait du côté client afin que nous n'ayons pas besoin de refaire une requête au CDN et les appels à l'API seront chargés à partir du répertoire des ressources mis en cache et ce même si nous rafraîchissez manuellement notre page.
+Naviguer entre les pages à l'aide de [`<NuxtLink>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component) est fait du côté client afin que nous n'ayons pas besoin de refaire une requête au CDN et les appels à l'API seront chargés à partir du répertoire des ressources mis en cache et ce même si nous rafraîchissez manuellement notre page.
 
 ### Solution de secours: la SPA
 
@@ -58,7 +58,7 @@ Les pages qui auront été exclues de la génération en utilisant la propriét�
 
 <base-alert type="next">
 
-Pour en savoir davantage sur la [propriété `generate`](/guides/configuration-glossary/configuration-generate#exclude)
+Pour en savoir davantage sur la [propriété `generate`](/docs/2.x//configuration-glossary/configuration-generate#exclude)
 
 </base-alert>
 
@@ -68,6 +68,6 @@ Afin de récupérer le nouveau contenu sur notre site à partir de l'API, nous a
 
 ### Mode de prévisualisation
 
-Le mode de prévisualisation va appeler notre API ou notre CMS afin que nous puissions voir les changements en live avant de déployer. Se référer au [mode de prévisualisation](/guides/features/live-preview) pour activer cette fonctionnalité.
+Le mode de prévisualisation va appeler notre API ou notre CMS afin que nous puissions voir les changements en live avant de déployer. Se référer au [mode de prévisualisation](/docs/2.x//features/live-preview) pour activer cette fonctionnalité.
 
 <quiz :questions="questions"></quiz>

--- a/content/fr/guides/concepts/views.md
+++ b/content/fr/guides/concepts/views.md
@@ -74,7 +74,7 @@ Il y a beaucoup de propriétés possibles sur un composant Page comme le `head` 
 
 <base-alert type="next">
 
-Se référer à [la documentation sur la structure des répertoires](/docs/2.x//directory-structure/nuxt) pour en apprendre davantage sur les propriétés que nous pouvons utiliser sur notre page.
+Se référer à [la documentation sur la structure des répertoires]((/docs/2.x/directory-structure/nuxt) pour en apprendre davantage sur les propriétés que nous pouvons utiliser sur notre page.
 
 </base-alert>
 
@@ -94,7 +94,7 @@ Nous pouvons définir un layout par défaut en ajoutant un fichier `default.vue`
 
 <base-alert type="next">
 
-Se référer au [composant Nuxt](/docs/2.x//features/nuxt-components) dans le chapitre des composants.
+Se référer au [composant Nuxt]((/docs/2.x/features/nuxt-components) dans le chapitre des composants.
 
 </base-alert>
 

--- a/content/fr/guides/concepts/views.md
+++ b/content/fr/guides/concepts/views.md
@@ -74,7 +74,7 @@ Il y a beaucoup de propriétés possibles sur un composant Page comme le `head` 
 
 <base-alert type="next">
 
-Se référer à [la documentation sur la structure des répertoires](/guides/directory-structure/nuxt) pour en apprendre davantage sur les propriétés que nous pouvons utiliser sur notre page.
+Se référer à [la documentation sur la structure des répertoires](/docs/2.x//directory-structure/nuxt) pour en apprendre davantage sur les propriétés que nous pouvons utiliser sur notre page.
 
 </base-alert>
 
@@ -94,7 +94,7 @@ Nous pouvons définir un layout par défaut en ajoutant un fichier `default.vue`
 
 <base-alert type="next">
 
-Se référer au [composant Nuxt](/guides/features/nuxt-components) dans le chapitre des composants.
+Se référer au [composant Nuxt](/docs/2.x//features/nuxt-components) dans le chapitre des composants.
 
 </base-alert>
 

--- a/content/fr/guides/configuration-glossary/configuration-build.md
+++ b/content/fr/guides/configuration-glossary/configuration-build.md
@@ -156,7 +156,7 @@ Si cela a déjà été activé grâce au fichier `nuxt.config.js` ou autrement, 
 
 <base-alert>
 
-**Attention**: Les clés `isClient` et `isServer` fournies n'ont rien à voir avec celles présentes dans le [`context`](/docs/2.x//internals-glossary/context). Elles ne sont **pas** dépréciées. Il ne faut en outre pas utiliser `process.client` et `process.server` ici car ils seront `undefined` à ce niveau.
+**Attention**: Les clés `isClient` et `isServer` fournies n'ont rien à voir avec celles présentes dans le [`context`]((/docs/2.x/internals-glossary/context). Elles ne sont **pas** dépréciées. Il ne faut en outre pas utiliser `process.client` et `process.server` ici car ils seront `undefined` à ce niveau.
 
 </base-alert>
 
@@ -670,7 +670,7 @@ On ne peut pas utiliser d'alias de chemin (`~` ou `@`), on aura besoin d'utilise
 
 ## templates
 
-> Nuxt.js nous permet d'utiliser nos propres templates qui seront render basés sur les [modules](/docs/2.x//directory-structure/modules).
+> Nuxt.js nous permet d'utiliser nos propres templates qui seront render basés sur les [modules]((/docs/2.x/directory-structure/modules).
 
 - Type: `Array`
 
@@ -760,7 +760,7 @@ Depuis `v2.9.0`, on peut aussi utiliser une fonction pour rendre la transpilatio
 
 ## watch
 
-> On peut fournir nos propres fichiers personnalisés à surveiller avant de régénérer après des modifications. Cette fonctionnalité est surtout utile à utiliser avec [modules](/docs/2.x//directory-structure/modules).
+> On peut fournir nos propres fichiers personnalisés à surveiller avant de régénérer après des modifications. Cette fonctionnalité est surtout utile à utiliser avec [modules]((/docs/2.x/directory-structure/modules).
 
 - Type: `Array<String>`
 

--- a/content/fr/guides/configuration-glossary/configuration-build.md
+++ b/content/fr/guides/configuration-glossary/configuration-build.md
@@ -156,7 +156,7 @@ Si cela a déjà été activé grâce au fichier `nuxt.config.js` ou autrement, 
 
 <base-alert>
 
-**Attention**: Les clés `isClient` et `isServer` fournies n'ont rien à voir avec celles présentes dans le [`context`](/guides/internals-glossary/context). Elles ne sont **pas** dépréciées. Il ne faut en outre pas utiliser `process.client` et `process.server` ici car ils seront `undefined` à ce niveau.
+**Attention**: Les clés `isClient` et `isServer` fournies n'ont rien à voir avec celles présentes dans le [`context`](/docs/2.x//internals-glossary/context). Elles ne sont **pas** dépréciées. Il ne faut en outre pas utiliser `process.client` et `process.server` ici car ils seront `undefined` à ce niveau.
 
 </base-alert>
 
@@ -670,7 +670,7 @@ On ne peut pas utiliser d'alias de chemin (`~` ou `@`), on aura besoin d'utilise
 
 ## templates
 
-> Nuxt.js nous permet d'utiliser nos propres templates qui seront render basés sur les [modules](/guides/directory-structure/modules).
+> Nuxt.js nous permet d'utiliser nos propres templates qui seront render basés sur les [modules](/docs/2.x//directory-structure/modules).
 
 - Type: `Array`
 
@@ -760,7 +760,7 @@ Depuis `v2.9.0`, on peut aussi utiliser une fonction pour rendre la transpilatio
 
 ## watch
 
-> On peut fournir nos propres fichiers personnalisés à surveiller avant de régénérer après des modifications. Cette fonctionnalité est surtout utile à utiliser avec [modules](/guides/directory-structure/modules).
+> On peut fournir nos propres fichiers personnalisés à surveiller avant de régénérer après des modifications. Cette fonctionnalité est surtout utile à utiliser avec [modules](/docs/2.x//directory-structure/modules).
 
 - Type: `Array<String>`
 

--- a/content/fr/guides/configuration-glossary/configuration-dev.md
+++ b/content/fr/guides/configuration-glossary/configuration-dev.md
@@ -16,7 +16,7 @@ Cette propriété est écrasée par les commandes `nuxt`:
 - `dev` est forcé à `true` avec `nuxt`
 - `dev` est forcé à `false` avec `nuxt build`, `nuxt start` et `nuxt generate`
 
-Cette propriété devrait être utilisée lorsque l'on utilise Nuxt de [manière programmatique](/guides/internals-glossary/nuxt):
+Cette propriété devrait être utilisée lorsque l'on utilise Nuxt de [manière programmatique](/docs/2.x//internals-glossary/nuxt):
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/fr/guides/configuration-glossary/configuration-dev.md
+++ b/content/fr/guides/configuration-glossary/configuration-dev.md
@@ -16,7 +16,7 @@ Cette propriété est écrasée par les commandes `nuxt`:
 - `dev` est forcé à `true` avec `nuxt`
 - `dev` est forcé à `false` avec `nuxt build`, `nuxt start` et `nuxt generate`
 
-Cette propriété devrait être utilisée lorsque l'on utilise Nuxt de [manière programmatique](/docs/2.x//internals-glossary/nuxt):
+Cette propriété devrait être utilisée lorsque l'on utilise Nuxt de [manière programmatique]((/docs/2.x/internals-glossary/nuxt):
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/fr/guides/configuration-glossary/configuration-env.md
+++ b/content/fr/guides/configuration-glossary/configuration-env.md
@@ -27,7 +27,7 @@ Cela nous permet de créer une propriété `baseUrl` qui sera égale à la varia
 Ensuite, on peut avoir accès à la variable `baseUrl` de 2 façons:
 
 1. Via `process.env.baseUrl`.
-2. Via `context.env.baseUrl`, voir l'[API context](/guides/internals-glossary/context).
+2. Via `context.env.baseUrl`, voir l'[API context](/docs/2.x//internals-glossary/context).
 
 On peut par exemple, utiliser la propriété `env` pour donner un token public.
 
@@ -69,4 +69,4 @@ if ('testing123' == 'testing123')
 
 ## serverMiddleware
 
-Comme le [serverMiddleware](/guides/configuration-glossary/configuration-servermiddleware) est découplé du build principal de Nuxt.js, les variables `env` définies dans le fichier `nuxt.config.js` n'y seront pas disponibles.
+Comme le [serverMiddleware](/docs/2.x//configuration-glossary/configuration-servermiddleware) est découplé du build principal de Nuxt.js, les variables `env` définies dans le fichier `nuxt.config.js` n'y seront pas disponibles.

--- a/content/fr/guides/configuration-glossary/configuration-env.md
+++ b/content/fr/guides/configuration-glossary/configuration-env.md
@@ -27,7 +27,7 @@ Cela nous permet de créer une propriété `baseUrl` qui sera égale à la varia
 Ensuite, on peut avoir accès à la variable `baseUrl` de 2 façons:
 
 1. Via `process.env.baseUrl`.
-2. Via `context.env.baseUrl`, voir l'[API context](/docs/2.x//internals-glossary/context).
+2. Via `context.env.baseUrl`, voir l'[API context]((/docs/2.x/internals-glossary/context).
 
 On peut par exemple, utiliser la propriété `env` pour donner un token public.
 
@@ -69,4 +69,4 @@ if ('testing123' == 'testing123')
 
 ## serverMiddleware
 
-Comme le [serverMiddleware](/docs/2.x//configuration-glossary/configuration-servermiddleware) est découplé du build principal de Nuxt.js, les variables `env` définies dans le fichier `nuxt.config.js` n'y seront pas disponibles.
+Comme le [serverMiddleware]((/docs/2.x/configuration-glossary/configuration-servermiddleware) est découplé du build principal de Nuxt.js, les variables `env` définies dans le fichier `nuxt.config.js` n'y seront pas disponibles.

--- a/content/fr/guides/configuration-glossary/configuration-extend-plugins.md
+++ b/content/fr/guides/configuration-glossary/configuration-extend-plugins.md
@@ -6,12 +6,12 @@ category: configuration-glossary
 position: 9
 ---
 
-> La propriété extendPlugins permet de personnaliser les plugins de Nuxt.js ([options.plugins](/guides/configuration-glossary/configuration-plugins)).
+> La propriété extendPlugins permet de personnaliser les plugins de Nuxt.js ([options.plugins](/docs/2.x//configuration-glossary/configuration-plugins)).
 
 - Type: `Function`
 - Par défaut: `undefined`
 
-On pourrait vouloir personnaliser les plugins ou changer l'ordre crée par Nuxt.js pour ceux-ci. Cette fonction accepte un tableau d'objets de [plugins](/guides/configuration-glossary/configuration-plugins) et doit renvoyer un tableau d'objets de plugins.
+On pourrait vouloir personnaliser les plugins ou changer l'ordre crée par Nuxt.js pour ceux-ci. Cette fonction accepte un tableau d'objets de [plugins](/docs/2.x//configuration-glossary/configuration-plugins) et doit renvoyer un tableau d'objets de plugins.
 
 Exemple de changement de l'ordre des plugins:
 

--- a/content/fr/guides/configuration-glossary/configuration-extend-plugins.md
+++ b/content/fr/guides/configuration-glossary/configuration-extend-plugins.md
@@ -6,12 +6,12 @@ category: configuration-glossary
 position: 9
 ---
 
-> La propriété extendPlugins permet de personnaliser les plugins de Nuxt.js ([options.plugins](/docs/2.x//configuration-glossary/configuration-plugins)).
+> La propriété extendPlugins permet de personnaliser les plugins de Nuxt.js ([options.plugins]((/docs/2.x/configuration-glossary/configuration-plugins)).
 
 - Type: `Function`
 - Par défaut: `undefined`
 
-On pourrait vouloir personnaliser les plugins ou changer l'ordre crée par Nuxt.js pour ceux-ci. Cette fonction accepte un tableau d'objets de [plugins](/docs/2.x//configuration-glossary/configuration-plugins) et doit renvoyer un tableau d'objets de plugins.
+On pourrait vouloir personnaliser les plugins ou changer l'ordre crée par Nuxt.js pour ceux-ci. Cette fonction accepte un tableau d'objets de [plugins]((/docs/2.x/configuration-glossary/configuration-plugins) et doit renvoyer un tableau d'objets de plugins.
 
 Exemple de changement de l'ordre des plugins:
 

--- a/content/fr/guides/configuration-glossary/configuration-generate.md
+++ b/content/fr/guides/configuration-glossary/configuration-generate.md
@@ -26,7 +26,7 @@ export default {
 
 - Type: `Object` ou `false`
 
-Cette option est utilisée par `nuxt generate` avec la [cible statique](/docs/2.x//features/deployment-targets#static-hosting) pour éviter de re-build lorsque les fichiers traqués n'ont pas été modifiés.
+Cette option est utilisée par `nuxt generate` avec la [cible statique]((/docs/2.x/features/deployment-targets#static-hosting) pour éviter de re-build lorsque les fichiers traqués n'ont pas été modifiés.
 
 Par défaut:
 
@@ -193,7 +193,7 @@ L'intervalle entre 2 cycles de render, utile pour éviter de spam une API avec l
 ## minify
 
 - **Déprécié !**
-- Il faut utiliser [build.html.minify](/docs/2.x//configuration-glossary/configuration-build#htmlminify) à la place.
+- Il faut utiliser [build.html.minify]((/docs/2.x/configuration-glossary/configuration-build#htmlminify) à la place.
 
 ## routes
 

--- a/content/fr/guides/configuration-glossary/configuration-generate.md
+++ b/content/fr/guides/configuration-glossary/configuration-generate.md
@@ -26,7 +26,7 @@ export default {
 
 - Type: `Object` ou `false`
 
-Cette option est utilisée par `nuxt generate` avec la [cible statique](/guides/features/deployment-targets#static-hosting) pour éviter de re-build lorsque les fichiers traqués n'ont pas été modifiés.
+Cette option est utilisée par `nuxt generate` avec la [cible statique](/docs/2.x//features/deployment-targets#static-hosting) pour éviter de re-build lorsque les fichiers traqués n'ont pas été modifiés.
 
 Par défaut:
 
@@ -193,7 +193,7 @@ L'intervalle entre 2 cycles de render, utile pour éviter de spam une API avec l
 ## minify
 
 - **Déprécié !**
-- Il faut utiliser [build.html.minify](/guides/configuration-glossary/configuration-build#htmlminify) à la place.
+- Il faut utiliser [build.html.minify](/docs/2.x//configuration-glossary/configuration-build#htmlminify) à la place.
 
 ## routes
 

--- a/content/fr/guides/configuration-glossary/configuration-head.md
+++ b/content/fr/guides/configuration-glossary/configuration-head.md
@@ -27,7 +27,7 @@ export default {
 
 Pour connaître la liste des options que vous pouvez donner à `head`, consultez la documentation [vue-meta](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
 
-Vous pouvez également utiliser `head` comme fonction dans vos composants pour accéder aux données des composants avec `this` ([en savoir plus](/docs/2.x//components-glossary/pages-head)).
+Vous pouvez également utiliser `head` comme fonction dans vos composants pour accéder aux données des composants avec `this` ([en savoir plus]((/docs/2.x/components-glossary/pages-head)).
 
 <base-alert type="info">
 

--- a/content/fr/guides/configuration-glossary/configuration-head.md
+++ b/content/fr/guides/configuration-glossary/configuration-head.md
@@ -27,7 +27,7 @@ export default {
 
 Pour connaître la liste des options que vous pouvez donner à `head`, consultez la documentation [vue-meta](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
 
-Vous pouvez également utiliser `head` comme fonction dans vos composants pour accéder aux données des composants avec `this` ([en savoir plus](/guides/components-glossary/pages-head)).
+Vous pouvez également utiliser `head` comme fonction dans vos composants pour accéder aux données des composants avec `this` ([en savoir plus](/docs/2.x//components-glossary/pages-head)).
 
 <base-alert type="info">
 

--- a/content/fr/guides/configuration-glossary/configuration-mode.md
+++ b/content/fr/guides/configuration-glossary/configuration-mode.md
@@ -22,12 +22,12 @@ Déprécié: il faut utiliser `ssr: false` au lieu de `mode: spa`.
 
 <base-alert type="next">
 
-Pour en savoir davantage sur l'option `SSR`, il faut se référer à la [propriété ssr](/docs/2.x//configuration-glossary/configuration-ssr).
+Pour en savoir davantage sur l'option `SSR`, il faut se référer à la [propriété ssr]((/docs/2.x/configuration-glossary/configuration-ssr).
 
 </base-alert>
 
 <base-alert type="next">
 
-Pour en savoir davantage sur l'option `mode`, il faut se référer à la section sur les [modes de render](/docs/2.x//features/rendering-modes).
+Pour en savoir davantage sur l'option `mode`, il faut se référer à la section sur les [modes de render]((/docs/2.x/features/rendering-modes).
 
 </base-alert>

--- a/content/fr/guides/configuration-glossary/configuration-mode.md
+++ b/content/fr/guides/configuration-glossary/configuration-mode.md
@@ -22,12 +22,12 @@ Déprécié: il faut utiliser `ssr: false` au lieu de `mode: spa`.
 
 <base-alert type="next">
 
-Pour en savoir davantage sur l'option `SSR`, il faut se référer à la [propriété ssr](/guides/configuration-glossary/configuration-ssr).
+Pour en savoir davantage sur l'option `SSR`, il faut se référer à la [propriété ssr](/docs/2.x//configuration-glossary/configuration-ssr).
 
 </base-alert>
 
 <base-alert type="next">
 
-Pour en savoir davantage sur l'option `mode`, il faut se référer à la section sur les [modes de render](/guides/features/rendering-modes).
+Pour en savoir davantage sur l'option `mode`, il faut se référer à la section sur les [modes de render](/docs/2.x//features/rendering-modes).
 
 </base-alert>

--- a/content/fr/guides/configuration-glossary/configuration-modern.md
+++ b/content/fr/guides/configuration-glossary/configuration-modern.md
@@ -43,6 +43,6 @@ Les deux bundles possibles sont:
 | spa       |   client    |
 
 - Le mode `moderne` pour `nuxt generate` ne peut être que `client`
-- Il faut utiliser [`render.crossorigin`](/docs/2.x//configuration-glossary/configuration-render#crossorigin) pour définir l'attribut `crossorigin` dans `<link>` et `<script>`.
+- Il faut utiliser [`render.crossorigin`]((/docs/2.x/configuration-glossary/configuration-render#crossorigin) pour définir l'attribut `crossorigin` dans `<link>` et `<script>`.
 
 > Se réferer à l'excellent post de [Phillip Walton](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) sur les builds modernes.

--- a/content/fr/guides/configuration-glossary/configuration-modern.md
+++ b/content/fr/guides/configuration-glossary/configuration-modern.md
@@ -43,6 +43,6 @@ Les deux bundles possibles sont:
 | spa       |   client    |
 
 - Le mode `moderne` pour `nuxt generate` ne peut être que `client`
-- Il faut utiliser [`render.crossorigin`](/guides/configuration-glossary/configuration-render#crossorigin) pour définir l'attribut `crossorigin` dans `<link>` et `<script>`.
+- Il faut utiliser [`render.crossorigin`](/docs/2.x//configuration-glossary/configuration-render#crossorigin) pour définir l'attribut `crossorigin` dans `<link>` et `<script>`.
 
 > Se réferer à l'excellent post de [Phillip Walton](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) sur les builds modernes.

--- a/content/fr/guides/configuration-glossary/configuration-modules.md
+++ b/content/fr/guides/configuration-glossary/configuration-modules.md
@@ -8,7 +8,7 @@ position: 19
 
 - Type: `Array`
 
-> Les modules sont des extensions Nuxt.js qui peuvent personnaliser les fonctionnalités principales et ajouter des intégrations sans fin. [En apprendre davantage](/docs/2.x//directory-structure/modules)
+> Les modules sont des extensions Nuxt.js qui peuvent personnaliser les fonctionnalités principales et ajouter des intégrations sans fin. [En apprendre davantage]((/docs/2.x/directory-structure/modules)
 
 Exemple (`nuxt.config.js`):
 
@@ -36,7 +36,7 @@ Nuxt.js essaie de résoudre chaque élément qui est présent dans le tableau de
 
 Les modules doivent exporter une fonction pour permettre d'améliorer le build/runtime et peuvent (optionnel) aussi retourner une promesse en attendant que leur job ne soit terminé. À noter qu'ils seront importés au runtime, donc ils doivent déjà être transpilés s'ils utilisent des fonctionnalités modernes (ex: ES6).
 
-Se référer au [guide des modules](/docs/2.x//directory-structure/modules) pour des informations détaillées sur leur fonctionnement ou si l'on souhaite développer son propre module. En outre, nous avons une section officielle des [modules](https://github.com/nuxt-community/awesome-nuxt#modules), listant des douzaines de modules prêts à l'emploi et faits par la communauté de Nuxt.js.
+Se référer au [guide des modules]((/docs/2.x/directory-structure/modules) pour des informations détaillées sur leur fonctionnement ou si l'on souhaite développer son propre module. En outre, nous avons une section officielle des [modules](https://github.com/nuxt-community/awesome-nuxt#modules), listant des douzaines de modules prêts à l'emploi et faits par la communauté de Nuxt.js.
 
 ## `buildModules`
 

--- a/content/fr/guides/configuration-glossary/configuration-modules.md
+++ b/content/fr/guides/configuration-glossary/configuration-modules.md
@@ -8,7 +8,7 @@ position: 19
 
 - Type: `Array`
 
-> Les modules sont des extensions Nuxt.js qui peuvent personnaliser les fonctionnalités principales et ajouter des intégrations sans fin. [En apprendre davantage](/guides/directory-structure/modules)
+> Les modules sont des extensions Nuxt.js qui peuvent personnaliser les fonctionnalités principales et ajouter des intégrations sans fin. [En apprendre davantage](/docs/2.x//directory-structure/modules)
 
 Exemple (`nuxt.config.js`):
 
@@ -36,7 +36,7 @@ Nuxt.js essaie de résoudre chaque élément qui est présent dans le tableau de
 
 Les modules doivent exporter une fonction pour permettre d'améliorer le build/runtime et peuvent (optionnel) aussi retourner une promesse en attendant que leur job ne soit terminé. À noter qu'ils seront importés au runtime, donc ils doivent déjà être transpilés s'ils utilisent des fonctionnalités modernes (ex: ES6).
 
-Se référer au [guide des modules](/guides/directory-structure/modules) pour des informations détaillées sur leur fonctionnement ou si l'on souhaite développer son propre module. En outre, nous avons une section officielle des [modules](https://github.com/nuxt-community/awesome-nuxt#modules), listant des douzaines de modules prêts à l'emploi et faits par la communauté de Nuxt.js.
+Se référer au [guide des modules](/docs/2.x//directory-structure/modules) pour des informations détaillées sur leur fonctionnement ou si l'on souhaite développer son propre module. En outre, nous avons une section officielle des [modules](https://github.com/nuxt-community/awesome-nuxt#modules), listant des douzaines de modules prêts à l'emploi et faits par la communauté de Nuxt.js.
 
 ## `buildModules`
 

--- a/content/fr/guides/configuration-glossary/configuration-rootdir.md
+++ b/content/fr/guides/configuration-glossary/configuration-rootdir.md
@@ -19,6 +19,6 @@ Exemple: lancer `nuxt ./my-app/` va définir `rootDir` au chemin absolu `./my-ap
 
 <base-alert type="info">
 
-`rootDir` doit être au même niveau que le répertoire `node_modules` afin de pouvoir [résoudre les dépendances](https://nodejs.org/api/modules.html#modules_all_together). Se référer à l'[option `srcDir`](/docs/2.x//configuration-glossary/configuration-srcdir) pour des exemples de structure de répertoire lorsque ce n'est pas le cas.
+`rootDir` doit être au même niveau que le répertoire `node_modules` afin de pouvoir [résoudre les dépendances](https://nodejs.org/api/modules.html#modules_all_together). Se référer à l'[option `srcDir`]((/docs/2.x/configuration-glossary/configuration-srcdir) pour des exemples de structure de répertoire lorsque ce n'est pas le cas.
 
 </base-alert>

--- a/content/fr/guides/configuration-glossary/configuration-rootdir.md
+++ b/content/fr/guides/configuration-glossary/configuration-rootdir.md
@@ -19,6 +19,6 @@ Exemple: lancer `nuxt ./my-app/` va définir `rootDir` au chemin absolu `./my-ap
 
 <base-alert type="info">
 
-`rootDir` doit être au même niveau que le répertoire `node_modules` afin de pouvoir [résoudre les dépendances](https://nodejs.org/api/modules.html#modules_all_together). Se référer à l'[option `srcDir`](/guides/configuration-glossary/configuration-srcdir) pour des exemples de structure de répertoire lorsque ce n'est pas le cas.
+`rootDir` doit être au même niveau que le répertoire `node_modules` afin de pouvoir [résoudre les dépendances](https://nodejs.org/api/modules.html#modules_all_together). Se référer à l'[option `srcDir`](/docs/2.x//configuration-glossary/configuration-srcdir) pour des exemples de structure de répertoire lorsque ce n'est pas le cas.
 
 </base-alert>

--- a/content/fr/guides/configuration-glossary/configuration-router.md
+++ b/content/fr/guides/configuration-glossary/configuration-router.md
@@ -17,7 +17,7 @@ L'URL de base de l'application. Par exemple, si l'intégralité de la SPA se sit
 
 Ceci peut être utile si l'on a besoin de servir du Nuxt.js dans un autre contexte, tel qu'une partie d'un plus gros site par exemple. Il sera à vous de juger si vous pensez qu'un reverse proxy pour le front sera nécessaire ou pas.
 
-Si on veut une redirection sur le `router.base`, on peut y parvenir en utilisant un hook, se référer à la documentation sur la [redirection sur router.base lorsque non à la racine](/docs/2.x//configuration-glossary/configuration-hooks#redirect-to-routerbase-when-not-on-root).
+Si on veut une redirection sur le `router.base`, on peut y parvenir en utilisant un hook, se référer à la documentation sur la [redirection sur router.base lorsque non à la racine]((/docs/2.x/configuration-glossary/configuration-hooks#redirect-to-routerbase-when-not-on-root).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -129,7 +129,7 @@ Si on le passe à `false`, le router va faire un rafraîchissement à chaque nav
 - Type: `String`
 - Par défaut: `'nuxt-link-active'`
 
-Permet de personnaliser globalement la classe active par défaut de [`<nuxt-link>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component).
+Permet de personnaliser globalement la classe active par défaut de [`<nuxt-link>`]((/docs/2.x/features/nuxt-components#the-nuxtlink-component).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -146,7 +146,7 @@ export default {
 - Type: `String`
 - Par défaut: `'nuxt-link-exact-active'`
 
-Permet de personnaliser globalement la classe active exacte par défaut de [`<nuxt-link>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component).
+Permet de personnaliser globalement la classe active exacte par défaut de [`<nuxt-link>`]((/docs/2.x/features/nuxt-components#the-nuxtlink-component).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -163,7 +163,7 @@ export default {
 - Type: `String`
 - Par défaut: `false`
 
-Permet de personnaliser globalement la classe prefetch par défaut de [`<nuxt-link>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component) (cette option est désactivée par défaut).
+Permet de personnaliser globalement la classe prefetch par défaut de [`<nuxt-link>`]((/docs/2.x/features/nuxt-components#the-nuxtlink-component) (cette option est désactivée par défaut).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -198,7 +198,7 @@ export default function (context) {
 }
 ```
 
-Pour en apprendre davantage, se référer au [guide du middleware](/docs/2.x//directory-structure/middleware#router-middleware).
+Pour en apprendre davantage, se référer au [guide du middleware]((/docs/2.x/directory-structure/middleware#router-middleware).
 
 ## mode
 
@@ -277,7 +277,7 @@ Depuis Nuxt.js v2.10.0, si nous avons défini `prefetchLinks` à `false` mais so
 
 ## prefetchPayloads
 
-> Ajouté avec la v2.13.0, disponible seulement pour une [cible statique](/docs/2.x//features/deployment-targets#static-hosting).
+> Ajouté avec la v2.13.0, disponible seulement pour une [cible statique]((/docs/2.x/features/deployment-targets#static-hosting).
 
 - Type: `Boolean`
 - Par défaut: `true`

--- a/content/fr/guides/configuration-glossary/configuration-router.md
+++ b/content/fr/guides/configuration-glossary/configuration-router.md
@@ -17,7 +17,7 @@ L'URL de base de l'application. Par exemple, si l'intégralité de la SPA se sit
 
 Ceci peut être utile si l'on a besoin de servir du Nuxt.js dans un autre contexte, tel qu'une partie d'un plus gros site par exemple. Il sera à vous de juger si vous pensez qu'un reverse proxy pour le front sera nécessaire ou pas.
 
-Si on veut une redirection sur le `router.base`, on peut y parvenir en utilisant un hook, se référer à la documentation sur la [redirection sur router.base lorsque non à la racine](/guides/configuration-glossary/configuration-hooks#redirect-to-routerbase-when-not-on-root).
+Si on veut une redirection sur le `router.base`, on peut y parvenir en utilisant un hook, se référer à la documentation sur la [redirection sur router.base lorsque non à la racine](/docs/2.x//configuration-glossary/configuration-hooks#redirect-to-routerbase-when-not-on-root).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -129,7 +129,7 @@ Si on le passe à `false`, le router va faire un rafraîchissement à chaque nav
 - Type: `String`
 - Par défaut: `'nuxt-link-active'`
 
-Permet de personnaliser globalement la classe active par défaut de [`<nuxt-link>`](/guides/features/nuxt-components#the-nuxtlink-component).
+Permet de personnaliser globalement la classe active par défaut de [`<nuxt-link>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -146,7 +146,7 @@ export default {
 - Type: `String`
 - Par défaut: `'nuxt-link-exact-active'`
 
-Permet de personnaliser globalement la classe active exacte par défaut de [`<nuxt-link>`](/guides/features/nuxt-components#the-nuxtlink-component).
+Permet de personnaliser globalement la classe active exacte par défaut de [`<nuxt-link>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -163,7 +163,7 @@ export default {
 - Type: `String`
 - Par défaut: `false`
 
-Permet de personnaliser globalement la classe prefetch par défaut de [`<nuxt-link>`](/guides/features/nuxt-components#the-nuxtlink-component) (cette option est désactivée par défaut).
+Permet de personnaliser globalement la classe prefetch par défaut de [`<nuxt-link>`](/docs/2.x//features/nuxt-components#the-nuxtlink-component) (cette option est désactivée par défaut).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -198,7 +198,7 @@ export default function (context) {
 }
 ```
 
-Pour en apprendre davantage, se référer au [guide du middleware](/guides/directory-structure/middleware#router-middleware).
+Pour en apprendre davantage, se référer au [guide du middleware](/docs/2.x//directory-structure/middleware#router-middleware).
 
 ## mode
 
@@ -277,7 +277,7 @@ Depuis Nuxt.js v2.10.0, si nous avons défini `prefetchLinks` à `false` mais so
 
 ## prefetchPayloads
 
-> Ajouté avec la v2.13.0, disponible seulement pour une [cible statique](/guides/features/deployment-targets#static-hosting).
+> Ajouté avec la v2.13.0, disponible seulement pour une [cible statique](/docs/2.x//features/deployment-targets#static-hosting).
 
 - Type: `Boolean`
 - Par défaut: `true`

--- a/content/fr/guides/configuration-glossary/configuration-server.md
+++ b/content/fr/guides/configuration-glossary/configuration-server.md
@@ -22,7 +22,7 @@ export default {
 }
 ```
 
-Cela vous permet de spécifier l'[hôte et le port](/guides/features/configuration#edit-host-and-port) pour votre instance de serveur Nuxt.js.
+Cela vous permet de spécifier l'[hôte et le port](/docs/2.x//features/configuration#edit-host-and-port) pour votre instance de serveur Nuxt.js.
 
 ## Exemple utilisant la configuration HTTPS
 

--- a/content/fr/guides/configuration-glossary/configuration-server.md
+++ b/content/fr/guides/configuration-glossary/configuration-server.md
@@ -22,7 +22,7 @@ export default {
 }
 ```
 
-Cela vous permet de spécifier l'[hôte et le port](/docs/2.x//features/configuration#edit-host-and-port) pour votre instance de serveur Nuxt.js.
+Cela vous permet de spécifier l'[hôte et le port]((/docs/2.x/features/configuration#edit-host-and-port) pour votre instance de serveur Nuxt.js.
 
 ## Exemple utilisant la configuration HTTPS
 

--- a/content/fr/guides/configuration-glossary/configuration-servermiddleware.md
+++ b/content/fr/guides/configuration-glossary/configuration-servermiddleware.md
@@ -11,7 +11,7 @@ position: 27
 
 Nuxt crée en interne une instance [connect](https://github.com/senchalabs/connect) à laquelle vous pouvez ajouter votre propre middleware personnalisé. Cela nous permet d'enregistrer des routes supplémentaires (généralement des routes `/api`) **sans avoir besoin d'un serveur externe**.
 
-Parce que Connect itself est un middleware, les middleware enregistrés fonctionneront avec `nuxt start` et aussi lorsqu'il est utilisé comme un middleware avec des usages programmatiques comme [express-template](https://github.com/nuxt-community/express-template). Les [Modules](/guide/modules) nuxt peuvent également fournir `serverMiddleware` en utilisant [this.addServerMiddleware()](/docs/2.x//internals-glossary/internals-module-container#addservermiddleware-middleware)
+Parce que Connect itself est un middleware, les middleware enregistrés fonctionneront avec `nuxt start` et aussi lorsqu'il est utilisé comme un middleware avec des usages programmatiques comme [express-template](https://github.com/nuxt-community/express-template). Les [Modules](/guide/modules) nuxt peuvent également fournir `serverMiddleware` en utilisant [this.addServerMiddleware()]((/docs/2.x/internals-glossary/internals-module-container#addservermiddleware-middleware)
 
 En plus, nous avons introduit une option `prefix` dont la valeur par défaut est `true`. Elle ajoutera la base du routeur aux middlewares de votre serveur.
 

--- a/content/fr/guides/configuration-glossary/configuration-servermiddleware.md
+++ b/content/fr/guides/configuration-glossary/configuration-servermiddleware.md
@@ -11,7 +11,7 @@ position: 27
 
 Nuxt crée en interne une instance [connect](https://github.com/senchalabs/connect) à laquelle vous pouvez ajouter votre propre middleware personnalisé. Cela nous permet d'enregistrer des routes supplémentaires (généralement des routes `/api`) **sans avoir besoin d'un serveur externe**.
 
-Parce que Connect itself est un middleware, les middleware enregistrés fonctionneront avec `nuxt start` et aussi lorsqu'il est utilisé comme un middleware avec des usages programmatiques comme [express-template](https://github.com/nuxt-community/express-template). Les [Modules](/guide/modules) nuxt peuvent également fournir `serverMiddleware` en utilisant [this.addServerMiddleware()](/guides/internals-glossary/internals-module-container#addservermiddleware-middleware)
+Parce que Connect itself est un middleware, les middleware enregistrés fonctionneront avec `nuxt start` et aussi lorsqu'il est utilisé comme un middleware avec des usages programmatiques comme [express-template](https://github.com/nuxt-community/express-template). Les [Modules](/guide/modules) nuxt peuvent également fournir `serverMiddleware` en utilisant [this.addServerMiddleware()](/docs/2.x//internals-glossary/internals-module-container#addservermiddleware-middleware)
 
 En plus, nous avons introduit une option `prefix` dont la valeur par défaut est `true`. Elle ajoutera la base du routeur aux middlewares de votre serveur.
 

--- a/content/fr/guides/configuration-glossary/configuration-srcdir.md
+++ b/content/fr/guides/configuration-glossary/configuration-srcdir.md
@@ -7,7 +7,7 @@ position: 28
 ---
 
 - Type: `String`
-- Par défaut : [rootDir value](/docs/2.x//configuration-glossary/configuration-rootdir)
+- Par défaut : [rootDir value]((/docs/2.x/configuration-glossary/configuration-rootdir)
 
 > Défini le répertoire source de votre application Nuxt.js
 

--- a/content/fr/guides/configuration-glossary/configuration-srcdir.md
+++ b/content/fr/guides/configuration-glossary/configuration-srcdir.md
@@ -7,7 +7,7 @@ position: 28
 ---
 
 - Type: `String`
-- Par défaut : [rootDir value](/guides/configuration-glossary/configuration-rootdir)
+- Par défaut : [rootDir value](/docs/2.x//configuration-glossary/configuration-rootdir)
 
 > Défini le répertoire source de votre application Nuxt.js
 

--- a/content/fr/guides/configuration-glossary/configuration-ssr.md
+++ b/content/fr/guides/configuration-glossary/configuration-ssr.md
@@ -21,6 +21,6 @@ export default {
 
 <base-alert type="next">
 
-Auparavant, le `mode` était utilisé pour désactiver ou activer le rendu côté serveur. Voici la [documentation de `mode'](/guides/configuration-glossary/configuration-mode).
+Auparavant, le `mode` était utilisé pour désactiver ou activer le rendu côté serveur. Voici la [documentation de `mode'](/docs/2.x//configuration-glossary/configuration-mode).
 
 </base-alert>

--- a/content/fr/guides/configuration-glossary/configuration-ssr.md
+++ b/content/fr/guides/configuration-glossary/configuration-ssr.md
@@ -21,6 +21,6 @@ export default {
 
 <base-alert type="next">
 
-Auparavant, le `mode` était utilisé pour désactiver ou activer le rendu côté serveur. Voici la [documentation de `mode'](/docs/2.x//configuration-glossary/configuration-mode).
+Auparavant, le `mode` était utilisé pour désactiver ou activer le rendu côté serveur. Voici la [documentation de `mode']((/docs/2.x/configuration-glossary/configuration-mode).
 
 </base-alert>

--- a/content/fr/guides/configuration-glossary/configuration-target.md
+++ b/content/fr/guides/configuration-glossary/configuration-target.md
@@ -16,4 +16,4 @@ Cibles de déploiement pour Nuxt >= v2.13 :
 
 > Vous pouvez utiliser cette option pour changer la cible de déploiement par défaut pour votre projet nuxt en utilisant `nuxt.config.js`
 
-Pour en savoir plus sur l'option `target`, consultez la [section sur les cibles de déploiement](/guides/features/deployment-targets).
+Pour en savoir plus sur l'option `target`, consultez la [section sur les cibles de déploiement](/docs/2.x//features/deployment-targets).

--- a/content/fr/guides/configuration-glossary/configuration-target.md
+++ b/content/fr/guides/configuration-glossary/configuration-target.md
@@ -16,4 +16,4 @@ Cibles de déploiement pour Nuxt >= v2.13 :
 
 > Vous pouvez utiliser cette option pour changer la cible de déploiement par défaut pour votre projet nuxt en utilisant `nuxt.config.js`
 
-Pour en savoir plus sur l'option `target`, consultez la [section sur les cibles de déploiement](/docs/2.x//features/deployment-targets).
+Pour en savoir plus sur l'option `target`, consultez la [section sur les cibles de déploiement]((/docs/2.x/features/deployment-targets).

--- a/content/fr/guides/configuration-glossary/configuration-transition.md
+++ b/content/fr/guides/configuration-glossary/configuration-transition.md
@@ -37,7 +37,7 @@ export default {
 }
 ```
 
-La clé de transition dans `nuxt.config.js` est utilisée pour définir les propriétés par défaut des transitions de page. Pour en savoir plus sur les clés disponibles, voir la [propriété de transition des pages](/docs/2.x//features/transitions).
+La clé de transition dans `nuxt.config.js` est utilisée pour définir les propriétés par défaut des transitions de page. Pour en savoir plus sur les clés disponibles, voir la [propriété de transition des pages]((/docs/2.x/features/transitions).
 
 ## La propriété layoutTransition
 

--- a/content/fr/guides/configuration-glossary/configuration-transition.md
+++ b/content/fr/guides/configuration-glossary/configuration-transition.md
@@ -37,7 +37,7 @@ export default {
 }
 ```
 
-La clé de transition dans `nuxt.config.js` est utilisée pour définir les propriétés par défaut des transitions de page. Pour en savoir plus sur les clés disponibles, voir la [propriété de transition des pages](/guides/features/transitions).
+La clé de transition dans `nuxt.config.js` est utilisée pour définir les propriétés par défaut des transitions de page. Pour en savoir plus sur les clés disponibles, voir la [propriété de transition des pages](/docs/2.x//features/transitions).
 
 ## La propriété layoutTransition
 

--- a/content/fr/guides/configuration-glossary/configuration-watchers.md
+++ b/content/fr/guides/configuration-glossary/configuration-watchers.md
@@ -38,6 +38,6 @@ Pour en savoir plus sur les options webpack de surveillance, voir la [documentat
 
 <base-alert type="next">
 
-Consultez le [Glossaire interne](/guides/internals-glossary/$nuxt)
+Consultez le [Glossaire interne](/docs/2.x//internals-glossary/$nuxt)
 
 </base-alert>

--- a/content/fr/guides/configuration-glossary/configuration-watchers.md
+++ b/content/fr/guides/configuration-glossary/configuration-watchers.md
@@ -38,6 +38,6 @@ Pour en savoir plus sur les options webpack de surveillance, voir la [documentat
 
 <base-alert type="next">
 
-Consultez le [Glossaire interne](/docs/2.x//internals-glossary/$nuxt)
+Consultez le [Glossaire interne]((/docs/2.x/internals-glossary/$nuxt)
 
 </base-alert>

--- a/content/fr/guides/directory-structure/assets.md
+++ b/content/fr/guides/directory-structure/assets.md
@@ -83,7 +83,7 @@ Si l'on travaille avec des images dynamiques, on aura besoin d'utiliser `require
 
 <base-alert type="next">
 
-Voir les [ressources webpack](/guides/directory-structure/assets#webpack-assets).
+Voir les [ressources webpack](/docs/2.x//directory-structure/assets#webpack-assets).
 
 </base-alert>
 
@@ -160,7 +160,7 @@ On peut utiliser des polices de caractères locales en les ajoutant dans le rép
 
 <base-alert type="next">
 
-Pour ajouter des polices de caractères externes telles que des Google Fonts, se référer le chapitre sur le [SEO et les méta tags](/guides/features/meta-tags-seo#external-resources).
+Pour ajouter des polices de caractères externes telles que des Google Fonts, se référer le chapitre sur le [SEO et les méta tags](/docs/2.x//features/meta-tags-seo#external-resources).
 
 </base-alert>
 
@@ -251,7 +251,7 @@ Cela sera transformé en:
 <img src="/_nuxt/img/notre_image.0c61159.png" />
 ```
 
-Si on souhaite changer la configuration d'un des loaders, on trouvera plus de détails à la page de [`build.extend`](/guides/configuration-glossary/configuration-build#extend).
+Si on souhaite changer la configuration d'un des loaders, on trouvera plus de détails à la page de [`build.extend`](/docs/2.x//configuration-glossary/configuration-build#extend).
 
 <app-modal>
   <code-sandbox :src="csb_link"></code-sandbox>

--- a/content/fr/guides/directory-structure/assets.md
+++ b/content/fr/guides/directory-structure/assets.md
@@ -83,7 +83,7 @@ Si l'on travaille avec des images dynamiques, on aura besoin d'utiliser `require
 
 <base-alert type="next">
 
-Voir les [ressources webpack](/docs/2.x//directory-structure/assets#webpack-assets).
+Voir les [ressources webpack]((/docs/2.x/directory-structure/assets#webpack-assets).
 
 </base-alert>
 
@@ -160,7 +160,7 @@ On peut utiliser des polices de caractères locales en les ajoutant dans le rép
 
 <base-alert type="next">
 
-Pour ajouter des polices de caractères externes telles que des Google Fonts, se référer le chapitre sur le [SEO et les méta tags](/docs/2.x//features/meta-tags-seo#external-resources).
+Pour ajouter des polices de caractères externes telles que des Google Fonts, se référer le chapitre sur le [SEO et les méta tags]((/docs/2.x/features/meta-tags-seo#external-resources).
 
 </base-alert>
 
@@ -251,7 +251,7 @@ Cela sera transformé en:
 <img src="/_nuxt/img/notre_image.0c61159.png" />
 ```
 
-Si on souhaite changer la configuration d'un des loaders, on trouvera plus de détails à la page de [`build.extend`](/docs/2.x//configuration-glossary/configuration-build#extend).
+Si on souhaite changer la configuration d'un des loaders, on trouvera plus de détails à la page de [`build.extend`]((/docs/2.x/configuration-glossary/configuration-build#extend).
 
 <app-modal>
   <code-sandbox :src="csb_link"></code-sandbox>

--- a/content/fr/guides/directory-structure/components.md
+++ b/content/fr/guides/directory-structure/components.md
@@ -37,7 +37,7 @@ Le répertoire des composants contient les composants Vue.js. Les composants son
 
 ### Récupérer de la data
 
-Pour récupérer de la data depuis une API de manière asynchrone dans les composants, on peut utiliser le hook [`fetch()`](/docs/2.x//features/data-fetching#the-fetch-method) de Nuxt.js.
+Pour récupérer de la data depuis une API de manière asynchrone dans les composants, on peut utiliser le hook [`fetch()`]((/docs/2.x/features/data-fetching#the-fetch-method) de Nuxt.js.
 
 En utilisant `$fetchState.pending`, on peut afficher un message pendant le chargement de la data. En utilisant `$fetchState.error`, on peut afficher un message d'erreur s'il y a une erreur lors de la récupération des données. Lorsque l'on utilise `fetch`, il faut définir la data dans la propriété `data`, celle-ci sera par la suite remplie une fois que les données auront été récoltées.
 
@@ -73,7 +73,7 @@ En utilisant `$fetchState.pending`, on peut afficher un message pendant le charg
 
 <base-alert type="next">
 
-Se référer au chapitre sur [fetch()](/docs/2.x//features/data-fetching#the-fetch-method) pour avoir davantage d'informations sur son fonctionnement.
+Se référer au chapitre sur [fetch()]((/docs/2.x/features/data-fetching#the-fetch-method) pour avoir davantage d'informations sur son fonctionnement.
 
 </base-alert>
 

--- a/content/fr/guides/directory-structure/components.md
+++ b/content/fr/guides/directory-structure/components.md
@@ -37,7 +37,7 @@ Le répertoire des composants contient les composants Vue.js. Les composants son
 
 ### Récupérer de la data
 
-Pour récupérer de la data depuis une API de manière asynchrone dans les composants, on peut utiliser le hook [`fetch()`](/guides/features/data-fetching#the-fetch-method) de Nuxt.js.
+Pour récupérer de la data depuis une API de manière asynchrone dans les composants, on peut utiliser le hook [`fetch()`](/docs/2.x//features/data-fetching#the-fetch-method) de Nuxt.js.
 
 En utilisant `$fetchState.pending`, on peut afficher un message pendant le chargement de la data. En utilisant `$fetchState.error`, on peut afficher un message d'erreur s'il y a une erreur lors de la récupération des données. Lorsque l'on utilise `fetch`, il faut définir la data dans la propriété `data`, celle-ci sera par la suite remplie une fois que les données auront été récoltées.
 
@@ -73,7 +73,7 @@ En utilisant `$fetchState.pending`, on peut afficher un message pendant le charg
 
 <base-alert type="next">
 
-Se référer au chapitre sur [fetch()](/guides/features/data-fetching#the-fetch-method) pour avoir davantage d'informations sur son fonctionnement.
+Se référer au chapitre sur [fetch()](/docs/2.x//features/data-fetching#the-fetch-method) pour avoir davantage d'informations sur son fonctionnement.
 
 </base-alert>
 

--- a/content/fr/guides/directory-structure/layouts.md
+++ b/content/fr/guides/directory-structure/layouts.md
@@ -94,7 +94,7 @@ Vous pouvez ajouter ici d'autres éléments tels que : Navigation, Header, Foote
 
 <base-alert type="info">
 
-Si vos [composants sont réglés sur true](/guides/directory-structure/components) alors il n'est pas nécessaire de déclarer l'importation pour vos composants.
+Si vos [composants sont réglés sur true](/docs/2.x//directory-structure/components) alors il n'est pas nécessaire de déclarer l'importation pour vos composants.
 
 </base-alert>
 

--- a/content/fr/guides/directory-structure/layouts.md
+++ b/content/fr/guides/directory-structure/layouts.md
@@ -94,7 +94,7 @@ Vous pouvez ajouter ici d'autres éléments tels que : Navigation, Header, Foote
 
 <base-alert type="info">
 
-Si vos [composants sont réglés sur true](/docs/2.x//directory-structure/components) alors il n'est pas nécessaire de déclarer l'importation pour vos composants.
+Si vos [composants sont réglés sur true]((/docs/2.x/directory-structure/components) alors il n'est pas nécessaire de déclarer l'importation pour vos composants.
 
 </base-alert>
 

--- a/content/fr/guides/directory-structure/middleware.md
+++ b/content/fr/guides/directory-structure/middleware.md
@@ -70,9 +70,9 @@ questions:
 
 Le répertoire `middleware` contient les middlewares de l'application. Un middleware nous permet de définir des fonctions personnalisées qui peuvent s'exécuter avant de render une page ou un groupe de pages (layout).
 
-Les middlewares partagés devraient être placés dans le répertoire `middleware/`. Le nom du fichiers sera aussi le nom du middleware (un fichier `middleware/auth.js` sera appelé avec middleware `auth`). On peut aussi utiliser des middlewares spécifiques à des pages en utilisant directement une fonction, voir [middlewares anonymes](/guides/components-glossary/pages-middleware#anonymous-middleware).
+Les middlewares partagés devraient être placés dans le répertoire `middleware/`. Le nom du fichiers sera aussi le nom du middleware (un fichier `middleware/auth.js` sera appelé avec middleware `auth`). On peut aussi utiliser des middlewares spécifiques à des pages en utilisant directement une fonction, voir [middlewares anonymes](/docs/2.x//components-glossary/pages-middleware#anonymous-middleware).
 
-Un middleware reçoit le [context](/guides/internals-glossary/context) en tant que premier argument.
+Un middleware reçoit le [context](/docs/2.x//internals-glossary/context) en tant que premier argument.
 
 ```js{}[middleware/user-agent.js]
 export default function (context) {

--- a/content/fr/guides/directory-structure/middleware.md
+++ b/content/fr/guides/directory-structure/middleware.md
@@ -70,9 +70,9 @@ questions:
 
 Le répertoire `middleware` contient les middlewares de l'application. Un middleware nous permet de définir des fonctions personnalisées qui peuvent s'exécuter avant de render une page ou un groupe de pages (layout).
 
-Les middlewares partagés devraient être placés dans le répertoire `middleware/`. Le nom du fichiers sera aussi le nom du middleware (un fichier `middleware/auth.js` sera appelé avec middleware `auth`). On peut aussi utiliser des middlewares spécifiques à des pages en utilisant directement une fonction, voir [middlewares anonymes](/docs/2.x//components-glossary/pages-middleware#anonymous-middleware).
+Les middlewares partagés devraient être placés dans le répertoire `middleware/`. Le nom du fichiers sera aussi le nom du middleware (un fichier `middleware/auth.js` sera appelé avec middleware `auth`). On peut aussi utiliser des middlewares spécifiques à des pages en utilisant directement une fonction, voir [middlewares anonymes]((/docs/2.x/components-glossary/pages-middleware#anonymous-middleware).
 
-Un middleware reçoit le [context](/docs/2.x//internals-glossary/context) en tant que premier argument.
+Un middleware reçoit le [context]((/docs/2.x/internals-glossary/context) en tant que premier argument.
 
 ```js{}[middleware/user-agent.js]
 export default function (context) {

--- a/content/fr/guides/directory-structure/modules.md
+++ b/content/fr/guides/directory-structure/modules.md
@@ -252,7 +252,7 @@ nuxt.hook('listen', async (server, {host, port})) => {
 
 `this`: le contexte des modules. Tous les modules seront appelés au sein du contexte de l'instance de `ModuleContainer`.
 
-Plus d'informations pour les méthodes disponibles sont présents dans la documentation du [ModuleContainer](/guides/internals-glossary/internals-module-container).
+Plus d'informations pour les méthodes disponibles sont présents dans la documentation du [ModuleContainer](/docs/2.x//internals-glossary/internals-module-container).
 
 ### Exécuter certaines actions lors de hooks spécifiques
 
@@ -382,7 +382,7 @@ export default function asyncModule($http) {
 
 <base-alert type="info">
 
-Il y a beaucoup de hooks et de possibilités pour les modules. Se référer au [fonctionnement interne](/guides/internals-glossary/internals) pour comprendre davantage l'API de Nuxt.js.
+Il y a beaucoup de hooks et de possibilités pour les modules. Se référer au [fonctionnement interne](/docs/2.x//internals-glossary/internals) pour comprendre davantage l'API de Nuxt.js.
 
 </base-alert>
 

--- a/content/fr/guides/directory-structure/modules.md
+++ b/content/fr/guides/directory-structure/modules.md
@@ -252,7 +252,7 @@ nuxt.hook('listen', async (server, {host, port})) => {
 
 `this`: le contexte des modules. Tous les modules seront appelés au sein du contexte de l'instance de `ModuleContainer`.
 
-Plus d'informations pour les méthodes disponibles sont présents dans la documentation du [ModuleContainer](/docs/2.x//internals-glossary/internals-module-container).
+Plus d'informations pour les méthodes disponibles sont présents dans la documentation du [ModuleContainer]((/docs/2.x/internals-glossary/internals-module-container).
 
 ### Exécuter certaines actions lors de hooks spécifiques
 
@@ -382,7 +382,7 @@ export default function asyncModule($http) {
 
 <base-alert type="info">
 
-Il y a beaucoup de hooks et de possibilités pour les modules. Se référer au [fonctionnement interne](/docs/2.x//internals-glossary/internals) pour comprendre davantage l'API de Nuxt.js.
+Il y a beaucoup de hooks et de possibilités pour les modules. Se référer au [fonctionnement interne]((/docs/2.x/internals-glossary/internals) pour comprendre davantage l'API de Nuxt.js.
 
 </base-alert>
 

--- a/content/fr/guides/directory-structure/nuxt-config.md
+++ b/content/fr/guides/directory-structure/nuxt-config.md
@@ -52,7 +52,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [build](/guides/configuration-glossary/configuration-build).
+Se référer à la propriété [build](/docs/2.x//configuration-glossary/configuration-build).
 
 </base-alert>
 
@@ -78,7 +78,7 @@ En omettant l'extension, cela nous permet de ne pas avoir à renommer le fichier
 
 <base-alert type="next">
 
-Se référer à la propriété [css](/guides/configuration-glossary/configuration-css).
+Se référer à la propriété [css](/docs/2.x//configuration-glossary/configuration-css).
 
 </base-alert>
 
@@ -94,7 +94,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [dev](/guides/configuration-glossary/configuration-dev).
+Se référer à la propriété [dev](/docs/2.x//configuration-glossary/configuration-dev).
 
 </base-alert>
 
@@ -112,7 +112,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [env](/guides/configuration-glossary/configuration-env).
+Se référer à la propriété [env](/docs/2.x//configuration-glossary/configuration-env).
 
 </base-alert>
 
@@ -131,7 +131,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [generate](/guides/configuration-glossary/configuration-generate).
+Se référer à la propriété [generate](/docs/2.x//configuration-glossary/configuration-generate).
 
 </base-alert>
 
@@ -153,7 +153,7 @@ Cette option permet de définir toutes les balises méta par défaut pour l'appl
 
 <base-alert type="next">
 
-Se référer à la propriété [head](/guides/configuration-glossary/configuration-head).
+Se référer à la propriété [head](/docs/2.x//configuration-glossary/configuration-head).
 
 </base-alert>
 
@@ -171,7 +171,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à l'intégration du [chargement](/guides/configuration-glossary/configuration-loading).
+Se référer à l'intégration du [chargement](/docs/2.x//configuration-glossary/configuration-loading).
 
 </base-alert>
 
@@ -187,7 +187,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [modules](/guides/configuration-glossary/configuration-modules).
+Se référer à la propriété [modules](/docs/2.x//configuration-glossary/configuration-modules).
 
 </base-alert>
 
@@ -205,7 +205,7 @@ Adapter cet emplacement peut être nécessaire si le projet est organisé en tan
 
 <base-alert type="next">
 
-Se référer à la propriété [modulesDir](/guides/configuration-glossary/configuration-modulesdir).
+Se référer à la propriété [modulesDir](/docs/2.x//configuration-glossary/configuration-modulesdir).
 
 </base-alert>
 
@@ -221,7 +221,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [plugins](/guides/configuration-glossary/configuration-plugins).
+Se référer à la propriété [plugins](/docs/2.x//configuration-glossary/configuration-plugins).
 
 </base-alert>
 
@@ -239,7 +239,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [router](/guides/configuration-glossary/configuration-router).
+Se référer à la propriété [router](/docs/2.x//configuration-glossary/configuration-router).
 
 </base-alert>
 
@@ -263,7 +263,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [server](/guides/configuration-glossary/configuration-server).
+Se référer à la propriété [server](/docs/2.x//configuration-glossary/configuration-server).
 
 </base-alert>
 
@@ -307,7 +307,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [dir](/guides/configuration-glossary/configuration-dir).
+Se référer à la propriété [dir](/docs/2.x//configuration-glossary/configuration-dir).
 
 </base-alert>
 
@@ -323,7 +323,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [transition](/guides/configuration-glossary/configuration-transition).
+Se référer à la propriété [transition](/docs/2.x//configuration-glossary/configuration-transition).
 
 </base-alert>
 
@@ -347,6 +347,6 @@ node_modules .nuxt dist
 
 <base-alert type="next">
 
-Se référer au [glossaire de configuration](/guides/configuration-glossary/configuration-build).
+Se référer au [glossaire de configuration](/docs/2.x//configuration-glossary/configuration-build).
 
 </base-alert>

--- a/content/fr/guides/directory-structure/nuxt-config.md
+++ b/content/fr/guides/directory-structure/nuxt-config.md
@@ -52,7 +52,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [build](/docs/2.x//configuration-glossary/configuration-build).
+Se référer à la propriété [build]((/docs/2.x/configuration-glossary/configuration-build).
 
 </base-alert>
 
@@ -78,7 +78,7 @@ En omettant l'extension, cela nous permet de ne pas avoir à renommer le fichier
 
 <base-alert type="next">
 
-Se référer à la propriété [css](/docs/2.x//configuration-glossary/configuration-css).
+Se référer à la propriété [css]((/docs/2.x/configuration-glossary/configuration-css).
 
 </base-alert>
 
@@ -94,7 +94,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [dev](/docs/2.x//configuration-glossary/configuration-dev).
+Se référer à la propriété [dev]((/docs/2.x/configuration-glossary/configuration-dev).
 
 </base-alert>
 
@@ -112,7 +112,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [env](/docs/2.x//configuration-glossary/configuration-env).
+Se référer à la propriété [env]((/docs/2.x/configuration-glossary/configuration-env).
 
 </base-alert>
 
@@ -131,7 +131,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [generate](/docs/2.x//configuration-glossary/configuration-generate).
+Se référer à la propriété [generate]((/docs/2.x/configuration-glossary/configuration-generate).
 
 </base-alert>
 
@@ -153,7 +153,7 @@ Cette option permet de définir toutes les balises méta par défaut pour l'appl
 
 <base-alert type="next">
 
-Se référer à la propriété [head](/docs/2.x//configuration-glossary/configuration-head).
+Se référer à la propriété [head]((/docs/2.x/configuration-glossary/configuration-head).
 
 </base-alert>
 
@@ -171,7 +171,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à l'intégration du [chargement](/docs/2.x//configuration-glossary/configuration-loading).
+Se référer à l'intégration du [chargement]((/docs/2.x/configuration-glossary/configuration-loading).
 
 </base-alert>
 
@@ -187,7 +187,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [modules](/docs/2.x//configuration-glossary/configuration-modules).
+Se référer à la propriété [modules]((/docs/2.x/configuration-glossary/configuration-modules).
 
 </base-alert>
 
@@ -205,7 +205,7 @@ Adapter cet emplacement peut être nécessaire si le projet est organisé en tan
 
 <base-alert type="next">
 
-Se référer à la propriété [modulesDir](/docs/2.x//configuration-glossary/configuration-modulesdir).
+Se référer à la propriété [modulesDir]((/docs/2.x/configuration-glossary/configuration-modulesdir).
 
 </base-alert>
 
@@ -221,7 +221,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [plugins](/docs/2.x//configuration-glossary/configuration-plugins).
+Se référer à la propriété [plugins]((/docs/2.x/configuration-glossary/configuration-plugins).
 
 </base-alert>
 
@@ -239,7 +239,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [router](/docs/2.x//configuration-glossary/configuration-router).
+Se référer à la propriété [router]((/docs/2.x/configuration-glossary/configuration-router).
 
 </base-alert>
 
@@ -263,7 +263,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [server](/docs/2.x//configuration-glossary/configuration-server).
+Se référer à la propriété [server]((/docs/2.x/configuration-glossary/configuration-server).
 
 </base-alert>
 
@@ -307,7 +307,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [dir](/docs/2.x//configuration-glossary/configuration-dir).
+Se référer à la propriété [dir]((/docs/2.x/configuration-glossary/configuration-dir).
 
 </base-alert>
 
@@ -323,7 +323,7 @@ export default {
 
 <base-alert type="next">
 
-Se référer à la propriété [transition](/docs/2.x//configuration-glossary/configuration-transition).
+Se référer à la propriété [transition]((/docs/2.x/configuration-glossary/configuration-transition).
 
 </base-alert>
 
@@ -347,6 +347,6 @@ node_modules .nuxt dist
 
 <base-alert type="next">
 
-Se référer au [glossaire de configuration](/docs/2.x//configuration-glossary/configuration-build).
+Se référer au [glossaire de configuration]((/docs/2.x/configuration-glossary/configuration-build).
 
 </base-alert>

--- a/content/fr/guides/directory-structure/pages.md
+++ b/content/fr/guides/directory-structure/pages.md
@@ -146,7 +146,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus sur le fonctionnement d'asyncData, consultez notre chapitre [Data Fetching](/guides/features/data-fetching#async-data)
+Pour en savoir plus sur le fonctionnement d'asyncData, consultez notre chapitre [Data Fetching](/docs/2.x//features/data-fetching#async-data)
 
 </base-alert>
 
@@ -173,7 +173,7 @@ Chaque fois que vous avez besoin d'obtenir des données asynchrones, vous pouvez
 
 <base-alert type="next">
 
-Pour en savoir plus sur le fonctionnement de l'extraction, consultez notre chapitre [Data Fetching](/guides/features/data-fetching)
+Pour en savoir plus sur le fonctionnement de l'extraction, consultez notre chapitre [Data Fetching](/docs/2.x//features/data-fetching)
 
 </base-alert>
 
@@ -191,7 +191,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre [Balises meta et référencement SEO](/guides/features/meta-tags-seo)
+Pour en savoir plus, consultez notre chapitre [Balises meta et référencement SEO](/docs/2.x//features/meta-tags-seo)
 
 </base-alert>
 
@@ -207,7 +207,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus sur les mises en page, consultez notre chapitre sur les [Vues](/guides/concepts/views#layouts).
+Pour en savoir plus sur les mises en page, consultez notre chapitre sur les [Vues](/docs/2.x//concepts/views#layouts).
 
 </base-alert>
 
@@ -229,7 +229,7 @@ S'applique uniquement si la propriété loading est également défini dans le f
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur le [Chargement](/guides/features/loading).
+Pour en savoir plus, consultez notre chapitre sur le [Chargement](/docs/2.x//features/loading).
 
 </base-alert>
 
@@ -245,7 +245,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur les [Transitions](/guides/features/transitions)
+Pour en savoir plus, consultez notre chapitre sur les [Transitions](/docs/2.x//features/transitions)
 
 </base-alert>
 
@@ -261,7 +261,7 @@ export default {
 
 Inversement, vous pouvez aussi régler manuellement `scrollToTop` à `false` sur les routes parentes.
 
-Si vous souhaitez remplacer le comportement de défilement par défaut de Nuxt.js, consultez l'option [scrollBehavior](/guides/configuration-glossary/configuration-router#scrollbehavior).
+Si vous souhaitez remplacer le comportement de défilement par défaut de Nuxt.js, consultez l'option [scrollBehavior](/docs/2.x//configuration-glossary/configuration-router#scrollbehavior).
 
 ### middleware
 
@@ -275,7 +275,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur les [Middleware](/guides/directory-structure/middleware)
+Pour en savoir plus, consultez notre chapitre sur les [Middleware](/docs/2.x//directory-structure/middleware)
 
 </base-alert>
 
@@ -315,7 +315,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus sur la propriété d'observation, consultez notre chapitre [Data Fetching](/guides/features/data-fetching) chapter
+Pour en savoir plus sur la propriété d'observation, consultez notre chapitre [Data Fetching](/docs/2.x//features/data-fetching) chapter
 
 </base-alert>
 
@@ -331,7 +331,7 @@ Par exemple, `pages/-about.vue` sera ignorée.
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur l'option [ignore](/guides/configuration-glossary/configuration-ignore)
+Pour en savoir plus, consultez notre chapitre sur l'option [ignore](/docs/2.x//configuration-glossary/configuration-ignore)
 
 </base-alert>
 
@@ -350,7 +350,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur l'option [dir](/guides/configuration-glossary/configuration-dir)
+Pour en savoir plus, consultez notre chapitre sur l'option [dir](/docs/2.x//configuration-glossary/configuration-dir)
 
 </base-alert>
 

--- a/content/fr/guides/directory-structure/pages.md
+++ b/content/fr/guides/directory-structure/pages.md
@@ -146,7 +146,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus sur le fonctionnement d'asyncData, consultez notre chapitre [Data Fetching](/docs/2.x//features/data-fetching#async-data)
+Pour en savoir plus sur le fonctionnement d'asyncData, consultez notre chapitre [Data Fetching]((/docs/2.x/features/data-fetching#async-data)
 
 </base-alert>
 
@@ -173,7 +173,7 @@ Chaque fois que vous avez besoin d'obtenir des données asynchrones, vous pouvez
 
 <base-alert type="next">
 
-Pour en savoir plus sur le fonctionnement de l'extraction, consultez notre chapitre [Data Fetching](/docs/2.x//features/data-fetching)
+Pour en savoir plus sur le fonctionnement de l'extraction, consultez notre chapitre [Data Fetching]((/docs/2.x/features/data-fetching)
 
 </base-alert>
 
@@ -191,7 +191,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre [Balises meta et référencement SEO](/docs/2.x//features/meta-tags-seo)
+Pour en savoir plus, consultez notre chapitre [Balises meta et référencement SEO]((/docs/2.x/features/meta-tags-seo)
 
 </base-alert>
 
@@ -207,7 +207,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus sur les mises en page, consultez notre chapitre sur les [Vues](/docs/2.x//concepts/views#layouts).
+Pour en savoir plus sur les mises en page, consultez notre chapitre sur les [Vues]((/docs/2.x/concepts/views#layouts).
 
 </base-alert>
 
@@ -229,7 +229,7 @@ S'applique uniquement si la propriété loading est également défini dans le f
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur le [Chargement](/docs/2.x//features/loading).
+Pour en savoir plus, consultez notre chapitre sur le [Chargement]((/docs/2.x/features/loading).
 
 </base-alert>
 
@@ -245,7 +245,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur les [Transitions](/docs/2.x//features/transitions)
+Pour en savoir plus, consultez notre chapitre sur les [Transitions]((/docs/2.x/features/transitions)
 
 </base-alert>
 
@@ -261,7 +261,7 @@ export default {
 
 Inversement, vous pouvez aussi régler manuellement `scrollToTop` à `false` sur les routes parentes.
 
-Si vous souhaitez remplacer le comportement de défilement par défaut de Nuxt.js, consultez l'option [scrollBehavior](/docs/2.x//configuration-glossary/configuration-router#scrollbehavior).
+Si vous souhaitez remplacer le comportement de défilement par défaut de Nuxt.js, consultez l'option [scrollBehavior]((/docs/2.x/configuration-glossary/configuration-router#scrollbehavior).
 
 ### middleware
 
@@ -275,7 +275,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur les [Middleware](/docs/2.x//directory-structure/middleware)
+Pour en savoir plus, consultez notre chapitre sur les [Middleware]((/docs/2.x/directory-structure/middleware)
 
 </base-alert>
 
@@ -315,7 +315,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus sur la propriété d'observation, consultez notre chapitre [Data Fetching](/docs/2.x//features/data-fetching) chapter
+Pour en savoir plus sur la propriété d'observation, consultez notre chapitre [Data Fetching]((/docs/2.x/features/data-fetching) chapter
 
 </base-alert>
 
@@ -331,7 +331,7 @@ Par exemple, `pages/-about.vue` sera ignorée.
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur l'option [ignore](/docs/2.x//configuration-glossary/configuration-ignore)
+Pour en savoir plus, consultez notre chapitre sur l'option [ignore]((/docs/2.x/configuration-glossary/configuration-ignore)
 
 </base-alert>
 
@@ -350,7 +350,7 @@ export default {
 
 <base-alert type="next">
 
-Pour en savoir plus, consultez notre chapitre sur l'option [dir](/docs/2.x//configuration-glossary/configuration-dir)
+Pour en savoir plus, consultez notre chapitre sur l'option [dir]((/docs/2.x/configuration-glossary/configuration-dir)
 
 </base-alert>
 

--- a/content/fr/guides/directory-structure/plugins.md
+++ b/content/fr/guides/directory-structure/plugins.md
@@ -198,7 +198,7 @@ module.exports = {
 }
 ```
 
-Pour davantage d'informations sur les options, veuillez vous référer à la [configuration du build](/docs/2.x//configuration-glossary/configuration-build#transpile).
+Pour davantage d'informations sur les options, veuillez vous référer à la [configuration du build]((/docs/2.x/configuration-glossary/configuration-build#transpile).
 
 ## Côté client ou serveur seulement
 
@@ -303,7 +303,7 @@ Il faut bien faire attention à ne pas utiliser `Vue.use()`, `Vue.component()` o
 
 ## La propriété extendPlugins
 
-On pourrait avoir envie de personnaliser les plugins ou changer l'ordre des plugins créé par Nuxt.js. Cette fonction accepte un tableau d'objets [plugins](/docs/2.x//configuration-glossary/configuration-plugins) et retourne la même chose, réarrangé.
+On pourrait avoir envie de personnaliser les plugins ou changer l'ordre des plugins créé par Nuxt.js. Cette fonction accepte un tableau d'objets [plugins]((/docs/2.x/configuration-glossary/configuration-plugins) et retourne la même chose, réarrangé.
 
 Un exemple de changement de l'ordre des plugins:
 

--- a/content/fr/guides/directory-structure/plugins.md
+++ b/content/fr/guides/directory-structure/plugins.md
@@ -198,7 +198,7 @@ module.exports = {
 }
 ```
 
-Pour davantage d'informations sur les options, veuillez vous référer à la [configuration du build](/guides/configuration-glossary/configuration-build#transpile).
+Pour davantage d'informations sur les options, veuillez vous référer à la [configuration du build](/docs/2.x//configuration-glossary/configuration-build#transpile).
 
 ## Côté client ou serveur seulement
 
@@ -303,7 +303,7 @@ Il faut bien faire attention à ne pas utiliser `Vue.use()`, `Vue.component()` o
 
 ## La propriété extendPlugins
 
-On pourrait avoir envie de personnaliser les plugins ou changer l'ordre des plugins créé par Nuxt.js. Cette fonction accepte un tableau d'objets [plugins](/guides/configuration-glossary/configuration-plugins) et retourne la même chose, réarrangé.
+On pourrait avoir envie de personnaliser les plugins ou changer l'ordre des plugins créé par Nuxt.js. Cette fonction accepte un tableau d'objets [plugins](/docs/2.x//configuration-glossary/configuration-plugins) et retourne la même chose, réarrangé.
 
 Un exemple de changement de l'ordre des plugins:
 

--- a/content/fr/guides/directory-structure/store.md
+++ b/content/fr/guides/directory-structure/store.md
@@ -254,7 +254,7 @@ Seul le module principal (dans `store/index.js`) recevra cette action. Vous devr
 
 </base-alert>
 
-Le [contexte](/guides/concepts/context-helpers) est donné à `nuxtServerInit` comme 2ème argument dans la méthode `asyncData`.
+Le [contexte](/docs/2.x//concepts/context-helpers) est donné à `nuxtServerInit` comme 2ème argument dans la méthode `asyncData`.
 
 Si `nuxt generate` est lancé, `nuxtServerInit` sera exécuté pour chaque route dynamique générée.
 

--- a/content/fr/guides/directory-structure/store.md
+++ b/content/fr/guides/directory-structure/store.md
@@ -254,7 +254,7 @@ Seul le module principal (dans `store/index.js`) recevra cette action. Vous devr
 
 </base-alert>
 
-Le [contexte](/docs/2.x//concepts/context-helpers) est donné à `nuxtServerInit` comme 2ème argument dans la méthode `asyncData`.
+Le [contexte]((/docs/2.x/concepts/context-helpers) est donné à `nuxtServerInit` comme 2ème argument dans la méthode `asyncData`.
 
 Si `nuxt generate` est lancé, `nuxtServerInit` sera exécuté pour chaque route dynamique générée.
 

--- a/content/fr/guides/features/configuration.md
+++ b/content/fr/guides/features/configuration.md
@@ -265,7 +265,7 @@ La méthode `extend` est appelée deux fois, une fois pour le bundle du client e
 
 ### Personnaliser la configuration des fragments
 
-Nous souhaiterions peut-être customiser un peu la [configuration d'optimisation](/docs/2.x//configuration-glossary/configuration-build#optimization), en évitant de ré-écrire l'objet par défaut.
+Nous souhaiterions peut-être customiser un peu la [configuration d'optimisation]((/docs/2.x/configuration-glossary/configuration-build#optimization), en évitant de ré-écrire l'objet par défaut.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -376,7 +376,7 @@ L'`axios-module` ne peut pas être utilisé dans le fichier `nuxt.config.js`. No
 
 <base-alert type="next">
 
-Le fichier `nuxt.config.js` a bien plus d'option de customisation et de configuration ! Se référer aux clés présentes dans le [glossaire de configuration](/docs/2.x//configuration-glossary/configuration-build).
+Le fichier `nuxt.config.js` a bien plus d'option de customisation et de configuration ! Se référer aux clés présentes dans le [glossaire de configuration]((/docs/2.x/configuration-glossary/configuration-build).
 
 </base-alert>
 

--- a/content/fr/guides/features/configuration.md
+++ b/content/fr/guides/features/configuration.md
@@ -265,7 +265,7 @@ La méthode `extend` est appelée deux fois, une fois pour le bundle du client e
 
 ### Personnaliser la configuration des fragments
 
-Nous souhaiterions peut-être customiser un peu la [configuration d'optimisation](/guides/configuration-glossary/configuration-build#optimization), en évitant de ré-écrire l'objet par défaut.
+Nous souhaiterions peut-être customiser un peu la [configuration d'optimisation](/docs/2.x//configuration-glossary/configuration-build#optimization), en évitant de ré-écrire l'objet par défaut.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -376,7 +376,7 @@ L'`axios-module` ne peut pas être utilisé dans le fichier `nuxt.config.js`. No
 
 <base-alert type="next">
 
-Le fichier `nuxt.config.js` a bien plus d'option de customisation et de configuration ! Se référer aux clés présentes dans le [glossaire de configuration](/guides/configuration-glossary/configuration-build).
+Le fichier `nuxt.config.js` a bien plus d'option de customisation et de configuration ! Se référer aux clés présentes dans le [glossaire de configuration](/docs/2.x//configuration-glossary/configuration-build).
 
 </base-alert>
 

--- a/content/fr/guides/features/data-fetching.md
+++ b/content/fr/guides/features/data-fetching.md
@@ -98,7 +98,7 @@ export default {
 
 <base-alert>
 
-`fetch(context)` a été déprécié dans nos pages, il faut utiliser un [middleware anonyme](/guides/directory-structure/middleware#anonymous-middleware) à la place: `middleware(context)`
+`fetch(context)` a été déprécié dans nos pages, il faut utiliser un [middleware anonyme](/docs/2.x//directory-structure/middleware#anonymous-middleware) à la place: `middleware(context)`
 
 </base-alert>
 
@@ -145,7 +145,7 @@ Nous avons aussi accès à `this.$fetch()`, utile si nous voulons appeler le hoo
 
 <base-alert type="info">
 
-On peut accéder au [contexte](/guides/concepts/context-helpers) Nuxt à l'intérieur du hook `fetch` avec `this.$nuxt.context`.
+On peut accéder au [contexte](/docs/2.x//concepts/context-helpers) Nuxt à l'intérieur du hook `fetch` avec `this.$nuxt.context`.
 
 </base-alert>
 
@@ -242,13 +242,13 @@ La navigation à la même page ne va pas rappeler `fetch` tant que le dernier ca
 
 <base-alert>
 
-`asyncData` est seulement disponible pour les [pages](/guides/directory-structure/pages) et nous n'avons donc pas accès à `this` à l'intérieur du hook.
+`asyncData` est seulement disponible pour les [pages](/docs/2.x//directory-structure/pages) et nous n'avons donc pas accès à `this` à l'intérieur du hook.
 
 </base-alert>
 
-La différence principale avec `fetch` est que vous n'avez pas à gérer les status d'erreur ou en cours. Nuxt.js va attendre que le hook `asyncData` soit terminé avant de procéder à la navigation sur la page suivante ou afficher la [page d'erreur](/guides/directory-structure/layouts#error-page)
+La différence principale avec `fetch` est que vous n'avez pas à gérer les status d'erreur ou en cours. Nuxt.js va attendre que le hook `asyncData` soit terminé avant de procéder à la navigation sur la page suivante ou afficher la [page d'erreur](/docs/2.x//directory-structure/layouts#error-page)
 
-Ce hook reçoit [le contexte](/guides/concepts/context-helpers) en tant que premier argument. Nous pouvons l'utiliser pour aller chercher de la data et Nuxt.js va automatiquement fusionner l'object retourné avec le `data` du composant.
+Ce hook reçoit [le contexte](/docs/2.x//concepts/context-helpers) en tant que premier argument. Nous pouvons l'utiliser pour aller chercher de la data et Nuxt.js va automatiquement fusionner l'object retourné avec le `data` du composant.
 
 ```html{}[pages/index.vue]
 <template>
@@ -319,7 +319,7 @@ La méthode `asyncData` n'est pas appelée par défaut sur les modifications li�
 
 <base-alert type="next">
 
-Pour en apprendre davantage sur la [propriété watchQuery](/guides/components-glossary/pages-watchquery) et voir la liste des [clés disponibles dans le contexte](/guides/concepts/context-helpers).
+Pour en apprendre davantage sur la [propriété watchQuery](/docs/2.x//components-glossary/pages-watchquery) et voir la liste des [clés disponibles dans le contexte](/docs/2.x//concepts/context-helpers).
 
 </base-alert>
 

--- a/content/fr/guides/features/data-fetching.md
+++ b/content/fr/guides/features/data-fetching.md
@@ -98,7 +98,7 @@ export default {
 
 <base-alert>
 
-`fetch(context)` a été déprécié dans nos pages, il faut utiliser un [middleware anonyme](/docs/2.x//directory-structure/middleware#anonymous-middleware) à la place: `middleware(context)`
+`fetch(context)` a été déprécié dans nos pages, il faut utiliser un [middleware anonyme]((/docs/2.x/directory-structure/middleware#anonymous-middleware) à la place: `middleware(context)`
 
 </base-alert>
 
@@ -145,7 +145,7 @@ Nous avons aussi accès à `this.$fetch()`, utile si nous voulons appeler le hoo
 
 <base-alert type="info">
 
-On peut accéder au [contexte](/docs/2.x//concepts/context-helpers) Nuxt à l'intérieur du hook `fetch` avec `this.$nuxt.context`.
+On peut accéder au [contexte]((/docs/2.x/concepts/context-helpers) Nuxt à l'intérieur du hook `fetch` avec `this.$nuxt.context`.
 
 </base-alert>
 
@@ -242,13 +242,13 @@ La navigation à la même page ne va pas rappeler `fetch` tant que le dernier ca
 
 <base-alert>
 
-`asyncData` est seulement disponible pour les [pages](/docs/2.x//directory-structure/pages) et nous n'avons donc pas accès à `this` à l'intérieur du hook.
+`asyncData` est seulement disponible pour les [pages]((/docs/2.x/directory-structure/pages) et nous n'avons donc pas accès à `this` à l'intérieur du hook.
 
 </base-alert>
 
-La différence principale avec `fetch` est que vous n'avez pas à gérer les status d'erreur ou en cours. Nuxt.js va attendre que le hook `asyncData` soit terminé avant de procéder à la navigation sur la page suivante ou afficher la [page d'erreur](/docs/2.x//directory-structure/layouts#error-page)
+La différence principale avec `fetch` est que vous n'avez pas à gérer les status d'erreur ou en cours. Nuxt.js va attendre que le hook `asyncData` soit terminé avant de procéder à la navigation sur la page suivante ou afficher la [page d'erreur]((/docs/2.x/directory-structure/layouts#error-page)
 
-Ce hook reçoit [le contexte](/docs/2.x//concepts/context-helpers) en tant que premier argument. Nous pouvons l'utiliser pour aller chercher de la data et Nuxt.js va automatiquement fusionner l'object retourné avec le `data` du composant.
+Ce hook reçoit [le contexte]((/docs/2.x/concepts/context-helpers) en tant que premier argument. Nous pouvons l'utiliser pour aller chercher de la data et Nuxt.js va automatiquement fusionner l'object retourné avec le `data` du composant.
 
 ```html{}[pages/index.vue]
 <template>
@@ -319,7 +319,7 @@ La méthode `asyncData` n'est pas appelée par défaut sur les modifications li�
 
 <base-alert type="next">
 
-Pour en apprendre davantage sur la [propriété watchQuery](/docs/2.x//components-glossary/pages-watchquery) et voir la liste des [clés disponibles dans le contexte](/docs/2.x//concepts/context-helpers).
+Pour en apprendre davantage sur la [propriété watchQuery]((/docs/2.x/components-glossary/pages-watchquery) et voir la liste des [clés disponibles dans le contexte]((/docs/2.x/concepts/context-helpers).
 
 </base-alert>
 

--- a/content/fr/guides/features/deployment-targets.md
+++ b/content/fr/guides/features/deployment-targets.md
@@ -17,7 +17,7 @@ export default {
 
 ### SPA
 
-Les Single Page Applications (SPA) sont des pages qui sont render seulement du côté client sans le besoin d'un serveur. Pour déployer une SPA, il faut mettre [le `mode` à `spa`](/docs/2.x//features/rendering-modes#spa) et ensuite utiliser la commande `build` pour générer notre application.
+Les Single Page Applications (SPA) sont des pages qui sont render seulement du côté client sans le besoin d'un serveur. Pour déployer une SPA, il faut mettre [le `mode` à `spa`]((/docs/2.x/features/rendering-modes#spa) et ensuite utiliser la commande `build` pour générer notre application.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -41,7 +41,7 @@ Les sites statiques fonctionnent avec le mode [universel](https://nuxtjs.org/gui
 **Utiliser la commande `nuxt dev` avec `static` comme cible de déploiement peut améliorer l'expérience développeur.**
 
 - Enlève `req` & `res` du `context`
-- Solution de secours sur le rendu côté client dans le cas d'une 404, d'erreurs et de redirections [voir les solutions de secours d'une SPA](/docs/2.x//concepts/static-site-generation#spa-fallback)
+- Solution de secours sur le rendu côté client dans le cas d'une 404, d'erreurs et de redirections [voir les solutions de secours d'une SPA]((/docs/2.x/concepts/static-site-generation#spa-fallback)
 - `$route.query` sera toujours égal à `{}` sur le render côté serveur
 - `process.static` est vrai
 

--- a/content/fr/guides/features/deployment-targets.md
+++ b/content/fr/guides/features/deployment-targets.md
@@ -17,7 +17,7 @@ export default {
 
 ### SPA
 
-Les Single Page Applications (SPA) sont des pages qui sont render seulement du côté client sans le besoin d'un serveur. Pour déployer une SPA, il faut mettre [le `mode` à `spa`](/guides/features/rendering-modes#spa) et ensuite utiliser la commande `build` pour générer notre application.
+Les Single Page Applications (SPA) sont des pages qui sont render seulement du côté client sans le besoin d'un serveur. Pour déployer une SPA, il faut mettre [le `mode` à `spa`](/docs/2.x//features/rendering-modes#spa) et ensuite utiliser la commande `build` pour générer notre application.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -41,7 +41,7 @@ Les sites statiques fonctionnent avec le mode [universel](https://nuxtjs.org/gui
 **Utiliser la commande `nuxt dev` avec `static` comme cible de déploiement peut améliorer l'expérience développeur.**
 
 - Enlève `req` & `res` du `context`
-- Solution de secours sur le rendu côté client dans le cas d'une 404, d'erreurs et de redirections [voir les solutions de secours d'une SPA](/guides/concepts/static-site-generation#spa-fallback)
+- Solution de secours sur le rendu côté client dans le cas d'une 404, d'erreurs et de redirections [voir les solutions de secours d'une SPA](/docs/2.x//concepts/static-site-generation#spa-fallback)
 - `$route.query` sera toujours égal à `{}` sur le render côté serveur
 - `process.static` est vrai
 

--- a/content/fr/guides/features/file-system-routing.md
+++ b/content/fr/guides/features/file-system-routing.md
@@ -76,7 +76,7 @@ Nuxt.js nous offre du code splitting automatique pour nos routes, sans configura
 
 <base-alert type="info">
 
-Utilisez le composant [NuxtLink](/guides/features/nuxt-components#the-nuxtlink-component) pour naviguer entre les pages.
+Utilisez le composant [NuxtLink](/docs/2.x//features/nuxt-components#the-nuxtlink-component) pour naviguer entre les pages.
 
 </base-alert>
 
@@ -181,7 +181,7 @@ Depuis Nuxt >= v2.13, un crawler va détecter nos liens et générer des routes 
 
 <base-alert type="next">
 
-[Générer des routes dynamiques](/guides/concepts/static-site-generation) pour des sites statiques.
+[Générer des routes dynamiques](/docs/2.x//concepts/static-site-generation) pour des sites statiques.
 
 </base-alert>
 
@@ -195,7 +195,7 @@ Nuxt.js nous permet de créer des routes imbriquées grâce à `vue-router`. Pou
 
 <base-alert>
 
-Il ne faut pas oublier d'inclure le composant [NuxtChild](/guides/features/nuxt-components#the-nuxtchild-component) à l'intérieur du composant parent (fichier `.vue`).
+Il ne faut pas oublier d'inclure le composant [NuxtChild](/docs/2.x//features/nuxt-components#the-nuxtchild-component) à l'intérieur du composant parent (fichier `.vue`).
 
 </base-alert>
 
@@ -331,7 +331,7 @@ Il y a plusieurs façons de personnaliser notre routeur avec Nuxt:
 
 - [router-extras-module](https://github.com/nuxt-community/router-extras-module) pour personnaliser les paramètres dans la page
 - le composant [@nuxtjs/router](https://github.com/nuxt-community/router-module) pour écraser le routeur Nuxt et écrire notre propre fichier `router.js`
-- utiliser la propriété [router.extendRoutes](/guides/configuration-glossary/configuration-router#extendroutes) dans notre fichier `nuxt.config.js`
+- utiliser la propriété [router.extendRoutes](/docs/2.x//configuration-glossary/configuration-router#extendroutes) dans notre fichier `nuxt.config.js`
 
 ## La propriété router
 
@@ -351,7 +351,7 @@ L'url de base de notre application. Par exemple, si nous voulons que notre Singl
 
 <base-alert type="next">
 
-[Propriété base du routeur](/guides/configuration-glossary/configuration-router#base).
+[Propriété base du routeur](/docs/2.x//configuration-glossary/configuration-router#base).
 
 </base-alert>
 
@@ -424,7 +424,7 @@ export default {
 
 <base-alert type="next">
 
-[propriété extendRoutes](/guides/configuration-glossary/configuration-router#extendroutes).
+[propriété extendRoutes](/docs/2.x//configuration-glossary/configuration-router#extendroutes).
 
 </base-alert>
 
@@ -434,7 +434,7 @@ S'occupe du routeur, si ce dernier doit se rabattre en mode `hash` lorsque le na
 
 <base-alert type="next">
 
-[propriété fallback](/guides/configuration-glossary/configuration-router#fallback).
+[propriété fallback](/docs/2.x//configuration-glossary/configuration-router#fallback).
 
 </base-alert>
 
@@ -444,7 +444,7 @@ Nous pouvons changer le mode du routeur, ce n'est cependant pas recommandé en r
 
 <base-alert type="next">
 
-[propriété mode](/guides/configuration-glossary/configuration-router#mode).
+[propriété mode](/docs/2.x//configuration-glossary/configuration-router#mode).
 
 </base-alert>
 
@@ -454,7 +454,7 @@ Fournit des fonctions de _parsing_ / _stringification_ personnalisées.
 
 <base-alert type="next">
 
-[propriété parseQuery / stringifyQuery](/guides/configuration-glossary/configuration-router#parsequery--stringifyquery).
+[propriété parseQuery / stringifyQuery](/docs/2.x//configuration-glossary/configuration-router#parsequery--stringifyquery).
 
 </base-alert>
 
@@ -502,7 +502,7 @@ export default function (to, from, savedPosition) {
 
 <base-alert type="next">
 
-[propriété scrollBehavior](/guides/configuration-glossary/configuration-router#scrollbehavior).
+[propriété scrollBehavior](/docs/2.x//configuration-glossary/configuration-router#scrollbehavior).
 
 </base-alert>
 
@@ -528,7 +528,7 @@ Cette option doit être changée avec une certaine préparation et une sequence 
 
 <base-alert type="next">
 
-[propriété trailingSlash](/guides/configuration-glossary/configuration-router#trailingslash).
+[propriété trailingSlash](/docs/2.x//configuration-glossary/configuration-router#trailingslash).
 
 </base-alert>
 

--- a/content/fr/guides/features/file-system-routing.md
+++ b/content/fr/guides/features/file-system-routing.md
@@ -76,7 +76,7 @@ Nuxt.js nous offre du code splitting automatique pour nos routes, sans configura
 
 <base-alert type="info">
 
-Utilisez le composant [NuxtLink](/docs/2.x//features/nuxt-components#the-nuxtlink-component) pour naviguer entre les pages.
+Utilisez le composant [NuxtLink]((/docs/2.x/features/nuxt-components#the-nuxtlink-component) pour naviguer entre les pages.
 
 </base-alert>
 
@@ -181,7 +181,7 @@ Depuis Nuxt >= v2.13, un crawler va détecter nos liens et générer des routes 
 
 <base-alert type="next">
 
-[Générer des routes dynamiques](/docs/2.x//concepts/static-site-generation) pour des sites statiques.
+[Générer des routes dynamiques]((/docs/2.x/concepts/static-site-generation) pour des sites statiques.
 
 </base-alert>
 
@@ -195,7 +195,7 @@ Nuxt.js nous permet de créer des routes imbriquées grâce à `vue-router`. Pou
 
 <base-alert>
 
-Il ne faut pas oublier d'inclure le composant [NuxtChild](/docs/2.x//features/nuxt-components#the-nuxtchild-component) à l'intérieur du composant parent (fichier `.vue`).
+Il ne faut pas oublier d'inclure le composant [NuxtChild]((/docs/2.x/features/nuxt-components#the-nuxtchild-component) à l'intérieur du composant parent (fichier `.vue`).
 
 </base-alert>
 
@@ -331,7 +331,7 @@ Il y a plusieurs façons de personnaliser notre routeur avec Nuxt:
 
 - [router-extras-module](https://github.com/nuxt-community/router-extras-module) pour personnaliser les paramètres dans la page
 - le composant [@nuxtjs/router](https://github.com/nuxt-community/router-module) pour écraser le routeur Nuxt et écrire notre propre fichier `router.js`
-- utiliser la propriété [router.extendRoutes](/docs/2.x//configuration-glossary/configuration-router#extendroutes) dans notre fichier `nuxt.config.js`
+- utiliser la propriété [router.extendRoutes]((/docs/2.x/configuration-glossary/configuration-router#extendroutes) dans notre fichier `nuxt.config.js`
 
 ## La propriété router
 
@@ -351,7 +351,7 @@ L'url de base de notre application. Par exemple, si nous voulons que notre Singl
 
 <base-alert type="next">
 
-[Propriété base du routeur](/docs/2.x//configuration-glossary/configuration-router#base).
+[Propriété base du routeur]((/docs/2.x/configuration-glossary/configuration-router#base).
 
 </base-alert>
 
@@ -424,7 +424,7 @@ export default {
 
 <base-alert type="next">
 
-[propriété extendRoutes](/docs/2.x//configuration-glossary/configuration-router#extendroutes).
+[propriété extendRoutes]((/docs/2.x/configuration-glossary/configuration-router#extendroutes).
 
 </base-alert>
 
@@ -434,7 +434,7 @@ S'occupe du routeur, si ce dernier doit se rabattre en mode `hash` lorsque le na
 
 <base-alert type="next">
 
-[propriété fallback](/docs/2.x//configuration-glossary/configuration-router#fallback).
+[propriété fallback]((/docs/2.x/configuration-glossary/configuration-router#fallback).
 
 </base-alert>
 
@@ -444,7 +444,7 @@ Nous pouvons changer le mode du routeur, ce n'est cependant pas recommandé en r
 
 <base-alert type="next">
 
-[propriété mode](/docs/2.x//configuration-glossary/configuration-router#mode).
+[propriété mode]((/docs/2.x/configuration-glossary/configuration-router#mode).
 
 </base-alert>
 
@@ -454,7 +454,7 @@ Fournit des fonctions de _parsing_ / _stringification_ personnalisées.
 
 <base-alert type="next">
 
-[propriété parseQuery / stringifyQuery](/docs/2.x//configuration-glossary/configuration-router#parsequery--stringifyquery).
+[propriété parseQuery / stringifyQuery]((/docs/2.x/configuration-glossary/configuration-router#parsequery--stringifyquery).
 
 </base-alert>
 
@@ -502,7 +502,7 @@ export default function (to, from, savedPosition) {
 
 <base-alert type="next">
 
-[propriété scrollBehavior](/docs/2.x//configuration-glossary/configuration-router#scrollbehavior).
+[propriété scrollBehavior]((/docs/2.x/configuration-glossary/configuration-router#scrollbehavior).
 
 </base-alert>
 
@@ -528,7 +528,7 @@ Cette option doit être changée avec une certaine préparation et une sequence 
 
 <base-alert type="next">
 
-[propriété trailingSlash](/docs/2.x//configuration-glossary/configuration-router#trailingslash).
+[propriété trailingSlash]((/docs/2.x/configuration-glossary/configuration-router#trailingslash).
 
 </base-alert>
 

--- a/content/fr/guides/features/live-preview.md
+++ b/content/fr/guides/features/live-preview.md
@@ -7,7 +7,7 @@ position: 12
 
 Avec Nuxt.js et une génération axée sur de l'intégralement statique, nous pouvons maintenant utiliser la prévisualisation en temps réel, sans configuration additionnelle. Cela nous permettra d'appeler notre API ou notre CMS afin que nous puissions voir les changements avant de déployer.
 
-<base-alert>Seulement disponible dans le cas d'un [target:static](/docs/2.x//features/deployment-targets#static-hosting)</base-alert>
+<base-alert>Seulement disponible dans le cas d'un [target:static]((/docs/2.x/features/deployment-targets#static-hosting)</base-alert>
 
 Le mode de prévisualisation va s'occuper de rafraîchir automatiquement la data de la page vu qu'il utilise `$nuxt.refresh` (et donc fait les appels de `nuxtServerInit`, `asyncData` et `fetch`) du côté client.
 
@@ -83,6 +83,6 @@ On peut passer de la data à la fonction `enablePreview`. La data sera ainsi dis
 
 <base-alert type="next">
 
-Se référer au [document sur la structure des répertoires](/docs/2.x//directory-structure/nuxt).
+Se référer au [document sur la structure des répertoires]((/docs/2.x/directory-structure/nuxt).
 
 </base-alert>

--- a/content/fr/guides/features/live-preview.md
+++ b/content/fr/guides/features/live-preview.md
@@ -7,7 +7,7 @@ position: 12
 
 Avec Nuxt.js et une génération axée sur de l'intégralement statique, nous pouvons maintenant utiliser la prévisualisation en temps réel, sans configuration additionnelle. Cela nous permettra d'appeler notre API ou notre CMS afin que nous puissions voir les changements avant de déployer.
 
-<base-alert>Seulement disponible dans le cas d'un [target:static](/guides/features/deployment-targets#static-hosting)</base-alert>
+<base-alert>Seulement disponible dans le cas d'un [target:static](/docs/2.x//features/deployment-targets#static-hosting)</base-alert>
 
 Le mode de prévisualisation va s'occuper de rafraîchir automatiquement la data de la page vu qu'il utilise `$nuxt.refresh` (et donc fait les appels de `nuxtServerInit`, `asyncData` et `fetch`) du côté client.
 
@@ -83,6 +83,6 @@ On peut passer de la data à la fonction `enablePreview`. La data sera ainsi dis
 
 <base-alert type="next">
 
-Se référer au [document sur la structure des répertoires](/guides/directory-structure/nuxt).
+Se référer au [document sur la structure des répertoires](/docs/2.x//directory-structure/nuxt).
 
 </base-alert>

--- a/content/fr/guides/features/meta-tags-seo.md
+++ b/content/fr/guides/features/meta-tags-seo.md
@@ -217,7 +217,7 @@ Nous voudrons peut-être désactiver cette option si nous avons beaucoup de page
 
 <base-alert type="next">
 
-[Conseils pour les ressources](/docs/2.x//configuration-glossary/configuration-render#resourcehints).
+[Conseils pour les ressources]((/docs/2.x/configuration-glossary/configuration-render#resourcehints).
 
 </base-alert>
 

--- a/content/fr/guides/features/meta-tags-seo.md
+++ b/content/fr/guides/features/meta-tags-seo.md
@@ -217,7 +217,7 @@ Nous voudrons peut-être désactiver cette option si nous avons beaucoup de page
 
 <base-alert type="next">
 
-[Conseils pour les ressources](/guides/configuration-glossary/configuration-render#resourcehints).
+[Conseils pour les ressources](/docs/2.x//configuration-glossary/configuration-render#resourcehints).
 
 </base-alert>
 

--- a/content/fr/guides/features/nuxt-components.md
+++ b/content/fr/guides/features/nuxt-components.md
@@ -94,7 +94,7 @@ Le composant `<Nuxt>` nous permet d'afficher les composants page. Basiquement, l
 
 <base-alert>
 
-Le composant `<Nuxt>` ne peut être utilisé que dans les [layouts](/docs/2.x//concepts/views#layouts).
+Le composant `<Nuxt>` ne peut être utilisé que dans les [layouts]((/docs/2.x/concepts/views#layouts).
 
 </base-alert>
 
@@ -255,7 +255,7 @@ Si nous voulons en savoir plus sur `RouterLink`, se référer à la [documentati
 
 <base-alert type="info">
 
-`<NuxtLink>` est utilise le [préfétching intelligent](/docs/2.x//features/nuxt-components#the-nuxtlink-component) par défaut.
+`<NuxtLink>` est utilise le [préfétching intelligent]((/docs/2.x/features/nuxt-components#the-nuxtlink-component) par défaut.
 
 </base-alert>
 

--- a/content/fr/guides/features/nuxt-components.md
+++ b/content/fr/guides/features/nuxt-components.md
@@ -94,7 +94,7 @@ Le composant `<Nuxt>` nous permet d'afficher les composants page. Basiquement, l
 
 <base-alert>
 
-Le composant `<Nuxt>` ne peut être utilisé que dans les [layouts](/guides/concepts/views#layouts).
+Le composant `<Nuxt>` ne peut être utilisé que dans les [layouts](/docs/2.x//concepts/views#layouts).
 
 </base-alert>
 
@@ -255,7 +255,7 @@ Si nous voulons en savoir plus sur `RouterLink`, se référer à la [documentati
 
 <base-alert type="info">
 
-`<NuxtLink>` est utilise le [préfétching intelligent](/guides/features/nuxt-components#the-nuxtlink-component) par défaut.
+`<NuxtLink>` est utilise le [préfétching intelligent](/docs/2.x//features/nuxt-components#the-nuxtlink-component) par défaut.
 
 </base-alert>
 

--- a/content/fr/guides/internals-glossary/context.md
+++ b/content/fr/guides/internals-glossary/context.md
@@ -6,7 +6,7 @@ category: internals-glossary
 position: 1
 ---
 
-Le `context` fournit des objets/paramètres en plus aux composants Vue et est disponible dans des lifecycles Nuxt spéciaux comme par exemple [`asyncData`](/api), [`fetch`](/guides/features/data-fetching), [`plugins`](/guides/directory-structure/plugins), [`middleware`](/guides/directory-structure/middleware#router-middleware) et [`nuxtServerInit`](/guides/directory-structure/store#the-nuxtserverinit-action).
+Le `context` fournit des objets/paramètres en plus aux composants Vue et est disponible dans des lifecycles Nuxt spéciaux comme par exemple [`asyncData`](/api), [`fetch`](/docs/2.x//features/data-fetching), [`plugins`](/docs/2.x//directory-structure/plugins), [`middleware`](/docs/2.x//directory-structure/middleware#router-middleware) et [`nuxtServerInit`](/docs/2.x//directory-structure/store#the-nuxtserverinit-action).
 
 > _Note: Le "context" auquel on fait référence ici ne doit pas être confondu avec l'objet `context` disponible dans les [`actions Vuex`](https://vuex.vuejs.org/guide/actions.html). Les deux n'ont rien à voir._
 
@@ -51,7 +51,7 @@ L'instance principale de Vue avec les options qui incluent tous vos plugins. Par
 
 `store` ([_Store Vuex_](https://vuex.vuejs.org/api/#vuex-store-instance-properties))
 
-L'instance du Store Vuex. **Disponible uniquement si le [store vuex](/guides/directory-structure/store) a été défini**.
+L'instance du Store Vuex. **Disponible uniquement si le [store vuex](/docs/2.x//directory-structure/store) a été défini**.
 
 ### route
 
@@ -75,7 +75,7 @@ Un alias de `route.query`.
 
 `env` (_Objet_)
 
-Variables d'environnement définies dans le fichier `nuxt.config.js`, se référer à l'[API env](/guides/configuration-glossary/configuration-env).
+Variables d'environnement définies dans le fichier `nuxt.config.js`, se référer à l'[API env](/docs/2.x//configuration-glossary/configuration-env).
 
 ### IsDev
 

--- a/content/fr/guides/internals-glossary/context.md
+++ b/content/fr/guides/internals-glossary/context.md
@@ -6,7 +6,7 @@ category: internals-glossary
 position: 1
 ---
 
-Le `context` fournit des objets/paramètres en plus aux composants Vue et est disponible dans des lifecycles Nuxt spéciaux comme par exemple [`asyncData`](/api), [`fetch`](/docs/2.x//features/data-fetching), [`plugins`](/docs/2.x//directory-structure/plugins), [`middleware`](/docs/2.x//directory-structure/middleware#router-middleware) et [`nuxtServerInit`](/docs/2.x//directory-structure/store#the-nuxtserverinit-action).
+Le `context` fournit des objets/paramètres en plus aux composants Vue et est disponible dans des lifecycles Nuxt spéciaux comme par exemple [`asyncData`](/api), [`fetch`]((/docs/2.x/features/data-fetching), [`plugins`]((/docs/2.x/directory-structure/plugins), [`middleware`]((/docs/2.x/directory-structure/middleware#router-middleware) et [`nuxtServerInit`]((/docs/2.x/directory-structure/store#the-nuxtserverinit-action).
 
 > _Note: Le "context" auquel on fait référence ici ne doit pas être confondu avec l'objet `context` disponible dans les [`actions Vuex`](https://vuex.vuejs.org/guide/actions.html). Les deux n'ont rien à voir._
 
@@ -51,7 +51,7 @@ L'instance principale de Vue avec les options qui incluent tous vos plugins. Par
 
 `store` ([_Store Vuex_](https://vuex.vuejs.org/api/#vuex-store-instance-properties))
 
-L'instance du Store Vuex. **Disponible uniquement si le [store vuex](/docs/2.x//directory-structure/store) a été défini**.
+L'instance du Store Vuex. **Disponible uniquement si le [store vuex]((/docs/2.x/directory-structure/store) a été défini**.
 
 ### route
 
@@ -75,7 +75,7 @@ Un alias de `route.query`.
 
 `env` (_Objet_)
 
-Variables d'environnement définies dans le fichier `nuxt.config.js`, se référer à l'[API env](/docs/2.x//configuration-glossary/configuration-env).
+Variables d'environnement définies dans le fichier `nuxt.config.js`, se référer à l'[API env]((/docs/2.x/configuration-glossary/configuration-env).
 
 ### IsDev
 

--- a/content/fr/guides/internals-glossary/internals-module-container.md
+++ b/content/fr/guides/internals-glossary/internals-module-container.md
@@ -8,7 +8,7 @@ position: 6
 
 - Source: **[core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/module.js)**
 
-Tous les [modules](/docs/2.x//directory-structure/modules) seront appelés dans le contexte de l'instance `ModuleContainer`.
+Tous les [modules]((/docs/2.x/directory-structure/modules) seront appelés dans le contexte de l'instance `ModuleContainer`.
 
 ## Plugins à usage unique
 
@@ -20,7 +20,7 @@ nuxt.moduleContainer.plugin('ready', async moduleContainer => {
 })
 ```
 
-Dans le contexte des [modules](/docs/2.x//directory-structure/modules), nous pouvons utiliser cette méthode à la place :
+Dans le contexte des [modules]((/docs/2.x/directory-structure/modules), nous pouvons utiliser cette méthode à la place :
 
 ```js
 this.plugin('ready', async moduleContainer => {
@@ -61,19 +61,19 @@ Vous pouvez utiliser `template.ssr : false` pour désactiver le plugin y compris
 
 ### addServerMiddleware (middleware)
 
-Pousse le middleware dans [options.serverMiddleware](/docs/2.x//configuration-glossary/configuration-servermiddleware).
+Pousse le middleware dans [options.serverMiddleware]((/docs/2.x/configuration-glossary/configuration-servermiddleware).
 
 ### extendBuild (fn)
 
-Permet d'étendre facilement la configuration du webpack par chaînage dans la fonction [options.build.extend](/docs/2.x//configuration-glossary/configuration-build#extend).
+Permet d'étendre facilement la configuration du webpack par chaînage dans la fonction [options.build.extend]((/docs/2.x/configuration-glossary/configuration-build#extend).
 
 ### extendRoutes (fn)
 
-Permet d'étendre facilement les routes dans la fonction [options.build.extendRoutes](/docs/2.x//configuration-glossary/configuration-router#extendroutes).
+Permet d'étendre facilement les routes dans la fonction [options.build.extendRoutes]((/docs/2.x/configuration-glossary/configuration-router#extendroutes).
 
 ### extendPlugins (fn)
 
-Permet d'étendre facilement les plugins dans la fonction [options.extendPlugins](/docs/2.x//configuration-glossary/configuration-extend-plugins).
+Permet d'étendre facilement les plugins dans la fonction [options.extendPlugins]((/docs/2.x/configuration-glossary/configuration-extend-plugins).
 
 ### addModule (moduleOpts, requireOnce)
 

--- a/content/fr/guides/internals-glossary/internals-module-container.md
+++ b/content/fr/guides/internals-glossary/internals-module-container.md
@@ -8,7 +8,7 @@ position: 6
 
 - Source: **[core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/module.js)**
 
-Tous les [modules](/guides/directory-structure/modules) seront appelés dans le contexte de l'instance `ModuleContainer`.
+Tous les [modules](/docs/2.x//directory-structure/modules) seront appelés dans le contexte de l'instance `ModuleContainer`.
 
 ## Plugins à usage unique
 
@@ -20,7 +20,7 @@ nuxt.moduleContainer.plugin('ready', async moduleContainer => {
 })
 ```
 
-Dans le contexte des [modules](/guides/directory-structure/modules), nous pouvons utiliser cette méthode à la place :
+Dans le contexte des [modules](/docs/2.x//directory-structure/modules), nous pouvons utiliser cette méthode à la place :
 
 ```js
 this.plugin('ready', async moduleContainer => {
@@ -61,19 +61,19 @@ Vous pouvez utiliser `template.ssr : false` pour désactiver le plugin y compris
 
 ### addServerMiddleware (middleware)
 
-Pousse le middleware dans [options.serverMiddleware](/guides/configuration-glossary/configuration-servermiddleware).
+Pousse le middleware dans [options.serverMiddleware](/docs/2.x//configuration-glossary/configuration-servermiddleware).
 
 ### extendBuild (fn)
 
-Permet d'étendre facilement la configuration du webpack par chaînage dans la fonction [options.build.extend](/guides/configuration-glossary/configuration-build#extend).
+Permet d'étendre facilement la configuration du webpack par chaînage dans la fonction [options.build.extend](/docs/2.x//configuration-glossary/configuration-build#extend).
 
 ### extendRoutes (fn)
 
-Permet d'étendre facilement les routes dans la fonction [options.build.extendRoutes](/guides/configuration-glossary/configuration-router#extendroutes).
+Permet d'étendre facilement les routes dans la fonction [options.build.extendRoutes](/docs/2.x//configuration-glossary/configuration-router#extendroutes).
 
 ### extendPlugins (fn)
 
-Permet d'étendre facilement les plugins dans la fonction [options.extendPlugins](/guides/configuration-glossary/configuration-extend-plugins).
+Permet d'étendre facilement les plugins dans la fonction [options.extendPlugins](/docs/2.x//configuration-glossary/configuration-extend-plugins).
 
 ### addModule (moduleOpts, requireOnce)
 

--- a/content/fr/guides/internals-glossary/internals.md
+++ b/content/fr/guides/internals-glossary/internals.md
@@ -8,7 +8,7 @@ position: 3
 
 Nuxt.js a une architecture entièrement modulaire qui permet aux développeurs d'étendre n'importe quelle partie de Nuxt Core en utilisant une API flexible.
 
-Pour plus d'informations détaillées, veuillez consulter le [Guide des modules](/guides/directory-structure/modules) si vous souhaitez développer votre propre module.
+Pour plus d'informations détaillées, veuillez consulter le [Guide des modules](/docs/2.x//directory-structure/modules) si vous souhaitez développer votre propre module.
 
 Cette section aide à se familiariser avec les modules internes de Nuxt et peut être utilisée comme référence pour mieux comprendre et écrire vos propres modules.
 
@@ -18,17 +18,17 @@ Ces classes sont le cœur de Nuxt et doivent exister à la fois sur le runtime e
 
 #### Nuxt
 
-- [Classe `Nuxt`](/guides/internals-glossary/internals-nuxt)
+- [Classe `Nuxt`](/docs/2.x//internals-glossary/internals-nuxt)
 - Source: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer
 
-- [Classe `Renderer`](/guides/internals-glossary/internals-renderer)
+- [Classe `Renderer`](/docs/2.x//internals-glossary/internals-renderer)
 - Source: [vue-renderer/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-renderer/src/renderer.js)
 
 #### ModuleContainer
 
-- [Classe `ModuleContainer`](/guides/internals-glossary/internals-module-container)
+- [Classe `ModuleContainer`](/docs/2.x//internals-glossary/internals-module-container)
 - Source: [core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/module.js)
 
 ### Build
@@ -37,12 +37,12 @@ Ces classes sont nécessaires que pour le mode build ou dev.
 
 #### Builder
 
-- [Classe `Builder`](/guides/internals-glossary/internals-builder)
+- [Classe `Builder`](/docs/2.x//internals-glossary/internals-builder)
 - Source: [builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/builder/src/builder.js)
 
 #### Generator
 
-- [Classe `Generator`](/guides/internals-glossary/internals-generator)
+- [Classe `Generator`](/docs/2.x//internals-glossary/internals-generator)
 - Source: [generator/generator.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/generator/src/generator.js)
 
 ### Générale

--- a/content/fr/guides/internals-glossary/internals.md
+++ b/content/fr/guides/internals-glossary/internals.md
@@ -8,7 +8,7 @@ position: 3
 
 Nuxt.js a une architecture entièrement modulaire qui permet aux développeurs d'étendre n'importe quelle partie de Nuxt Core en utilisant une API flexible.
 
-Pour plus d'informations détaillées, veuillez consulter le [Guide des modules](/docs/2.x//directory-structure/modules) si vous souhaitez développer votre propre module.
+Pour plus d'informations détaillées, veuillez consulter le [Guide des modules]((/docs/2.x/directory-structure/modules) si vous souhaitez développer votre propre module.
 
 Cette section aide à se familiariser avec les modules internes de Nuxt et peut être utilisée comme référence pour mieux comprendre et écrire vos propres modules.
 
@@ -18,17 +18,17 @@ Ces classes sont le cœur de Nuxt et doivent exister à la fois sur le runtime e
 
 #### Nuxt
 
-- [Classe `Nuxt`](/docs/2.x//internals-glossary/internals-nuxt)
+- [Classe `Nuxt`]((/docs/2.x/internals-glossary/internals-nuxt)
 - Source: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer
 
-- [Classe `Renderer`](/docs/2.x//internals-glossary/internals-renderer)
+- [Classe `Renderer`]((/docs/2.x/internals-glossary/internals-renderer)
 - Source: [vue-renderer/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-renderer/src/renderer.js)
 
 #### ModuleContainer
 
-- [Classe `ModuleContainer`](/docs/2.x//internals-glossary/internals-module-container)
+- [Classe `ModuleContainer`]((/docs/2.x/internals-glossary/internals-module-container)
 - Source: [core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/module.js)
 
 ### Build
@@ -37,12 +37,12 @@ Ces classes sont nécessaires que pour le mode build ou dev.
 
 #### Builder
 
-- [Classe `Builder`](/docs/2.x//internals-glossary/internals-builder)
+- [Classe `Builder`]((/docs/2.x/internals-glossary/internals-builder)
 - Source: [builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/builder/src/builder.js)
 
 #### Generator
 
-- [Classe `Generator`](/docs/2.x//internals-glossary/internals-generator)
+- [Classe `Generator`]((/docs/2.x/internals-glossary/internals-generator)
 - Source: [generator/generator.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/generator/src/generator.js)
 
 ### Générale

--- a/content/fr/guides/internals-glossary/nuxt-render-route.md
+++ b/content/fr/guides/internals-glossary/nuxt-render-route.md
@@ -17,7 +17,7 @@ position: 11
 
 > Rendu d'une route spécifique avec un contexte donné.
 
-Cette méthode doit être utilisée principalement à des fins d'essai ainsi qu'avec [`nuxt.renderAndGetWindow`](/docs/2.x//internals-glossary/nuxt-render-and-get-window).
+Cette méthode doit être utilisée principalement à des fins d'essai ainsi qu'avec [`nuxt.renderAndGetWindow`]((/docs/2.x/internals-glossary/nuxt-render-and-get-window).
 
 <base-alert>
 
@@ -51,6 +51,6 @@ start()
 
 <base-alert type="next">
 
-Consultez le [Glossaire des composants](/docs/2.x//components-glossary/pages-fetch)
+Consultez le [Glossaire des composants]((/docs/2.x/components-glossary/pages-fetch)
 
 </base-alert>

--- a/content/fr/guides/internals-glossary/nuxt-render-route.md
+++ b/content/fr/guides/internals-glossary/nuxt-render-route.md
@@ -17,7 +17,7 @@ position: 11
 
 > Rendu d'une route spécifique avec un contexte donné.
 
-Cette méthode doit être utilisée principalement à des fins d'essai ainsi qu'avec [`nuxt.renderAndGetWindow`](/guides/internals-glossary/nuxt-render-and-get-window).
+Cette méthode doit être utilisée principalement à des fins d'essai ainsi qu'avec [`nuxt.renderAndGetWindow`](/docs/2.x//internals-glossary/nuxt-render-and-get-window).
 
 <base-alert>
 
@@ -51,6 +51,6 @@ start()
 
 <base-alert type="next">
 
-Consultez le [Glossaire des composants](/guides/components-glossary/pages-fetch)
+Consultez le [Glossaire des composants](/docs/2.x//components-glossary/pages-fetch)
 
 </base-alert>

--- a/content/id/guides/directory-structure/components.md
+++ b/content/id/guides/directory-structure/components.md
@@ -37,7 +37,7 @@ Direktori komponen berisi komponen Vue.js Anda. Komponen adalah bagian-bagian be
 
 ### Data _Fetching_
 
-Untuk mengakses data _asynchronous_ dari API di komponen Anda, Anda dapat menggunakan Nuxt [hook `fetch()`](/guides/features/data-fetching#the-fetch-method).
+Untuk mengakses data _asynchronous_ dari API di komponen Anda, Anda dapat menggunakan Nuxt [hook `fetch()`](/docs/2.x//features/data-fetching#the-fetch-method).
 
 Dengan menggunakan `$fetchState.pending` Anda dapat menampilkan pesan ketika data sedang menunggu untuk dimuat dan dengan menggunakan `$fetchState.error` Anda dapat menampilkan pesan galat jika ada galat saat mengambil data. Saat menggunakan _fetch_ Anda harus mendeklarasikan data di properti data. Ini kemudian diisi dengan data yang berasal dari pengambilan.
 
@@ -71,7 +71,7 @@ Dengan menggunakan `$fetchState.pending` Anda dapat menampilkan pesan ketika dat
 
 <base-alert type="next">
 
-Lihat bab tentang [fetch()](/guides/features/data-fetching#the-fetch-method) untuk detail lebih lanjut tentang cara kerja _fetch_.
+Lihat bab tentang [fetch()](/docs/2.x//features/data-fetching#the-fetch-method) untuk detail lebih lanjut tentang cara kerja _fetch_.
 
 </base-alert>
 

--- a/content/id/guides/directory-structure/components.md
+++ b/content/id/guides/directory-structure/components.md
@@ -37,7 +37,7 @@ Direktori komponen berisi komponen Vue.js Anda. Komponen adalah bagian-bagian be
 
 ### Data _Fetching_
 
-Untuk mengakses data _asynchronous_ dari API di komponen Anda, Anda dapat menggunakan Nuxt [hook `fetch()`](/docs/2.x//features/data-fetching#the-fetch-method).
+Untuk mengakses data _asynchronous_ dari API di komponen Anda, Anda dapat menggunakan Nuxt [hook `fetch()`]((/docs/2.x/features/data-fetching#the-fetch-method).
 
 Dengan menggunakan `$fetchState.pending` Anda dapat menampilkan pesan ketika data sedang menunggu untuk dimuat dan dengan menggunakan `$fetchState.error` Anda dapat menampilkan pesan galat jika ada galat saat mengambil data. Saat menggunakan _fetch_ Anda harus mendeklarasikan data di properti data. Ini kemudian diisi dengan data yang berasal dari pengambilan.
 
@@ -71,7 +71,7 @@ Dengan menggunakan `$fetchState.pending` Anda dapat menampilkan pesan ketika dat
 
 <base-alert type="next">
 
-Lihat bab tentang [fetch()](/docs/2.x//features/data-fetching#the-fetch-method) untuk detail lebih lanjut tentang cara kerja _fetch_.
+Lihat bab tentang [fetch()]((/docs/2.x/features/data-fetching#the-fetch-method) untuk detail lebih lanjut tentang cara kerja _fetch_.
 
 </base-alert>
 

--- a/content/id/guides/directory-structure/middleware.md
+++ b/content/id/guides/directory-structure/middleware.md
@@ -70,9 +70,9 @@ questions:
 
 Direktori `middleware` berisi aplikasi _middleware_ Anda. _Middleware_ memungkinkan Anda menentukan fungsi kustom yang dapat dijalankan sebelum merender halaman atau sekelompok halaman (_layout_).
 
-_Shared Middleware_ harus ditempatkan di direktori `middleware/`. Nama berkas akan menjadi nama _middleware_ (`middleware/auth.js` akan menjadi _middleware_ `auth`). Anda juga dapat mendefinisikan middleware khusus halaman dengan menggunakan fungsi secara langsung, lihat [_middleware_ anonim](/guides/components-glossary/pages-middleware#anonymous-middleware).
+_Shared Middleware_ harus ditempatkan di direktori `middleware/`. Nama berkas akan menjadi nama _middleware_ (`middleware/auth.js` akan menjadi _middleware_ `auth`). Anda juga dapat mendefinisikan middleware khusus halaman dengan menggunakan fungsi secara langsung, lihat [_middleware_ anonim](/docs/2.x//components-glossary/pages-middleware#anonymous-middleware).
 
-Sebuah middleware menerima [_context_](/guides/internals-glossary/context) sebagai argumen pertama.
+Sebuah middleware menerima [_context_](/docs/2.x//internals-glossary/context) sebagai argumen pertama.
 
 ```js{}[middleware/user-agent.js]
 export default function (context) {

--- a/content/id/guides/directory-structure/middleware.md
+++ b/content/id/guides/directory-structure/middleware.md
@@ -70,9 +70,9 @@ questions:
 
 Direktori `middleware` berisi aplikasi _middleware_ Anda. _Middleware_ memungkinkan Anda menentukan fungsi kustom yang dapat dijalankan sebelum merender halaman atau sekelompok halaman (_layout_).
 
-_Shared Middleware_ harus ditempatkan di direktori `middleware/`. Nama berkas akan menjadi nama _middleware_ (`middleware/auth.js` akan menjadi _middleware_ `auth`). Anda juga dapat mendefinisikan middleware khusus halaman dengan menggunakan fungsi secara langsung, lihat [_middleware_ anonim](/docs/2.x//components-glossary/pages-middleware#anonymous-middleware).
+_Shared Middleware_ harus ditempatkan di direktori `middleware/`. Nama berkas akan menjadi nama _middleware_ (`middleware/auth.js` akan menjadi _middleware_ `auth`). Anda juga dapat mendefinisikan middleware khusus halaman dengan menggunakan fungsi secara langsung, lihat [_middleware_ anonim]((/docs/2.x/components-glossary/pages-middleware#anonymous-middleware).
 
-Sebuah middleware menerima [_context_](/docs/2.x//internals-glossary/context) sebagai argumen pertama.
+Sebuah middleware menerima [_context_]((/docs/2.x/internals-glossary/context) sebagai argumen pertama.
 
 ```js{}[middleware/user-agent.js]
 export default function (context) {

--- a/content/id/guides/features/deployment-targets.md
+++ b/content/id/guides/features/deployment-targets.md
@@ -18,7 +18,7 @@ export default {
 Menjalankan perintah `nuxt dev` dengan properti `target` bernilai `static` akan meningkatkan pengalaman pengembang seperti:
 
 - Menghapus `req` dan `res` dari `context`
-- _Fallback_ ke pe-_render_-an di sisi klien dalam kasus 404, galat, dan _redirect_ [lihat _fallback_ SPA](/docs/2.x//concepts/static-site-generation#spa-fallback)
+- _Fallback_ ke pe-_render_-an di sisi klien dalam kasus 404, galat, dan _redirect_ [lihat _fallback_ SPA]((/docs/2.x/concepts/static-site-generation#spa-fallback)
 - `$route.query` akan selalu bernilai `{}` untuk pe-_render_-an di sisi server.
 - `process.static` bernilai `true`
 

--- a/content/id/guides/features/deployment-targets.md
+++ b/content/id/guides/features/deployment-targets.md
@@ -18,7 +18,7 @@ export default {
 Menjalankan perintah `nuxt dev` dengan properti `target` bernilai `static` akan meningkatkan pengalaman pengembang seperti:
 
 - Menghapus `req` dan `res` dari `context`
-- _Fallback_ ke pe-_render_-an di sisi klien dalam kasus 404, galat, dan _redirect_ [lihat _fallback_ SPA](/guides/concepts/static-site-generation#spa-fallback)
+- _Fallback_ ke pe-_render_-an di sisi klien dalam kasus 404, galat, dan _redirect_ [lihat _fallback_ SPA](/docs/2.x//concepts/static-site-generation#spa-fallback)
 - `$route.query` akan selalu bernilai `{}` untuk pe-_render_-an di sisi server.
 - `process.static` bernilai `true`
 

--- a/content/id/guides/internals-glossary/internals.md
+++ b/content/id/guides/internals-glossary/internals.md
@@ -8,7 +8,7 @@ position: 3
 
 Nuxt.js memiliki arsitektur yang sepenuhnya modular yang membuka kesempatan bagi pengembang untuk memperluas bagian apapun dari Nuxt Core menggunakan sebuah API yang fleksibel.
 
-Anda dapat membaca [Panduan Modul](/guides/directory-structure/modules) untuk mempelajari lebih lanjut apabila Anda tertarik untuk mengembangkan modul Anda sendiri.
+Anda dapat membaca [Panduan Modul](/docs/2.x//directory-structure/modules) untuk mempelajari lebih lanjut apabila Anda tertarik untuk mengembangkan modul Anda sendiri.
 
 Dokumen ini membantu Anda untuk akrab dengan internal Nuxt dan dapat digunakan sebagai acuan ketika Anda mengemabngkan modul Anda sendiri.
 
@@ -18,17 +18,17 @@ Kelas-kelas berikut merupakan kelas utama dalam Nuxt dan tersedia baik pada saat
 
 #### Nuxt
 
-- [Kelas `Nuxt`](/guides/internals-glossary/internals-nuxt)
+- [Kelas `Nuxt`](/docs/2.x//internals-glossary/internals-nuxt)
 - Sumber: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer
 
-- [Kelas `Renderer`](/guides/internals-glossary/internals-renderer)
+- [Kelas `Renderer`](/docs/2.x//internals-glossary/internals-renderer)
 - Sumber: [vue-renderer/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-renderer/src/renderer.js)
 
 #### ModuleContainer
 
-- [Kelas `ModuleContainer`](/guides/internals-glossary/internals-module-container)
+- [Kelas `ModuleContainer`](/docs/2.x//internals-glossary/internals-module-container)
 - Source: [core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/module.js)
 
 ### Build
@@ -37,12 +37,12 @@ Kelas-kelas berikut hanya dibutuhkan pada saat pengembangan atau pada saat kode 
 
 #### Builder
 
-- [Kelas `Builder`](/guides/internals-glossary/internals-builder)
+- [Kelas `Builder`](/docs/2.x//internals-glossary/internals-builder)
 - Sumber: [builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/builder/src/builder.js)
 
 #### Generator
 
-- [Kelas `Generator`](/guides/internals-glossary/internals-generator)
+- [Kelas `Generator`](/docs/2.x//internals-glossary/internals-generator)
 - Sumber: [generator/generator.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/generator/src/generator.js)
 
 ### Common

--- a/content/id/guides/internals-glossary/internals.md
+++ b/content/id/guides/internals-glossary/internals.md
@@ -8,7 +8,7 @@ position: 3
 
 Nuxt.js memiliki arsitektur yang sepenuhnya modular yang membuka kesempatan bagi pengembang untuk memperluas bagian apapun dari Nuxt Core menggunakan sebuah API yang fleksibel.
 
-Anda dapat membaca [Panduan Modul](/docs/2.x//directory-structure/modules) untuk mempelajari lebih lanjut apabila Anda tertarik untuk mengembangkan modul Anda sendiri.
+Anda dapat membaca [Panduan Modul]((/docs/2.x/directory-structure/modules) untuk mempelajari lebih lanjut apabila Anda tertarik untuk mengembangkan modul Anda sendiri.
 
 Dokumen ini membantu Anda untuk akrab dengan internal Nuxt dan dapat digunakan sebagai acuan ketika Anda mengemabngkan modul Anda sendiri.
 
@@ -18,17 +18,17 @@ Kelas-kelas berikut merupakan kelas utama dalam Nuxt dan tersedia baik pada saat
 
 #### Nuxt
 
-- [Kelas `Nuxt`](/docs/2.x//internals-glossary/internals-nuxt)
+- [Kelas `Nuxt`]((/docs/2.x/internals-glossary/internals-nuxt)
 - Sumber: [core/nuxt.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/nuxt.js)
 
 #### Renderer
 
-- [Kelas `Renderer`](/docs/2.x//internals-glossary/internals-renderer)
+- [Kelas `Renderer`]((/docs/2.x/internals-glossary/internals-renderer)
 - Sumber: [vue-renderer/renderer.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-renderer/src/renderer.js)
 
 #### ModuleContainer
 
-- [Kelas `ModuleContainer`](/docs/2.x//internals-glossary/internals-module-container)
+- [Kelas `ModuleContainer`]((/docs/2.x/internals-glossary/internals-module-container)
 - Source: [core/module.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/core/src/module.js)
 
 ### Build
@@ -37,12 +37,12 @@ Kelas-kelas berikut hanya dibutuhkan pada saat pengembangan atau pada saat kode 
 
 #### Builder
 
-- [Kelas `Builder`](/docs/2.x//internals-glossary/internals-builder)
+- [Kelas `Builder`]((/docs/2.x/internals-glossary/internals-builder)
 - Sumber: [builder/builder.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/builder/src/builder.js)
 
 #### Generator
 
-- [Kelas `Generator`](/docs/2.x//internals-glossary/internals-generator)
+- [Kelas `Generator`]((/docs/2.x/internals-glossary/internals-generator)
 - Sumber: [generator/generator.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/generator/src/generator.js)
 
 ### Common

--- a/content/ja/guides/directory-structure/pages.md
+++ b/content/ja/guides/directory-structure/pages.md
@@ -147,7 +147,7 @@ export default {
 
 <base-alert type="next">
 
-`asyncData` の詳細は[データの取得](/guides/features/data-fetching#async-data)ページを参照してください。
+`asyncData` の詳細は[データの取得](/docs/2.x//features/data-fetching#async-data)ページを参照してください。
 
 </base-alert>
 
@@ -174,7 +174,7 @@ export default {
 
 <base-alert type="next">
 
-`fetch` の詳細は[データの取得](/guides/features/data-fetching)ページを参照してください。
+`fetch` の詳細は[データの取得](/docs/2.x//features/data-fetching)ページを参照してください。
 
 </base-alert>
 
@@ -192,7 +192,7 @@ export default {
 
 <base-alert type="next">
 
-詳細は[メタタグと SEO](/guides/features/meta-tags-seo) ページを参照してください。
+詳細は[メタタグと SEO](/docs/2.x//features/meta-tags-seo) ページを参照してください。
 
 </base-alert>
 
@@ -208,7 +208,7 @@ export default {
 
 <base-alert type="next">
 
-レイアウトの詳細は[レイアウトのドキュメント](/guides/concepts/views#layouts)を参照してください。
+レイアウトの詳細は[レイアウトのドキュメント](/docs/2.x//concepts/views#layouts)を参照してください。
 
 </base-alert>
 
@@ -230,7 +230,7 @@ nuxt.config.js で `loading` が設定されている場合のみ適用されま
 
 <base-alert type="next">
 
-詳細は[ローディング](/guides/features/loading)ページを参照してください。
+詳細は[ローディング](/docs/2.x//features/loading)ページを参照してください。
 
 </base-alert>
 
@@ -264,7 +264,7 @@ export default {
 
 逆に、親ルートでも `scrollToTop` を手動で `false` に設定することができます。
 
-スクロールについて Nuxt.js のデフォルトの挙動を上書きしたいときは、[scrollBehavior オプション](/guides/configuration-glossary/configuration-router#scrollbehavior)を参照してください。
+スクロールについて Nuxt.js のデフォルトの挙動を上書きしたいときは、[scrollBehavior オプション](/docs/2.x//configuration-glossary/configuration-router#scrollbehavior)を参照してください。
 
 ### middleware プロパティ
 
@@ -318,7 +318,7 @@ export default {
 
 <base-alert type="next">
 
-詳細は[データの取得](/guides/features/data-fetching)ページを参照してください。
+詳細は[データの取得](/docs/2.x//features/data-fetching)ページを参照してください。
 
 </base-alert>
 
@@ -334,7 +334,7 @@ export default {
 
 <base-alert type="next">
 
-詳細は[ignore オプション](/guides/configuration-glossary/configuration-ignore)ページを参照してください。
+詳細は[ignore オプション](/docs/2.x//configuration-glossary/configuration-ignore)ページを参照してください。
 
 </base-alert>
 
@@ -353,7 +353,7 @@ export default {
 
 <base-alert type="next">
 
-詳細は [dir オプション](/guides/configuration-glossary/configuration-dir)ページを参照してください。
+詳細は [dir オプション](/docs/2.x//configuration-glossary/configuration-dir)ページを参照してください。
 
 </base-alert>
 

--- a/content/ja/guides/directory-structure/pages.md
+++ b/content/ja/guides/directory-structure/pages.md
@@ -147,7 +147,7 @@ export default {
 
 <base-alert type="next">
 
-`asyncData` の詳細は[データの取得](/docs/2.x//features/data-fetching#async-data)ページを参照してください。
+`asyncData` の詳細は[データの取得]((/docs/2.x/features/data-fetching#async-data)ページを参照してください。
 
 </base-alert>
 
@@ -174,7 +174,7 @@ export default {
 
 <base-alert type="next">
 
-`fetch` の詳細は[データの取得](/docs/2.x//features/data-fetching)ページを参照してください。
+`fetch` の詳細は[データの取得]((/docs/2.x/features/data-fetching)ページを参照してください。
 
 </base-alert>
 
@@ -192,7 +192,7 @@ export default {
 
 <base-alert type="next">
 
-詳細は[メタタグと SEO](/docs/2.x//features/meta-tags-seo) ページを参照してください。
+詳細は[メタタグと SEO]((/docs/2.x/features/meta-tags-seo) ページを参照してください。
 
 </base-alert>
 
@@ -208,7 +208,7 @@ export default {
 
 <base-alert type="next">
 
-レイアウトの詳細は[レイアウトのドキュメント](/docs/2.x//concepts/views#layouts)を参照してください。
+レイアウトの詳細は[レイアウトのドキュメント]((/docs/2.x/concepts/views#layouts)を参照してください。
 
 </base-alert>
 
@@ -230,7 +230,7 @@ nuxt.config.js で `loading` が設定されている場合のみ適用されま
 
 <base-alert type="next">
 
-詳細は[ローディング](/docs/2.x//features/loading)ページを参照してください。
+詳細は[ローディング]((/docs/2.x/features/loading)ページを参照してください。
 
 </base-alert>
 
@@ -264,7 +264,7 @@ export default {
 
 逆に、親ルートでも `scrollToTop` を手動で `false` に設定することができます。
 
-スクロールについて Nuxt.js のデフォルトの挙動を上書きしたいときは、[scrollBehavior オプション](/docs/2.x//configuration-glossary/configuration-router#scrollbehavior)を参照してください。
+スクロールについて Nuxt.js のデフォルトの挙動を上書きしたいときは、[scrollBehavior オプション]((/docs/2.x/configuration-glossary/configuration-router#scrollbehavior)を参照してください。
 
 ### middleware プロパティ
 
@@ -318,7 +318,7 @@ export default {
 
 <base-alert type="next">
 
-詳細は[データの取得](/docs/2.x//features/data-fetching)ページを参照してください。
+詳細は[データの取得]((/docs/2.x/features/data-fetching)ページを参照してください。
 
 </base-alert>
 
@@ -334,7 +334,7 @@ export default {
 
 <base-alert type="next">
 
-詳細は[ignore オプション](/docs/2.x//configuration-glossary/configuration-ignore)ページを参照してください。
+詳細は[ignore オプション]((/docs/2.x/configuration-glossary/configuration-ignore)ページを参照してください。
 
 </base-alert>
 
@@ -353,7 +353,7 @@ export default {
 
 <base-alert type="next">
 
-詳細は [dir オプション](/docs/2.x//configuration-glossary/configuration-dir)ページを参照してください。
+詳細は [dir オプション]((/docs/2.x/configuration-glossary/configuration-dir)ページを参照してください。
 
 </base-alert>
 

--- a/content/ja/guides/features/deployment-targets.md
+++ b/content/ja/guides/features/deployment-targets.md
@@ -18,7 +18,7 @@ export default {
 target を static にした状態で nuxt dev を実行すると、開発者の体験は向上するでしょう:
 
 - `context` から `req` と `res` を削除します
-- クライアントサイドレンダリングの 404、エラー、リダイレクトをフォールバックします [SPA フォールバックを参照](/docs/2.x//concepts/static-site-generation#spa-fallback)
+- クライアントサイドレンダリングの 404、エラー、リダイレクトをフォールバックします [SPA フォールバックを参照]((/docs/2.x/concepts/static-site-generation#spa-fallback)
 - サーバーサイドレンダリングでは常に `$route.query` と `{}` は等しくなります
 - `process.static` は true になります
 

--- a/content/ja/guides/features/deployment-targets.md
+++ b/content/ja/guides/features/deployment-targets.md
@@ -18,7 +18,7 @@ export default {
 target を static にした状態で nuxt dev を実行すると、開発者の体験は向上するでしょう:
 
 - `context` から `req` と `res` を削除します
-- クライアントサイドレンダリングの 404、エラー、リダイレクトをフォールバックします [SPA フォールバックを参照](/guides/concepts/static-site-generation#spa-fallback)
+- クライアントサイドレンダリングの 404、エラー、リダイレクトをフォールバックします [SPA フォールバックを参照](/docs/2.x//concepts/static-site-generation#spa-fallback)
 - サーバーサイドレンダリングでは常に `$route.query` と `{}` は等しくなります
 - `process.static` は true になります
 

--- a/content/ko/guides/features/deployment-targets.md
+++ b/content/ko/guides/features/deployment-targets.md
@@ -18,7 +18,7 @@ export default {
 target static과 함께 nuxt dev를 실행하면 개발자 경험이 향상됩니다.
 
 - `context` 객체인 `req` & `res` 객체는 제거됩니다.
-- 404, 오류 및 리디렉션등은 클라이언트 사이드 렌더링으로 대체됩니다. [SPA fallback 자세히 보기](/docs/2.x//concepts/static-site-generation#spa-fallback)
+- 404, 오류 및 리디렉션등은 클라이언트 사이드 렌더링으로 대체됩니다. [SPA fallback 자세히 보기]((/docs/2.x/concepts/static-site-generation#spa-fallback)
 - `$route.query` 는 서버 사이드 렌더링에서는 항상 `{}` 와 같습니다.
 - `process.static` 은 항상 true 입니다.
 

--- a/content/ko/guides/features/deployment-targets.md
+++ b/content/ko/guides/features/deployment-targets.md
@@ -18,7 +18,7 @@ export default {
 target static과 함께 nuxt dev를 실행하면 개발자 경험이 향상됩니다.
 
 - `context` 객체인 `req` & `res` 객체는 제거됩니다.
-- 404, 오류 및 리디렉션등은 클라이언트 사이드 렌더링으로 대체됩니다. [SPA fallback 자세히 보기](/guides/concepts/static-site-generation#spa-fallback)
+- 404, 오류 및 리디렉션등은 클라이언트 사이드 렌더링으로 대체됩니다. [SPA fallback 자세히 보기](/docs/2.x//concepts/static-site-generation#spa-fallback)
 - `$route.query` 는 서버 사이드 렌더링에서는 항상 `{}` 와 같습니다.
 - `process.static` 은 항상 true 입니다.
 


### PR DESCRIPTION
Hi there!
I've found many broken links (and no redirection) all over the french translations.

I've searched into the english version and found that all the links was directly bind to the new `/docs/2.x/` structure.

I've made a search and replace all over the `guide` directories (to exclude the archives) in all the language.