### PR TITLE
docs: remove extraneous 'params.slug' parameter on author page

### DIFF
--- a/content/en/blog/creating-blog-with-nuxt-content.md
+++ b/content/en/blog/creating-blog-with-nuxt-content.md
@@ -764,7 +764,7 @@ We then fetch all the details we want to show on this page. In the last example 
 <script>
   export default {
     async asyncData({ $content, params }) {
-      const articles = await $content('articles', params.slug)
+      const articles = await $content('articles')
         .where({
           'author.name': {
             $regex: [params.author, 'i']


### PR DESCRIPTION
This PR updates a code snippet in the `Creating a Blog with Nuxt Content' post to match a minor change made in this PR for the source code: https://github.com/nuxtlabs/demo-blog-nuxt-content/pull/69

Per the PR description:


> This PR removes the params.slug parameter from $content() calls on pages which don't have a slug param, such as the authors and tags pages. The inclusion of this undefined parameter doesn't affect the functionality of these pages since $content() ignores the undefined second parameter. Removing this unnecessary parameter just makes the code easier to understand.

