### PR TITLE
refactor: release on datetime with named formatting

### DIFF
--- a/components/templates/Releases.vue
+++ b/components/templates/Releases.vue
@@ -20,14 +20,7 @@
               {{ $t('releases.version') }} <span class="font-bold">{{ release.name }}</span>
             </h2>
             <p class="text-xs font-semibold uppercase text-tw-gray-400">
-              {{ $t('releases.released_on') }}
-              {{
-                new Date(release.date).toLocaleDateString($i18n.locale, {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric'
-                })
-              }}
+              {{ $t('releases.released_on', { datetime: formatDateByLocale($i18n.locale, release.date) }) }}
             </p>
           </div>
 
@@ -58,8 +51,15 @@ export default defineComponent({
       releases.value = document.body?.releases
     })
 
+    const formatDateByLocale = (locale, d) => {
+      const currentLocale = locale || 'en-US'
+      const options = { year: 'numeric', month: 'long', day: 'numeric' }
+      return new Date(d).toLocaleDateString(currentLocale, options)
+    }
+
     return {
-      releases
+      releases,
+      formatDateByLocale
     }
   }
 })

--- a/i18n/en-US.js
+++ b/i18n/en-US.js
@@ -115,7 +115,7 @@ export default {
   },
   releases: {
     version: 'Version',
-    released_on: 'Released on'
+    released_on: 'Released on {datetime}'
   },
   partners: {
     become_partner: 'Become a partner'

--- a/i18n/fr-FR.js
+++ b/i18n/fr-FR.js
@@ -116,7 +116,7 @@ export default {
   },
   releases: {
     version: 'Version',
-    released_on: 'Sortie le'
+    released_on: 'Sortie le {datetime}'
   },
   partners: {
     become_partner: 'Devenez partenaire'

--- a/i18n/ja-JP.js
+++ b/i18n/ja-JP.js
@@ -113,6 +113,10 @@ export default {
       Business: 'ビジネス'
     }
   },
+  releases: {
+    version: 'バージョン',
+    released_on: 'リリース日 {datetime}'
+  },
   partners: {
     become_partner: 'パートナーになる'
   },


### PR DESCRIPTION
Using named formatting is much easier to maintain.
https://kazupon.github.io/vue-i18n/guide/formatting.html#named-formatting

The message of an i18n resource can understand context-sensitive by using parameters.
From a localization point of view, you can also benefit from named formatting.