### PR TITLE
Update app engine-deployment.md

### DIFF
--- a/content/en/guides/deployment/appengine-deployment.md
+++ b/content/en/guides/deployment/appengine-deployment.md
@@ -51,7 +51,7 @@ env: flex
 
 ## Build and deploy the app
 
-Now build your app with `npm run build`.
+Now build your app with `npm run build` or `yarn build`.
 
 At this point, your app is ready to be uploaded to Google App Engine. Now just run the following command:
 


### PR DESCRIPTION
If new devs use yarn and then use npm run build, the following error will appear when they execute gcloud app deploy:

ERROR: (gcloud.app.deploy) Error Response: [3] The directory [.yarn/cache] has too many files (greater than 1000).