### PR TITLE
docs: correct name of component interacting with router-middleware

### DIFF
--- a/content/en/examples/middleware-router.md
+++ b/content/en/examples/middleware-router.md
@@ -12,7 +12,7 @@ csb_link: https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/midd
 
 `middleware/class.js` uses router middleware to set a class before we enter the route.
 
-`components/Navigation.vue` changes the font size for the route with the name of `router-middleware`.
+`layouts/default.vue` changes the font size for the route with the name of `router-middleware`.
 
 `nuxt.config.js` contains the `router` property to activate the middleware.
 

--- a/content/es/examples/middleware-router.md
+++ b/content/es/examples/middleware-router.md
@@ -12,7 +12,7 @@ csb_link: https://codesandbox.io/embed/github/nuxt-academy/examples/tree/master/
 
 `middleware/class.js` utiliza router middleware para establecer una clase antes de acceder a la ruta.
 
-`components/Navigation.vue` cambia el tamaño de la fuente para la ruta con nombre `router-middleware`.
+`layouts/default.vue` cambia el tamaño de la fuente para la ruta con nombre `router-middleware`.
 
 `nuxt.config.js` contiene la propiedad `router` para activar el middleware.
 

--- a/content/ja/examples/middleware-router.md
+++ b/content/ja/examples/middleware-router.md
@@ -12,7 +12,7 @@ csb_link: https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/midd
 
 `middleware/class.js` uses router middleware to set a class before we enter the route.
 
-`components/Navigation.vue` changes the font size for the route with the name of `router-middleware`.
+`layouts/default.vue` changes the font size for the route with the name of `router-middleware`.
 
 `nuxt.config.js` contains the `router` property to activate the middleware.
 

--- a/content/zh/examples/middleware-router.md
+++ b/content/zh/examples/middleware-router.md
@@ -14,7 +14,7 @@ csb_link: https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/midd
 
 `middleware/class.js` 使用路由中间件在进入路由之前修改路由名(route.name)。
 
-`components/Navigation.vue` 使用`router-middleware`的路由名来更改当前路由的字体大小。
+`layouts/default.vue` 使用`router-middleware`的路由名来更改当前路由的字体大小。
 
 `nuxt.config.js` 包含`router`属性用以激活(使用)中间件。
 


### PR DESCRIPTION
Just a minor thing I noticed. The example code does not have a `components/Navigation.vue` file, and instead, the `layouts/default.vue` file is what is using the value of the class from the store.