### PR TITLE
Title paramater should not be translated

### DIFF
--- a/content/fr/guides/components-glossary/pages-head.md
+++ b/content/fr/guides/components-glossary/pages-head.md
@@ -26,7 +26,7 @@ Utilisez la méthode `head` pour définir les balises d'entête HTML de votre pa
     },
     head() {
       return {
-        titre: this.titre,
+        title: this.titre,
         meta: [
           // `hid` est un identifiant unique. N'utilisez pas `vmid` pour cela car cela ne marchera pas.
           {


### PR DESCRIPTION
When checking the docs I found this example in French for the head function.
But I noticed the 'title' parameter was translated in French to 'titre' making the example invalid.