### PR TITLE
chore(examples): add missing key to v-for for data-fetching

### DIFF
--- a/content/en/guides/features/data-fetching.md
+++ b/content/en/guides/features/data-fetching.md
@@ -118,7 +118,7 @@ In addition to fetch being called by Nuxt, you can manually call fetch in your c
   <div v-else>
     <h1>Nuxt Mountains</h1>
     <ul>
-      <li v-for="mountain of mountains">{{ mountain.title }}</li>
+      <li v-for="(mountain, index) of mountains" v-bind:key="index">{{ mountain.title }}</li>
     </ul>
     <button @click="$fetch">Refresh</button>
   </div>

--- a/content/en/guides/features/data-fetching.md
+++ b/content/en/guides/features/data-fetching.md
@@ -118,7 +118,7 @@ In addition to fetch being called by Nuxt, you can manually call fetch in your c
   <div v-else>
     <h1>Nuxt Mountains</h1>
     <ul>
-      <li v-for="(mountain, index) of mountains" v-bind:key="index">{{ mountain.title }}</li>
+      <li v-for="mountain of mountains" :key="mountain.slug">{{ mountain.title }}</li>
     </ul>
     <button @click="$fetch">Refresh</button>
   </div>


### PR DESCRIPTION
This PR adds a simple index as a key to the v-for elements. Without a key, the example errors.