### PR TITLE
Add information about runtimeOption properties

### DIFF
--- a/content/en/0.docs/5.configuration-glossary/9.configuration-env.md
+++ b/content/en/0.docs/5.configuration-glossary/9.configuration-env.md
@@ -17,6 +17,14 @@ Share environment variables between client and server.
 
 The env property defines environment variables that should be available on the client side. They can be assigned using server side environment variables, the [dotenv module](https://github.com/nuxt-community/dotenv-module) ones or similar.
 
+<base-alert type="info">
+
+For nuxt versions > 2.12+, in cases where environment variables are required at runtime (not build time) it is recommended to subsitute the `env` property with [runtimeConfig properties](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-runtime-config#publicruntimeconfig) `publicRuntimeOptions` and `privateRuntimeOptions`. 
+
+See also: Blogpost, _Moving from @nuxtjs/dotenv to runtime config_  (https://nuxtjs.org/blog/moving-from-nuxtjs-dotenv-to-runtime-config)
+
+</base-alert>
+
 **Make sure to read about `process.env` and `process.env == {}` below for better troubleshooting.**
 
 ```js{}[nuxt.config.js]


### PR DESCRIPTION
People browsing the docs about the `env` property should be informed about the officially recommended alternative runtimeOption properties.

See: https://github.com/nuxt/nuxtjs.org/pull/1537#issuecomment-880555715