### PR TITLE
fix: table overflowing on mobile screen

### DIFF
--- a/assets/css/content.scss
+++ b/assets/css/content.scss
@@ -417,4 +417,14 @@
   }
 }
 
+.nuxt-content {
+  table {
+    @media (max-width: 678px) {
+      display: block;
+      width: 100%;
+      overflow-x: scroll;
+    }
+  }
+}
+
 /* purgecss end ignore */


### PR DESCRIPTION
**🐛 The bug**
When navigating on mobile (SM-G973F) I realized the `<table>` part of the docs were overflowing it's content horizontally.

![Screenshot from 2021-05-09 18-38-12](https://user-images.githubusercontent.com/34862686/117588884-bcc1d980-b0fc-11eb-9f60-3f398b652f7a.png)

**🛠️ To reproduce**
The issue is reproducible by running the project locally on your computer and navigating to a `/internals-glossary/**` page, where the markdown translates to a `<table>` on `nuxt-content`

**🔨 The fix**

https://user-images.githubusercontent.com/34862686/117589027-a0726c80-b0fd-11eb-9635-315758131092.mp4


