### PR TITLE
docs: remove duplicate sponsor referrals

### DIFF
--- a/content/sponsors.js
+++ b/content/sponsors.js
@@ -40,19 +40,19 @@ export default {
     },
     {
       name: 'Layer0',
-      url: 'https://www.layer0.co/?ref=nuxt',
+      url: 'https://www.layer0.co/',
       img: 'layer0-logo.svg',
       class: 'h-12'
     },
     {
       name: 'Storyblok',
-      url: 'https://www.storyblok.com/?ref=nuxt',
+      url: 'https://www.storyblok.com/',
       img: 'storyblok-logo.svg',
       class: 'h-10'
     },
     {
       name: '64 Robots',
-      url: 'https://www.64robots.com/?ref=nuxt',
+      url: 'https://www.64robots.com/',
       img: '64-robots.png',
       class: 'h-12'
     }


### PR DESCRIPTION
the Nuxt referral string is automatically appended to the links by the HomeSponsors component:

> https://github.com/nuxt/nuxtjs.org/blob/5f5588072409608c5ee487da1f5a9024fd277cd6/components/templates/home/Sponsors.vue#L37

so having these in the source URLs causes the result to look like `?ref=nuxt?ref=nuxt`:

> ![](https://i.imgur.com/Z8gkdVj.png)