### PR TITLE
Update deployment-cloud-run.md

### DIFF
--- a/content/en/guides/deployment/deployment-cloud-run.md
+++ b/content/en/guides/deployment/deployment-cloud-run.md
@@ -105,13 +105,13 @@ Run the following command to start the build process:
 
 Run the following command to deploy your application:
 
-`gcloud run deploy --image=gcr.io/<YOUR_GOOGLE_CLOUD_PROJECT_ID>/my-nuxt-app-name:1.0.0 --platform managed --port 3000`
+`gcloud run deploy --image=gcr.io/<YOUR_GOOGLE_CLOUD_PROJECT_ID>/my-nuxt-app-name:1.0.0 --platform managed --port 8080`
 
 Allow unauthenticated invocations if you want to set up a public access.
 
 Be aware that Cloud Run applications will have a default concurrency value of 80 (each container instance will handle up to 80 requests at a time). You can specify the concurrency value this way:
 
-`gcloud run deploy --image=gcr.io/<YOUR_GOOGLE_CLOUD_PROJECT_ID>/my-nuxt-app-name:1.0.0 --platform managed --port 3000 --concurrency <YOUR_CONCURRENCY_VALUE>`
+`gcloud run deploy --image=gcr.io/<YOUR_GOOGLE_CLOUD_PROJECT_ID>/my-nuxt-app-name:1.0.0 --platform managed --port 8080 --concurrency <YOUR_CONCURRENCY_VALUE>`
 
 Run the following command to check if the deployment was created successfully:
 


### PR DESCRIPTION
If we set the PORT as environment variable to 8080 in Docker container, then it would be more appropriate to use port 8080 in the "Deploying your application" section as well (in my opinion) - i hope this contribution makes sense, peace!