### PR TITLE
feat(preview): lazy load more homepage images

### DIFF
--- a/components/organisms/home/HomeCampfire.vue
+++ b/components/organisms/home/HomeCampfire.vue
@@ -15,7 +15,7 @@
           <li v-for="post in posts" :key="post.title" class="flex flex-col self-start">
             <NuxtLink :to="localePath(post.to)">
               <div class="aspect-w-16 aspect-h-8 bg-gray-100 overflow-hidden dark:bg-secondary-darker mb-4 rounded-lg">
-                <NuxtImg :src="post.imgUrl" width="864" height="378" :alt="post.title" />
+                <NuxtImg :src="post.imgUrl" width="864" height="378" :alt="post.title" loading="lazy"/>
               </div>
             </NuxtLink>
             <span class="text-cloud-light text-body-base lg:text-body-lg font-bold mb-2">{{ post.category }}</span>

--- a/components/organisms/home/HomeTestimonials.vue
+++ b/components/organisms/home/HomeTestimonials.vue
@@ -67,12 +67,12 @@
             >
               <NuxtLabel tag="p" class="text-left" v-html="testimonial.testimonial"></NuxtLabel>
               <div class="flex w-full justify-between items-center">
-                <a :href="testimonial.authorUrl" target="_blank" rel="noopener">
+                <a :href="testimonial.authorUrl" target="_blank" rel="noopener" class="block h-12 w-12">
                   <img
                     :src="`/img/home/testimonials/${testimonial.authorIcon}.png`"
                     width="48"
                     height="48"
-                    class="h-12 w-12"
+                    loading="lazy"
                   />
                 </a>
                 <a
@@ -89,6 +89,7 @@
                     :src="`/img/home/testimonials/${testimonial.jobIcon}.svg`"
                     width="28"
                     height="28"
+                    loading="lazy"
                     :class="{ 'light-img': testimonial.jobIconDark }"
                   />
                   <img
@@ -97,6 +98,7 @@
                     width="28"
                     height="28"
                     class="dark-img"
+                    loading="lazy"
                   />
                 </a>
               </div>


### PR DESCRIPTION
Adds `loading="lazy"` to the "Sharing is Caring" and "Testimonials" sections on the homepage.