### PR TITLE
docs: personal token not required for github pages deployment

### DIFF
--- a/content/en/0.docs/8.deployment/10.github-pages.md
+++ b/content/en/0.docs/8.deployment/10.github-pages.md
@@ -84,8 +84,6 @@ npm run deploy
 
 You can take deployment one step further and rather than having to manually compile and deploy the files from your local install, you can make use of a build server to monitor your GitHub repository for new commits and then checkout, compile and deploy everything for you automatically.
 
-Before you configure the build server, you'll first need to [generate a GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/#creating-a-token) in order to grant the build server permission to perform tasks on your behalf. Once you have created your token, keep a copy of it safe ready to use a little later on.
-
 ### GitHub Actions
 
 To deploy via [GitHub Actions](https://github.com/features/actions), the official tool for software automation with GitHub, if you don't have a workflow you need to create a new one or append a new step to your existing workflow.


### PR DESCRIPTION
Personal access token is not necesary.

https://github.com/marketplace/actions/github-pages-action#:~:text=For%20newbies%20of%20GitHub%20Actions%3A%20Note%20that%20the%20GITHUB_TOKEN%20is%20NOT%20a%20personal%20access%20token.%20A%20GitHub%20Actions%20runner%20automatically%20creates%20a%20GITHUB_TOKEN%20secret%20to%20authenticate%20in%20your%20workflow.%20So%2C%20you%20can%20start%20to%20deploy%20immediately%20without%20any%20configuration.