### PR TITLE
feat(preview): add some accessability props to homepage elements

### DIFF
--- a/components/molecules/footer/FooterSocialLinks.vue
+++ b/components/molecules/footer/FooterSocialLinks.vue
@@ -1,7 +1,7 @@
 <template>
   <ul class="flex items-center space-x-4 xl:space-x-5">
     <li v-for="(social, key) in socials" :key="key">
-      <NuxtHref :href="social.href">
+      <NuxtHref :href="social.href" :title="social.name">
         <Component :is="social.icon" class="w-6 h-6 text-gray-400 dark:text-cloud-lighter hover:text-primary" />
       </NuxtHref>
     </li>
@@ -15,18 +15,22 @@ export default defineComponent({
   setup() {
     const socials = [
       {
+        name: 'Nuxt Youtube',
         href: 'https://www.youtube.com/channel/UCJ9jj5YMzo-HsyM6WG9Q_Lg',
         icon: 'IconYoutube'
       },
       {
+        name: 'Nuxt Discord',
         href: 'https://discord.com/invite/ps2h6QT',
         icon: 'IconDiscord'
       },
       {
+        name: 'Nuxt Twitter',
         href: 'https://twitter.com/nuxt_js',
         icon: 'IconTwitter'
       },
       {
+        name: 'Nuxt GitHub',
         href: 'https://github.com/nuxt',
         icon: 'IconGitHub'
       }

--- a/components/organisms/animations/AnimFromCliCodeblock.vue
+++ b/components/organisms/animations/AnimFromCliCodeblock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fromcli__container">
+  <div class="fromcli__container" aria-live="polite">
     <div class="fromcli__code">
       <div class="fromcli__code__wrapper">
         <div class="fromcli__code__bash">
@@ -114,23 +114,25 @@
     </div>
     <div class="fromcli__display">
       <div class="fromcli__display_loading">
-        <img loading="lazy" class="fromcli__display__logo" src="~/static/img/home/learn/master/logo.svg" />
+        <img loading="lazy" class="fromcli__display__logo" src="~/static/img/home/learn/master/logo.svg" alt="" />
         <div class="fromcli__display__progressbar">
           <div class="fromcli__display__progressbar__background"></div>
           <div class="fromcli__display__progressbar__progress"></div>
         </div>
       </div>
       <div class="fromcli__display__content">
-        <img loading="lazy" class="fromcli__display__content__logo" src="~/static/img/home/learn/master/logo.svg" />
+        <img loading="lazy" class="fromcli__display__content__logo" src="~/static/img/home/learn/master/logo.svg" alt="" />
         <img
           loading="lazy"
           class="fromcli__display__content__content1"
           src="~/static/img/home/learn/master/cliContent1.svg"
+          alt=""
         />
         <img
           loading="lazy"
           class="fromcli__display__content__content2"
           src="~/static/img/home/learn/master/cliContent2.svg"
+          alt=""
         />
       </div>
     </div>

--- a/components/organisms/animations/AnimFromScratchCodeblock.vue
+++ b/components/organisms/animations/AnimFromScratchCodeblock.vue
@@ -57,16 +57,16 @@
               <span>&lt;</span>
               <span class="text-red-400">h1</span>
               <span>&gt;</span>
-              Hello world !
+              <span>Hello world !</span>
               <span>&lt;</span>
-              &#47;
+              <span>&#47;</span>
               <span class="text-red-400">h1</span>
               <span>&gt;</span>
             </p>
             <p>
               <!-- Template tag open -->
               <span>&lt;</span>
-              &#47;
+              <span>&#47;</span>
               <span class="text-red-400">template</span>
               <span>&gt;</span>
             </p>
@@ -76,14 +76,14 @@
     </div>
     <div class="fromscratch__display">
       <div class="fromscratch__display_loading">
-        <img loading="lazy" class="fromscratch__display__logo" src="~/static/img/home/learn/master/logo.svg" />
+        <img loading="lazy" class="fromscratch__display__logo" src="~/static/img/home/learn/master/logo.svg" alt="" />
         <div class="fromscratch__display__progressbar">
           <div class="fromscratch__display__progressbar__background"></div>
           <div class="fromscratch__display__progressbar__progress"></div>
         </div>
       </div>
       <div class="fromscratch__display__content">
-        <img loading="lazy" src="~/static/img/home/learn/master/sidebar.svg" />
+        <img loading="lazy" src="~/static/img/home/learn/master/sidebar.svg" alt="" />
         <p>Hello world !</p>
       </div>
     </div>

--- a/components/organisms/app/AppFooter.vue
+++ b/components/organisms/app/AppFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="" aria-labelledby="footerHeading">
+  <footer class="">
     <div class="select-none pt-24">
       <img
         loading="lazy"

--- a/components/organisms/app/AppHeader.vue
+++ b/components/organisms/app/AppHeader.vue
@@ -7,6 +7,7 @@
         <Link
           :class="[aside ? 'justify-center lg:justify-start' : 'justify-start']"
           class="flex items-center flex-1 lg:flex-none lg:w-60"
+          aria-label="Homepage"
           :to="localePath('/')"
         >
           <!-- "mr-4 lg:mr-0" to optically center logo text -->

--- a/components/organisms/home/CodeBlockAnimation.vue
+++ b/components/organisms/home/CodeBlockAnimation.vue
@@ -2,13 +2,13 @@
   <div>
     <ul class="flex">
       <li>
-        <button class="relative mr-8 text-lg font-bold light:text-gray-800" @click="activeCodeBlock = 'fromCLI'">
+        <button class="relative mr-8 text-lg font-bold light:text-gray-800" id="code-block-cli" @click="activeCodeBlock = 'fromCLI'">
           From CLI
           <span v-if="activeCodeBlock === 'fromCLI'" class="absolute -bottom-1.5 left-0 h-0.5 bg-primary w-1/3" />
         </button>
       </li>
       <li>
-        <button class="relative mr-8 text-lg font-bold light:text-gray-800" @click="activeCodeBlock = 'fromScratch'">
+        <button class="relative mr-8 text-lg font-bold light:text-gray-800" id="code-block-scratch" @click="activeCodeBlock = 'fromScratch'">
           From Scratch
           <span v-if="activeCodeBlock === 'fromScratch'" class="absolute -bottom-1.5 left-0 h-0.5 bg-primary w-1/3" />
         </button>
@@ -19,11 +19,19 @@
     <div class="mt-40 mb-40 lg:mt-0 lg:mb-0 w-full" :style="{ height: '300px' }">
       <div class="relative">
         <Transition name="fade">
-          <AnimFromCliCodeblock v-if="activeCodeBlock === 'fromCLI'" />
+          <AnimFromCliCodeblock
+            v-if="activeCodeBlock === 'fromCLI'"
+            role="img"
+            aria-describedby="code-block-cli"
+          />
         </Transition>
 
         <Transition name="fade">
-          <AnimFromScratchCodeblock v-if="activeCodeBlock === 'fromScratch'" />
+          <AnimFromScratchCodeblock
+            v-if="activeCodeBlock === 'fromScratch'"
+            role="img"
+            aria-describedby="code-block-scratch"
+          />
         </Transition>
       </div>
     </div>

--- a/components/organisms/home/HomeTestimonials.vue
+++ b/components/organisms/home/HomeTestimonials.vue
@@ -70,6 +70,7 @@
                 <a :href="testimonial.authorUrl" target="_blank" rel="noopener">
                   <img
                     :src="`/img/home/testimonials/${testimonial.authorIcon}.png`"
+                    :alt="`Photo of ${testimonial.author}`"
                     width="48"
                     height="48"
                     class="h-12 w-12"
@@ -84,9 +85,10 @@
                   <NuxtLabel tag="span" class="font-bold text-base">{{ testimonial.author }}</NuxtLabel>
                   <NuxtLabel tag="span" class="text-sm dark:text-cloud-lighter">{{ testimonial.job }}</NuxtLabel>
                 </a>
-                <a :href="testimonial.jobUrl" target="_blank" rel="noopener sponsored" class="hidden xl:block">
+                <a :href="testimonial.jobUrl" :aria-label="`${testimonial.jobName} website`" target="_blank" rel="noopener sponsored" class="hidden xl:block">
                   <img
                     :src="`/img/home/testimonials/${testimonial.jobIcon}.svg`"
+                    :alt="`${testimonial.jobName} Logo`"
                     width="28"
                     height="28"
                     :class="{ 'light-img': testimonial.jobIconDark }"
@@ -94,6 +96,7 @@
                   <img
                     v-if="testimonial.jobIconDark"
                     :src="`/img/home/testimonials/${testimonial.jobIconDark}.svg`"
+                    :alt="`${testimonial.jobName} Logo`"
                     width="28"
                     height="28"
                     class="dark-img"
@@ -126,6 +129,7 @@ export default defineComponent({
         authorIcon: 'evan',
         authorUrl: 'https://twitter.com/youyuxi',
         job: 'Creator of Vue.js',
+        jobName: 'Vue.js',
         jobIcon: 'vue',
         jobUrl: 'https://vuejs.org'
       },
@@ -136,6 +140,7 @@ export default defineComponent({
         authorIcon: 'sarah',
         authorUrl: 'https://twitter.com/sarah_edo',
         job: 'Core Team of Vue.js',
+        jobName: 'Vue.js',
         jobIcon: 'vue',
         jobUrl: 'https://vuejs.org'
       },
@@ -146,6 +151,7 @@ export default defineComponent({
         authorIcon: 'addy',
         authorUrl: 'https://twitter.com/addyosmani',
         job: 'Chief Engineer of Chrome',
+        jobName: 'Google Chrome',
         jobIcon: 'chrome',
         jobUrl: 'https://www.google.com/chrome/'
       },
@@ -156,6 +162,7 @@ export default defineComponent({
         authorIcon: 'guillermo',
         authorUrl: 'https://twitter.com/rauchg',
         job: 'Founder of Vercel',
+        jobName: 'Vercel',
         jobIcon: 'vercel-light',
         jobIconDark: 'vercel-dark',
         jobUrl: 'https://vercel.com'
@@ -167,6 +174,7 @@ export default defineComponent({
         authorIcon: 'dominik',
         authorUrl: 'https://twitter.com/domangerer',
         job: 'Founder of Storyblok',
+        jobName: 'Storyblok',
         jobIcon: 'storyblok',
         jobUrl: 'https://www.storyblok.com'
       },
@@ -177,6 +185,7 @@ export default defineComponent({
         authorIcon: 'sadek',
         authorUrl: 'https://twitter.com/Sadache',
         job: 'Founder of Prismic',
+        jobName: 'Prismic',
         jobIcon: 'prismic',
         jobUrl: 'https://prismic.io'
       },
@@ -187,6 +196,7 @@ export default defineComponent({
         authorIcon: 'ajay',
         authorUrl: 'https://www.linkedin.com/in/ajaykapur/',
         job: 'Founder of Layer0',
+        jobName: 'Layer0',
         jobIcon: 'layer0-light',
         jobIconDark: 'layer0-dark',
         jobUrl: 'https://www.layer0.co/'
@@ -198,6 +208,7 @@ export default defineComponent({
         authorIcon: 'dave',
         authorUrl: 'https://twitter.com/paper_tokyo',
         job: 'Co-founder of Swell',
+        jobName: 'Swell',
         jobIcon: 'swell',
         jobUrl: 'https://swell.is'
       },
@@ -208,6 +219,7 @@ export default defineComponent({
         authorIcon: 'savas',
         authorUrl: 'https://www.linkedin.com/in/savas-vedova/',
         job: 'Founder of Stormkit',
+        jobName: 'Stormkit',
         jobIcon: 'stormkit',
         jobUrl: 'https://www.stormkit.io/'
       }


### PR DESCRIPTION
This adds some accessibility warnings caught from lighthouse.

I think the `docus` `AppAside` organism could use a little love too but I'm not going to talk through the whole thing here.