### PR TITLE
Nuxt app tries to restart app using pm2 start

### DIFF
--- a/content/en/guides/deployment/deployment-pm2.md
+++ b/content/en/guides/deployment/deployment-pm2.md
@@ -51,6 +51,8 @@ Check the status `pm2 ls`.
 
 Your Nuxt.js application is now serving!
 
+After `npm run build`, and then run `pm2 start` and my nuxt app is running on port then it tries to run app again and again and it throws error that app is already listening on port. While my `ecosystem.config.js` file is in fork mode.
+
 ## Further Information
 
 This solution guarantees no downtime for your application on this server. (You should also prevent server failure through redundancy or high availability cloud solutions.)


### PR DESCRIPTION
Nuxt app tries to restart app again and again by using pm2 start. As my ecosystem.config.js file mode is fork.