### PR TITLE
docs: Explain component directory better

### DIFF
--- a/content/en/docs/4.directory-structure/3.components.md
+++ b/content/en/docs/4.directory-structure/3.components.md
@@ -125,40 +125,35 @@ If you have components in nested directories such as:
 components/
   base/
       foo/
-         Button.vue
+         CustomButton.vue
 ```
 
 The component name will be based on its own path directory and filename. Therefore, the component will be:
 
 ```html
-<BaseFooButton />
+<BaseFooCustomButton />
 ```
 
-However, if we want to keep `Button.vue`, we can use the `prefix` option in the `nuxt.config.js` configuration file to add a prefix to all components in a given directory:
-
-```bash
-components/
-  base/
-      foo/
-         Button.vue
-```
+If we want to use it as `<CustomButton />` while keeping the directory structure, we can add the directory of `CustomButton.vue` into `nuxt.config.js`.
 
 ```bash{}[nuxt.config.js]
 components: {
   dirs: [
     '~/components',
-    '~/components/base'
+    '~/components/base/foo'
   ]
 }
 ```
 
-Thus, we can use `BaseButton` in the template instead of `Button` without having to change the name of the `Button.vue` file.
-
-And now in your template you can use `FooButton` instead of `BaseFooButton`.
+And now we can use `<CustomButton />` instead of `<BaseFooCustomButton />`.
 
 ```html{}[pages/index.vue]
-<FooButton />
+<CustomButton />
 ```
+
+::alert{type="next"}
+See [the components property](/docs/configuration-glossary/configuration-components) for other methods of controlling component name.
+::
 
 ::alert{type="info"}
 Learn more about the [components module](/tutorials/improve-your-developer-experience-with-nuxt-components).


### PR DESCRIPTION
> However, if we want to keep `Button.vue`, we can use the `prefix` option in the `nuxt.config.js` configuration file to add a prefix to all components in a given directory:

I think this sentence is quite unclear. First, what does it mean by "keep `Button.vue`"? I'm guessing it means "keep using `<Button />`". Second, it mentioned "use the `prefix` option", but it did not provide any `prefix` option in the example below.

> Thus, we can use `BaseButton` in the template instead of `Button` without having to change the name of the `Button.vue` file.

This sentence is quite unclear too. First, why can we "use `BaseButton`"? According to the example code given, we should not be able to use `<BaseButton />`. We can only use `<FooButton />`. Second, why "we can use `BaseButton` instead of `Button`"? I thought that what we want is `<Button />`?

I have reworded these few sentences assuming that we want to use the directory structure

```
components/
    base/
        foo/
            CustomButton.vue
```

while using `<CustomButton />` in our template.

I've changed `<Button />` to `<CustomButton />` because, according to Vue Style Guide, we should use multi-word component names.

I've added a link pointing to The Components Property section for other methods of controlling the component name.