### PR TITLE
Update Stormkit documentation

### DIFF
--- a/content/en/guides/deployment/deployment-stormkitio.md
+++ b/content/en/guides/deployment/deployment-stormkitio.md
@@ -7,8 +7,7 @@ category: deployment
 position: 118
 ---
 
-
-Easily build, deploy and scale your Nuxt apps with Stormkit. Stormkit has a built-in support for Nuxt to deploy apps in just a few clicks and seconds. Just toggle Serverless or Static mode with a switch under your Environment configuration. We'll understand your <code>publish</code> folder directly from the framework configuration file.
+Easily build, deploy and scale your Nuxt applications with [Stormkit.io](https://www.stormkit.io). It supports instant rollbacks, serverless-side logic, snippet injections, multiple development environments and more...
 
 ## Prerequisites
 
@@ -19,16 +18,36 @@ This guide assumes you already have a Nuxt project to deploy. If you need a proj
 1. Go to [app.stormkit.io](https://app.stormkit.io) and log in by selecting your git provider.
 2. Once logged in, Stormkit will ask you in which provider your codebase is located. Click on the provider once more.
 3. If Github, click on ‘Connect more repositories’ and grant Stormkit access to it.
-5. Next, select your repository. 
+4. Next, select your repository. This will create the application on Stormkit.
+5. On your application's page, find the **Production** environment and click on that.
+6. Click on edit to configure your application. You will provide the build command and the
+   environment variables in this screen.
 
-Now, it's connected. You’ll be presented with a page where you see the production environment:
+## Static websites
 
-5. Click on <code>Details</code> under the production environment. You’ll be brought to a page where you can deploy your application. 
-6. Click on <code>Deploy now</code> button on top right of the screen. 
-7. Voilà! Your app is being deployed.
+You don't have to do anything for static websites. Applications built with `nuxt generate` will be handled out of the box.
 
-Once you have deployed your application, Stormkit will generate a URL for you. Preview your application using that link. Later, you can connect your domain and publish this deployment so that the users will start to see that version of your application. You can also do staged-rollouts or A/B testing by publishing multiple versions at the same time. You can always cancel the deployment or rollback to an earlier version, whenever you like.
+## Single page applications
 
-## Further instructions
-For more insctructions, including screen shots, check out [Stormkit documentation](https://www.stormkit.io/docs/deployments/configuration).
-For instructions for single page applications or hybrid applications check out these [methods](https://www.stormkit.io/docs/deployments/configuration/nuxt).
+For single page applications, all you have to do is to provide a `stormkit.config.yml` which redirects
+all requests to `index.html`. To do so, create a `stormkit.config.yml` file on the top level of your project and specify the following rule:
+
+```
+app:
+- redirects:
+    - from: /*
+      to: /index.html
+      assets: false
+```
+
+## Hybrid applications
+
+For hybrid applications, you'll have to turn on the `Serverless` toggle on the build configuration page. This will tell Stormkit to serve the requests from the lambdas instead of the CDN. You can find more on [this guide](https://www.stormkit.io/docs/deployments/configuration/nuxt#hybrid) to configure your hybrid serverless applications.
+
+## Hosting using Stormkit
+
+Stormkit generates a unique URL for each deployment. You can preview your application using these links. Later, you can connect your domain and publish any deployment so that the users will start to see that version of your application. You can also do staged-rollouts or A/B testing by publishing multiple versions at the same time.
+
+## Support
+
+If you need additional support, you can chat with Stormkit developers and other community members on [Discord](https://discord.gg/6yQWhyY).


### PR DESCRIPTION
This PR updates the Stormkit documentation page by giving more details:

1. It specifies the required steps for SPAs and hybrid applications.
2. It indicates the support channel
3. Updates the steps to setup the application