### PR TITLE
docs(ja): update 1.fetch.md

### DIFF
--- a/content/ja/docs/7.components-glossary/1.fetch.md
+++ b/content/ja/docs/7.components-glossary/1.fetch.md
@@ -46,7 +46,7 @@ fetch フック内では `this.$nuxt.context` を使用して、Nuxt [context](/
 
 - `fetchOnServer`: `Boolean` または `Function`（デフォルト: `true`）。サーバーがページをレンダリングする際に `fetch()` を呼び出します。
 - `fetchKey`: `String` または `Function`（デフォルトはコンポーネントスコープ ID またはコンポート名）でこのコンポーネントの取得結果を識別するキー（または一意のキーを生成する関数）です（Nuxt v2.15 以上で利用可能）。[詳細は PR を参照してください](https://github.com/nuxt/nuxt.js/pull/8466)。
-- `fetchDelay`: `Integer`（デフォルト: `200`）。最小実行時間をミリ秒単位で設定します（過剰実行を防ぐため）。
+- `fetchDelay`: `Integer`（デフォルト: `200`）。最小実行時間をミリ秒単位で設定します（極短期間での画面切り替えによるちらつきを防ぐため）。
 
 `fetchOnServer` が偽の値をとり得る場合(`false` または、`false` になりえる値を返す)、`fetch` はクライアントサイドでのみ呼び出され、サーバーでコンポーネントをレンダリングする際には `$fetchState.pending` は `true` を返します。
 


### PR DESCRIPTION
Currently, the purpose of `fetchDelay` is explained as "過剰実行を防ぐため", which means "to avoid excessive execution".
I think this is not correct.

I propose changing the phrase to "極短期間での画面切り替えによるちらつきを防ぐため", which is google translated as:
"To prevent flicker due to screen switching in a very short period of time"

(Note: the original phrase was: "to avoid quick flashes", which I could not come up with concise phrase, so a bit descriptive)