### PR TITLE
docs: change example to `head` object and remove resource hints

### DIFF
--- a/content/en/docs/3.features/5.meta-tags-seo.md
+++ b/content/en/docs/3.features/5.meta-tags-seo.md
@@ -47,7 +47,7 @@ This will give you the same title and description on every page
 
 ### Local Settings
 
-You can also add titles and meta for each page using the `head` method inside your script tag on every page.
+You can also add titles and meta for each page by setting the `head` property inside your script tag on every page:
 
 ```js{}[pages/index.vue]
 <script>
@@ -173,13 +173,3 @@ export default {
   }
 </style>
 ```
-
-## Resource Hints
-
-Adds prefetch and preload links for faster initial page load time.
-
-You may want to only disable this option if you have many pages and routes.
-
-::alert{type="next"}
-[Resource Hints](/docs/configuration-glossary/configuration-render#resourcehints)
-::


### PR DESCRIPTION
This PR attempts to clarify the difference between setting the `head` to an object vs. as a function. It also removes _Resource Hints_ as they belong to the render configuration, not metadata and SEO https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-render#resourcehints