### PR TITLE
docs: Fix dir option example

### DIFF
--- a/content/en/guides/directory-structure/nuxt-config.md
+++ b/content/en/guides/directory-structure/nuxt-config.md
@@ -396,7 +396,9 @@ This option lets you define custom names of your Nuxt.js directories.
 
 ```js{}[nuxt.config.js]
 export default {
-  pages: 'views' // Nuxt will look for the views/ instead of the pages/ folder
+  dir: {
+    pages: 'views' // Nuxt will look for the views/ instead of the pages/ folder
+  }
 }
 ```
 


### PR DESCRIPTION
```
export default {
  pages: 'views'
}
```

to

```
export default {
  dir: {
    pages: 'views'
  }
}
```