### PR TITLE
fix markdown typo

### DIFF
--- a/content/en/guides/configuration-glossary/configuration-build.md
+++ b/content/en/guides/configuration-glossary/configuration-build.md
@@ -639,7 +639,7 @@ This option is automatically set based on `mode` value if not provided.
 
 This mode bundles `node_modules` that are normally preserved as externals in the server build ([more information](https://github.com/nuxt/nuxt.js/pull/4661)).
 
-<base-alert type="warning">\*_Warning_: Runtime dependencies (modules, `nuxt.config`, server middleware and static directory) are not bundled. This feature only disables use of [webpack-externals](https://webpack.js.org/configuration/externals/) for server-bundle.</base-alert>
+<base-alert type="warning">**Warning:** Runtime dependencies (modules, `nuxt.config`, server middleware and static directory) are not bundled. This feature only disables use of [webpack-externals](https://webpack.js.org/configuration/externals/) for server-bundle.</base-alert>
 
 <base-alert type="info">**Info:** you can use the command `yarn nuxt build --standalone` to enable this mode on the command line. (If you are not using `yarn` you can run the command with `npx`.)</base-alert>
 


### PR DESCRIPTION
`\*_Warning_:` -> `**Warning:**`
<img width="688" alt="スクリーンショット 2021-08-21 15 58 09" src="https://user-images.githubusercontent.com/65712721/130313841-ee165111-d6bc-4eb0-b089-7c6c11a7aa2a.png">
<img width="687" alt="スクリーンショット 2021-08-21 15 58 56" src="https://user-images.githubusercontent.com/65712721/130313842-d0902673-00a1-4046-aefd-6a3e4aff0583.png">
