### PR TITLE
fix: correct directory name

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-srcdir.md
+++ b/content/en/guides/configuration-glossary/configuration-srcdir.md
@@ -47,7 +47,7 @@ works with the following folder structure (note that nuxt.config is listed in th
 
 Example 2:
 
-Instead of example 1 you can also move the nuxt.config into your `src` folder. In this case you only need to specify client as the `rootDir` and you can leave `srcDir` empty:
+Instead of example 1 you can also move the nuxt.config into your `client` folder. In this case you only need to specify `client` as the `rootDir` and you can leave `srcDir` empty:
 
 Prerequisites:
 


### PR DESCRIPTION
Inconsistent directory names may have been caused by a previous translation (?)