### PR TITLE
docs: change minimum node version to 12

### DIFF
--- a/content/en/guides/get-started/installation.md
+++ b/content/en/guides/get-started/installation.md
@@ -12,7 +12,7 @@ ManualInstallVideoTitle: Nuxt Manual Installation
 
 ## Prerequisites
 
-- [node](https://nodejs.org) - _We recommend you have the latest LTS version installed_ or at least v10.13 and above (excluding v11).
+- [node](https://nodejs.org) - _We recommend you have the latest LTS version installed_ or at least v12 and above.
 - A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension or [WebStorm](https://www.jetbrains.com/webstorm/)
 - A terminal, we recommend using VS Code's [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal) or [WebStorm terminal](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 

--- a/content/en/guides/get-started/installation.md
+++ b/content/en/guides/get-started/installation.md
@@ -12,7 +12,7 @@ ManualInstallVideoTitle: Nuxt Manual Installation
 
 ## Prerequisites
 
-- [node](https://nodejs.org) - _We recommend you have the latest LTS version installed_ or at least v12 and above.
+- [node](https://nodejs.org) - _We recommend you have the latest LTS version installed_.
 - A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension or [WebStorm](https://www.jetbrains.com/webstorm/)
 - A terminal, we recommend using VS Code's [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal) or [WebStorm terminal](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 


### PR DESCRIPTION
According to v2.15.0 release notes [1] the minimum node version is 12.

[1] https://github.com/nuxt/nuxt.js/releases/tag/v2.15.0