### PR TITLE
docs: update number of modules and maintainers

### DIFF
--- a/content/en/guides/directory-structure/modules.md
+++ b/content/en/guides/directory-structure/modules.md
@@ -70,8 +70,8 @@ questions:
 
 Discover our [list of modules](https://modules.nuxtjs.org) to supercharge your Nuxt project, created by the Nuxt team and community.
 
-- 145+ Modules
-- 89+ Maintainers
+- 165+ Modules
+- 105+ Maintainers
 
 <base-alert type="next">
 


### PR DESCRIPTION
According to official modules website: https://modules.nuxtjs.org/
Number of Nuxt modules and Maintainers are increased and it is not 145+ and 89+ anymore.