### PR TITLE
rename title 'modules directory' to 'modules'

### DIFF
--- a/content/en/guides/directory-structure/modules.md
+++ b/content/en/guides/directory-structure/modules.md
@@ -1,5 +1,5 @@
 ---
-title: Modules directory
+title: Modules
 menuTitle: modules
 description: Nuxt.js provides a higher-order module system that makes it possible to extend the core. Modules are functions that are called sequentially when booting Nuxt.js.
 position: 9


### PR DESCRIPTION
The title of the page 'modules directory' gives the impression its a page about listing existing modules. In fact, it has really important info about creating your own modules.