### PR TITLE
docs: correctly link context.app to documentation in "Context and Helpers"

### DIFF
--- a/content/en/guides/concepts/context-helpers.md
+++ b/content/en/guides/concepts/context-helpers.md
@@ -93,7 +93,7 @@ Learn more about the different context keys in our [Internals Glossary](/docs/2.
 
 ### Using page parameters for your API query
 
-The context directly exposes possible dynamic parameters of the route via `context.params`. In the following example, we call an API via the `nuxt/http` module using a dynamic page parameter as part of the URL. Modules, like the [nuxt/http](https://http.nuxtjs.org/) module, can expose own functions which are then available through the [context.app](http://context.app) object.
+The context directly exposes possible dynamic parameters of the route via `context.params`. In the following example, we call an API via the `nuxt/http` module using a dynamic page parameter as part of the URL. Modules, like the [nuxt/http](https://http.nuxtjs.org/) module, can expose own functions which are then available through the [context.app](/docs/2.x/internals-glossary/context#app) object.
 
 Also, we wrap the API call in a `try/catch` statement to handle potential errors. With the `context.error` function, we can directly show Nuxt's error page and pass in the occurred error.
 


### PR DESCRIPTION
Updates a link for `context.app` to https://nuxtjs.org/docs/2.x/internals-glossary/context#app