### PR TITLE
docs: Include Page.key option in documentation

### DIFF
--- a/content/en/docs/4.directory-structure/9.pages.md
+++ b/content/en/docs/4.directory-structure/9.pages.md
@@ -243,6 +243,18 @@ export default {
 See more on the watch query property in our [Data Fetching](/docs/features/data-fetching) chapter
 ::
 
+### key
+
+Same as the `key` property that can be used on Vue components in templates as a hint for the virtual DOM, this property allows the key value to be defined from the page itself (rather than the parent component).
+
+By default in Nuxt, this value will be the `$route.path`, meaning that navigating to a different route will ensure a clean page component is created. Logically equivalent to:
+
+```html
+<router-view :key="$route.path" />
+```
+
+The property can be a `String` or a `Function` which takes the route as the first argument.
+
 ## Ignoring pages
 
 If you want to ignore pages so that they are not included in the generated `router.js` file then you can ignore them by prefixing them with a `-`.


### PR DESCRIPTION
I stumbled across this option reading the code, I think it would be very worthwhile to document it.

It would also explain why route navigation in Nuxt will destroy/recreate page components even if the same component is used in two routes. I'm not debating the behaviour at all, I agree with it, but as it doesn't match the norm for a Vue project, no harm having something in the documentation which explains it.