### PR TITLE
fix(preview): various team info

### DIFF
--- a/content/en/teams/2.community.md
+++ b/content/en/teams/2.community.md
@@ -197,8 +197,8 @@ members:
       - linkedIn: 'https://www.linkedin.com/in/pascalluther/'
   -
     avatarUrl: 'https://github.com/NicoPennec.png'
-    name: "Nicolas PENNEC"
-    location: 'Zurich, Switzerland'
+    name: "Nicolas Pennec"
+    location: 'Rennes, France'
     socials:
       - gitHub: 'https://github.com/NicoPennec'
       - twitter: 'https://twitter.com/NicoPennec'

--- a/content/en/teams/2.community.md
+++ b/content/en/teams/2.community.md
@@ -27,7 +27,7 @@ members:
   -
     avatarUrl: 'https://github.com/ricardogobbosouza.png'
     name: 'Ricardo Gobbo de Souza'
-    location: 'The Netherlands'
+    location: 'São José dos Campos, São Paulo, Brasil'
     socials:
       - gitHub: 'https://github.com/ricardogobbosouza'
       - twitter: 'https://twitter.com/gobbo_ricardo'


### PR DESCRIPTION
Current: ![grafik](https://user-images.githubusercontent.com/640208/125037986-21fe6080-e095-11eb-91ec-0467ea5bb0cb.png)

Preview: 
![grafik](https://user-images.githubusercontent.com/640208/125038049-3b071180-e095-11eb-96e5-0a32e762ab4b.png)


----

According to his [GH page](https://github.com/NicoPennec) and website [https://pennec.io/](https://pennec.io/), Nicolas Pennec lives in Rennes and not in Zurich ☺️ 
I've also changed the capitalization to stay in line with the other names.
