### PR TITLE
Update deprecated slot attribute to v-slot

### DIFF
--- a/content/en/guides/features/nuxt-components.md
+++ b/content/en/guides/features/nuxt-components.md
@@ -397,11 +397,16 @@ Use a slot as placeholder until `<client-only />` is mounted on client-side.
       <comments />
 
       <!-- loading indicator, rendered on server-side -->
-      <comments-placeholder slot="placeholder" />
+      <comments-placeholder #placeholder />
     </client-only>
   </div>
 </template>
 ```
+<base-alert>
+
+If you are using a version of Nuxt < v2.5.0 *and* a vue version < v2.6.0 use the deprecated syntax `<client-only slot="placeholder">` instead of `<client-only #placeholder>`. More Info: https://vuejs.org/v2/guide/components-slots.html#Deprecated-Syntax
+
+</base-alert>
 
 <base-alert  type="info">
 


### PR DESCRIPTION
### Update Docs: The client-only component
Update `<client-only>` example to use to use `v-slot` directive instead of deprecated `slot` attribute. (See https://vuejs.org/v2/guide/components-slots.html#Deprecated-Syntax)

Add a `<base-alert>` informing about the deprecated syntax for versions of nuxt < v2.5.0 and vue < v2.6.0.