### PR TITLE
docs: add note on modules using plugins

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-modules.md
+++ b/content/en/guides/configuration-glossary/configuration-modules.md
@@ -34,6 +34,10 @@ Module developers usually provide additionally needed steps and details for usag
 
 Nuxt.js tries to resolve each item in the modules array using node require path (in the `node_modules`) and then will be resolved from project `srcDir` if `~` alias is used. Modules are executed sequentially so the order is important.
 
+**Note:** Any plugins injected by modules are added to the *beginning* of the plugins list. Your options are to:
+- Manually add your plugin to the end of the list of plugins (`this.nuxt.options.plugins.push(...`)
+- Reverse the order of the modules if it depends on another
+
 Modules should export a function to enhance nuxt build/runtime and optionally return a promise until their job is finished. Note that they are required at runtime so should be already transpiled if depending on modern ES6 features.
 
 Please see [Modules Guide](/docs/2.x/directory-structure/modules) for more detailed information on how they work or if interested developing your own module. Also we have provided an official [Modules](https://github.com/nuxt-community/awesome-nuxt#modules) Section listing dozens of production ready modules made by Nuxt Community.


### PR DESCRIPTION
Nuxt.js behavior is different when resolving modules vs modules with plugins. A note for clarification might be helpful. 

Wondering if the [modules directory page](https://nuxtjs.org/docs/2.x/directory-structure/modules) can be updated too?