### PR TITLE
Naming update for Moovweb and Moovweb XDN to Layer0

### DIFF
--- a/content/en/guides/deployment/deploy-on-moovweb.md
+++ b/content/en/guides/deployment/deploy-on-moovweb.md
@@ -1,36 +1,36 @@
 ---
-title: Deploy Nuxt with Moovweb XDN
-description: How to deploy Nuxt.js app with Moovweb XDN?
-menu: Moovweb XDN
+title: Deploy Nuxt on Layer0
+description: How to deploy Nuxt.js app on Layer0?
+menu: Layer0
 target: Server
 category: deployment
 position: 110
 ---
 
-Moovweb XDN supports universal (SSR) Nuxt.js applications.
+Layer0 supports universal (SSR) Nuxt.js applications.
 
-The [Moovweb XDN](https://www.moovweb.com/) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. The XDN is focused on large, dynamic websites and best-in-class performance through an integrated Content Delivery Network (CDN), CDN-as-JavaScript, predictive prefetching, and performance monitoring. Moovweb offers a free tier.
+[Layer0](https://www.layer0.co) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. It is focused on large, dynamic websites and best-in-class performance through EdgeJS (a JavaScript-based Content Delivery Network), predictive prefetching, and performance monitoring. Layer0 offers a free tier.
 
-For detailed instructions consult the [Moovweb XDN Nuxt.js documentation](https://developer.moovweb.com/guides/nuxt).
+For detailed instructions consult the [Layer0 Nuxt.js documentation](https://docs.layer0.co/guides/nuxt).
 
 ## Getting Started
 
-1. Sign up for a free account on the [XDN signup page](https://moovweb.app/signup).
+1. Sign up for a free account on [Layer0's signup page](https://app.layer0.co/signup).
 
-2. Install the XDN CLI
+2. Install the [Layer0 CLI](https://docs.layer0.co/guides/cli)
 
 <code-group>
   <code-block label="Yarn" active>
 
 ```bash
-yarn add -g @xdn/cli
+yarn global add @layer0/cli
 ```
 
   </code-block>
   <code-block label="npm">
 
 ```bash
-npm i -g @xdn/cli
+npm i -g @layer0/cli
 ```
 
   </code-block>
@@ -39,37 +39,37 @@ npm i -g @xdn/cli
 
 ## Configure your project
 
-3. Make sure [server side rendering is enabled](/docs/2.x/configuration-glossary/configuration-ssr) and in your `nuxt.config.js` add the `@xdn/nuxt` module:
+3. Make sure [server side rendering is enabled](/docs/2.x/configuration-glossary/configuration-ssr) and in your `nuxt.config.js` add the `@layer0/nuxt` module:
 
 ```js
 // nuxt.config.js
 
 module.exports = {
-  modules: ['@xdn/nuxt/module']
+  modules: ['@layer0/nuxt/module']
 }
 ```
 
-4. Run `xdn init` which will configure your project for the XDN.
+4. Run `layer0 init` which will configure your project for Layer0.
 
 ## Running and deploying your project
 
 5. To test your app locally, run the following in your project directory:
 
 ```js
-xdn run
+layer0 run
 ```
 
 6. To deploy your app, run the following in your project directory:
 
 ```js
-xdn deploy
+layer0 deploy
 ```
 
 ## Optimize your project's performance
 
-- (Optional) To optimize the performance of server side rendering in Nuxt.js, Moovweb recommends moving most your modules into `buildModules` as described in the [modules vs buildModules section](https://developer.moovweb.com/guides/nuxt#section_modules_vs_buildmodules) of the XDN Nuxt.js guide.
-- (Optional) The XDN automatically supports Nuxt.js's built-in routing scheme. However you can and should optimize the performance by customizing the routing, caching, and prefetching via CDN-as-JavaScript as shown in the [Routing section](https://developer.moovweb.com/guides/nuxt#section_routing) of the XDN Nuxt.js guide.
+- (Optional) To optimize the performance of server side rendering in Nuxt.js, Layer0 recommends moving most your modules into `buildModules` as described in the [modules vs buildModules section](https://docs.layer0.co/guides/nuxt#section_modules_vs_buildmodules) of the Layer0 Nuxt.js guide.
+- (Optional) Layer0 automatically supports Nuxt.js's built-in routing scheme. However you can and should optimize the performance by customizing the routing, caching, and prefetching via EdgeJS as shown in the [Routing section](https://docs.layer0.co/guides/nuxt#section_routing) of the Layer0 Nuxt.js guide.
 
 ## Get help
 
-If you have issues please check the [Troubleshooting section](https://developer.moovweb.com/guides/nuxt#section_troubleshooting) of the guide or create a ticket in the [forums](https://forum.moovweb.com/).
+If you have issues please check the [Troubleshooting section](https://docs.layer0.co/guides/nuxt#section_troubleshooting) of the guide or create a ticket in the [forums](https://forum.layer0.co).

--- a/content/fr/guides/deployment/deploy-on-moovweb.md
+++ b/content/fr/guides/deployment/deploy-on-moovweb.md
@@ -1,36 +1,36 @@
 ---
-title: Deploy Nuxt with Moovweb XDN
-description: How to deploy Nuxt.js app with Moovweb XDN?
-menu: Moovweb XDN
+title: Deploy Nuxt on Layer0
+description: How to deploy Nuxt.js app on Layer0?
+menu: Layer0
 target: Server
 category: deployment
 position: 110
 ---
 
-Moovweb XDN supports universal (SSR) Nuxt.js applications.
+Layer0 supports universal (SSR) Nuxt.js applications.
 
-The [Moovweb XDN](https://www.moovweb.com/) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. The XDN is focused on large, dynamic websites and best-in-class performance through an integrated Content Delivery Network (CDN), CDN-as-JavaScript, predictive prefetching, and performance monitoring. Moovweb offers a free tier.
+[Layer0](https://www.layer0.co) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. It is focused on large, dynamic websites and best-in-class performance through EdgeJS (a JavaScript-based Content Delivery Network), predictive prefetching, and performance monitoring. Layer0 offers a free tier.
 
-For detailed instructions consult the [Moovweb XDN Nuxt.js documentation](https://developer.moovweb.com/guides/nuxt).
+For detailed instructions consult the [Layer0 Nuxt.js documentation](https://docs.layer0.co/guides/nuxt).
 
 ## Getting Started
 
-1. Sign up for a free account on the [XDN signup page](https://moovweb.app/signup).
+1. Sign up for a free account on [Layer0's signup page](https://app.layer0.co/signup).
 
-2. Install the XDN CLI
+2. Install the [Layer0 CLI](https://docs.layer0.co/guides/cli)
 
 <code-group>
   <code-block label="Yarn" active>
 
 ```bash
-yarn add -g @xdn/cli
+yarn global add @layer0/cli
 ```
 
   </code-block>
   <code-block label="npm">
 
 ```bash
-npm i -g @xdn/cli
+npm i -g @layer0/cli
 ```
 
   </code-block>
@@ -39,37 +39,37 @@ npm i -g @xdn/cli
 
 ## Configure your project
 
-3. Make sure [server side rendering is enabled](/docs/2.x/configuration-glossary/configuration-ssr) and in your `nuxt.config.js` add the `@xdn/nuxt` module:
+3. Make sure [server side rendering is enabled](/docs/2.x/configuration-glossary/configuration-ssr) and in your `nuxt.config.js` add the `@layer0/nuxt` module:
 
 ```js
 // nuxt.config.js
 
 module.exports = {
-  modules: ['@xdn/nuxt/module']
+  modules: ['@layer0/nuxt/module']
 }
 ```
 
-4. Run `xdn init` which will configure your project for the XDN.
+4. Run `layer0 init` which will configure your project for Layer0.
 
 ## Running and deploying your project
 
 5. To test your app locally, run the following in your project directory:
 
 ```js
-xdn run
+layer0 run
 ```
 
 6. To deploy your app, run the following in your project directory:
 
 ```js
-xdn deploy
+layer0 deploy
 ```
 
 ## Optimize your project's performance
 
-- (Optional) To optimize the performance of server side rendering in Nuxt.js, Moovweb recommends moving most your modules into `buildModules` as described in the [modules vs buildModules section](https://developer.moovweb.com/guides/nuxt#section_modules_vs_buildmodules) of the XDN Nuxt.js guide.
-- (Optional) The XDN automatically supports Nuxt.js's built-in routing scheme. However you can and should optimize the performance by customizing the routing, caching, and prefetching via CDN-as-JavaScript as shown in the [Routing section](https://developer.moovweb.com/guides/nuxt#section_routing) of the XDN Nuxt.js guide.
+- (Optional) To optimize the performance of server side rendering in Nuxt.js, Layer0 recommends moving most your modules into `buildModules` as described in the [modules vs buildModules section](https://docs.layer0.co/guides/nuxt#section_modules_vs_buildmodules) of the Layer0 Nuxt.js guide.
+- (Optional) Layer0 automatically supports Nuxt.js's built-in routing scheme. However you can and should optimize the performance by customizing the routing, caching, and prefetching via EdgeJS as shown in the [Routing section](https://docs.layer0.co/guides/nuxt#section_routing) of the Layer0 Nuxt.js guide.
 
 ## Get help
 
-If you have issues please check the [Troubleshooting section](https://developer.moovweb.com/guides/nuxt#section_troubleshooting) of the guide or create a ticket in the [forums](https://forum.moovweb.com/).
+If you have issues please check the [Troubleshooting section](https://docs.layer0.co/guides/nuxt#section_troubleshooting) of the guide or create a ticket in the [forums](https://forum.layer0.co).

--- a/content/ja/guides/deployment/deploy-on-moovweb.md
+++ b/content/ja/guides/deployment/deploy-on-moovweb.md
@@ -1,36 +1,36 @@
 ---
-title: Deploy Nuxt with Moovweb XDN
-description: How to deploy Nuxt.js app with Moovweb XDN?
-menu: Moovweb XDN
+title: Deploy Nuxt on Layer0
+description: How to deploy Nuxt.js app on Layer0?
+menu: Layer0
 target: Server
 category: deployment
 position: 110
 ---
 
-Moovweb XDN supports universal (SSR) Nuxt.js applications.
+Layer0 supports universal (SSR) Nuxt.js applications.
 
-The [Moovweb XDN](https://www.moovweb.com/) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. The XDN is focused on large, dynamic websites and best-in-class performance through an integrated Content Delivery Network (CDN), CDN-as-JavaScript, predictive prefetching, and performance monitoring. Moovweb offers a free tier.
+[Layer0](https://www.layer0.co) is an all-in-one platform to develop, deploy, preview, experiment on, monitor, and run your headless frontend. It is focused on large, dynamic websites and best-in-class performance through EdgeJS (a JavaScript-based Content Delivery Network), predictive prefetching, and performance monitoring. Layer0 offers a free tier.
 
-For detailed instructions consult the [Moovweb XDN Nuxt.js documentation](https://developer.moovweb.com/guides/nuxt).
+For detailed instructions consult the [Layer0 Nuxt.js documentation](https://docs.layer0.co/guides/nuxt).
 
 ## Getting Started
 
-1. Sign up for a free account on the [XDN signup page](https://moovweb.app/signup).
+1. Sign up for a free account on [Layer0's signup page](https://app.layer0.co/signup).
 
-2. Install the XDN CLI
+2. Install the [Layer0 CLI](https://docs.layer0.co/guides/cli)
 
 <code-group>
   <code-block label="Yarn" active>
 
 ```bash
-yarn add -g @xdn/cli
+yarn global add @layer0/cli
 ```
 
   </code-block>
   <code-block label="npm">
 
 ```bash
-npm i -g @xdn/cli
+npm i -g @layer0/cli
 ```
 
   </code-block>
@@ -39,37 +39,37 @@ npm i -g @xdn/cli
 
 ## Configure your project
 
-3. Make sure [server side rendering is enabled](/docs/2.x/configuration-glossary/configuration-ssr) and in your `nuxt.config.js` add the `@xdn/nuxt` module:
+3. Make sure [server side rendering is enabled](/docs/2.x/configuration-glossary/configuration-ssr) and in your `nuxt.config.js` add the `@layer0/nuxt` module:
 
 ```js
 // nuxt.config.js
 
 module.exports = {
-  modules: ['@xdn/nuxt/module']
+  modules: ['@layer0/nuxt/module']
 }
 ```
 
-4. Run `xdn init` which will configure your project for the XDN.
+4. Run `layer0 init` which will configure your project for Layer0.
 
 ## Running and deploying your project
 
 5. To test your app locally, run the following in your project directory:
 
 ```js
-xdn run
+layer0 run
 ```
 
 6. To deploy your app, run the following in your project directory:
 
 ```js
-xdn deploy
+layer0 deploy
 ```
 
 ## Optimize your project's performance
 
-- (Optional) To optimize the performance of server side rendering in Nuxt.js, Moovweb recommends moving most your modules into `buildModules` as described in the [modules vs buildModules section](https://developer.moovweb.com/guides/nuxt#section_modules_vs_buildmodules) of the XDN Nuxt.js guide.
-- (Optional) The XDN automatically supports Nuxt.js's built-in routing scheme. However you can and should optimize the performance by customizing the routing, caching, and prefetching via CDN-as-JavaScript as shown in the [Routing section](https://developer.moovweb.com/guides/nuxt#section_routing) of the XDN Nuxt.js guide.
+- (Optional) To optimize the performance of server side rendering in Nuxt.js, Layer0 recommends moving most your modules into `buildModules` as described in the [modules vs buildModules section](https://docs.layer0.co/guides/nuxt#section_modules_vs_buildmodules) of the Layer0 Nuxt.js guide.
+- (Optional) Layer0 automatically supports Nuxt.js's built-in routing scheme. However you can and should optimize the performance by customizing the routing, caching, and prefetching via EdgeJS as shown in the [Routing section](https://docs.layer0.co/guides/nuxt#section_routing) of the Layer0 Nuxt.js guide.
 
 ## Get help
 
-If you have issues please check the [Troubleshooting section](https://developer.moovweb.com/guides/nuxt#section_troubleshooting) of the guide or create a ticket in the [forums](https://forum.moovweb.com/).
+If you have issues please check the [Troubleshooting section](https://docs.layer0.co/guides/nuxt#section_troubleshooting) of the guide or create a ticket in the [forums](https://forum.layer0.co).


### PR DESCRIPTION
Moovweb rebranded to [Layer0](https://www.layer0.co/post/introducing-layer0) hence a lot of changes. I work there, and I've made the necessary changes to the deployment process.