### PR TITLE
docs: add definitions for acronyms + technical terms

### DIFF
--- a/content/en/docs/2.concepts/2.context-helpers.md
+++ b/content/en/docs/2.concepts/2.context-helpers.md
@@ -15,7 +15,7 @@ The context provides *additional* and often optional information about the curre
 
 The `context` object is available in specific Nuxt functions like [asyncData](/docs/features/data-fetching#async-data), [plugins](/docs/directory-structure/plugins), [middleware](/docs/directory-structure/middleware) and [nuxtServerInit](/docs/directory-structure/store#the-nuxtserverinit-action). It provides _additional_ and often optional information about the current request to the application.
 
-First and foremost, the context is used to provide access to other parts of the Nuxt application, e.g. the Vuex store or the underlying `connect` instance. Thus, we have the `req` and `res` objects in the context available on the server side and `store` always available. But with time, the context was extended with many other helpful variables and shortcuts. Now we have access to HMR functionalities in `development` mode, the current `route`, page `params` and `query`, as well as the option to access environment variables through the context. Furthermore, module functions and helpers can be exposed through the context to be available on both - the client and the server side.
+First and foremost, the context is used to provide access to other parts of the Nuxt application, e.g. the Vuex store or the underlying `connect` instance. Thus, we have the `req` and `res` objects in the context available on the server side and `store` always available. But with time, the context was extended with many other helpful variables and shortcuts. Now we have access to HMR (Hot Module Reload / Replacement) functionalities in `development` mode, the current `route`, page `params` and `query`, as well as the option to access environment variables through the context. Furthermore, module functions and helpers can be exposed through the context to be available on both - the client and the server side.
 
 **All context keys that are present by default**
 
@@ -49,7 +49,7 @@ function (context) { // Could be asyncData, nuxtServerInit, ...
 ```
 
 ::alert{type="warning"}
-The _context_ we refer to here is not to be confused with the `context` object available in [Vuex Actions](https://vuex.vuejs.org/guide/actions.html) or the one available in the `build.extend` function in your `nuxt.config.js`. These are all not related to each other!
+The _context_ we refer to here is not to be confused with the `context` object available in [Vuex Actions](https://vuex.vuejs.org/guide/actions.html) or the one available in the `build.extend` function in your `nuxt.config.js`. These are not related to each other!
 ::
 
 Learn more about the different context keys in our [Internals Glossary](/docs/internals-glossary/context)
@@ -95,11 +95,11 @@ export default {
 }
 ```
 
-Want to use query parameters instead? You then use [context.query.id](/docs/internals-glossary/context#query) then.
+Want to use query parameters instead? You then use [context.query.id](/docs/internals-glossary/context#query).
 
 ### Redirecting users & accessing the store
 
-Accessing the Vuex store (when you have it set up through the `store` directory) is also possible through the context. It provides a `store` object which can be treated as `this.$store` in Vue components. In addition, we use the `redirect` method, an exposed helper through the context, to redirect the user in case the `authenticated` state is falsy.
+Accessing the [Vuex store](/docs/directory-structure/store) (when you have it set up through the `store` directory) is also possible through the context. It provides a `store` object which can be treated as `this.$store` in Vue components. In addition, we use the `redirect` method, an exposed helper through the context, to redirect the user in case the `authenticated` state is [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy).
 
 ```js
 export default {
@@ -140,7 +140,7 @@ The `$nuxt` helper provides a quick way to find out whether the internet connect
 
 ### Accessing the root instance
 
-Besides providing DX/UX features, the `$nuxt` helper also provides a shortcut to the root instance of your application from every other component. But that's not everything — you can also access the `$nuxt` helper through `window.$nuxt` which can be used as an escape hatch to gain access to module methods like `$axios` from outside your Vue components. This should be used wisely and **only as last resort**.
+Besides providing DX/UX (Developer Experience / User Experience) features, the `$nuxt` helper also provides a shortcut to the root instance of your application from every other component. But that's not everything — you can also access the `$nuxt` helper through `window.$nuxt` which can be used as an escape hatch to gain access to module methods like `$axios` from outside your Vue components. This should be used wisely and **only as last resort**.
 
 ### Refreshing page data
 


### PR DESCRIPTION
This PR attempts to fix things that caught my attention while reading this fine article, namely:
- Explains what HMR is. 
- Removes some redundant words. 
- Cross-references the store directory when referencing Vuex.
- Links out to the MDN glossary definition of Falsy.
- Explains what DX/UX is.

It'd be great to have a acronym/definition type component that one could use, e.g. 

```html
<acronym def="Hot Module Reload / Replacement">HMR</acronym>
```

styled e.g. as

```css
display: inline-block;
border-bottom: dashed 1px silver;
cursor: help;
```