### PR TITLE
feat(Showcases): improve UX

### DIFF
--- a/components/organisms/asides/AsideShowcases.vue
+++ b/components/organisms/asides/AsideShowcases.vue
@@ -17,7 +17,7 @@
         "
       >
         <div class="py-4 pr-0">
-          <ul class="flex flex-wrap lg:flex-col">
+          <ul class="flex lg:flex-col">
             <li v-for="option in options" :key="option.name">
               <button
                 class="py-2 px-4 flex justify-between w-full focus:outline-none focus:ring-transparent"

--- a/components/organisms/heroes/PageHero.vue
+++ b/components/organisms/heroes/PageHero.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative pt-24 pb-32 bg-gray-100 dark:bg-secondary-darkest">
+  <div class="relative pt-16 sm:pt-24 pb-32 bg-gray-100 dark:bg-secondary-darkest">
     <div class="relative d-container-content">
       <h1
         class="

--- a/components/organisms/lists/ShowcasesListing.vue
+++ b/components/organisms/lists/ShowcasesListing.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-container-content mt-8">
+  <div ref="showcases-container" class="d-container-content mt-8">
     <div v-if="categories && categories.length" class="lg:flex gap-8">
       <AsideShowcases
         :options="categories"
@@ -72,10 +72,18 @@ export default {
     },
     categories() {
       return (
-        this.showcases?.groups?.map(group => ({
-          name: group.name,
-          display: this.$t(`showcases.categories.${group.name}`)
-        })) || []
+        this.showcases?.groups?.map(group => {
+          const key = `showcases.categories.${group.name}`
+          let display = this.$t(`showcases.categories.${group.name}`)
+          // fallback on `group.name` if translation unavailable
+          if (display === key) {
+            display = group.name
+          }
+          return {
+            name: group.name,
+            display
+          }
+        }) || []
       )
     }
   },
@@ -104,6 +112,11 @@ export default {
       } else {
         this.selectedCategory = category.name
       }
+
+      // scroll to top of the list, handling header height
+      const yOffset = 72
+      const y = this.$refs['showcases-container'].getBoundingClientRect().top + window.pageYOffset - yOffset
+      window.scrollTo({ top: y, behavior: 'smooth' })
     }
   }
 }

--- a/content/en/showcases/index.md
+++ b/content/en/showcases/index.md
@@ -11,7 +11,7 @@ layout:
 Showcases
 
 #description
-  Discover our selection of websites built with Nuxt. This collection is powered by VueTelescope. Visit [vuetelescope.com](https://vuetelescope.com) and try out the browser extension.
+  Discover our selection of websites built with Nuxt. This collection is powered by VueTelescope. Visit [VueTelescope](https://vuetelescope.com) and try out the browser extension.
 
 #bottom
   :showcases-bottom-hero

--- a/content/fr/showcases/index.md
+++ b/content/fr/showcases/index.md
@@ -11,7 +11,7 @@ layout:
 Showcases
 
 #description
-Découvrez notre sélection de site fait avec Nuxt. Cette collection est propulsée par VueTelescope. Visitez [vuetelescope.com](https://vuetelescope.com) et essayez l'extension pour Chrome et Firefox.
+Découvrez notre sélection de site fait avec Nuxt. Cette collection est propulsée par VueTelescope. Visitez [VueTelescope](https://vuetelescope.com) et essayez l'extension pour Chrome et Firefox.
 
 #bottom
   :showcases-bottom-hero

--- a/content/ja/showcases/index.md
+++ b/content/ja/showcases/index.md
@@ -11,7 +11,7 @@ layout:
 導入事例
 
 #description
-  Nuxt で構築されたウェブサイトのセレクションをご覧ください。このコレクションは、VueTelescope によって提供されています。[vuetelescope.com](https://vuetelescope.com) にアクセスして、ブラウザ拡張をお試しください。
+  Nuxt で構築されたウェブサイトのセレクションをご覧ください。このコレクションは、VueTelescope によって提供されています。[VueTelescope](https://vuetelescope.com) にアクセスして、ブラウザ拡張をお試しください。
 
 #bottom
   :showcases-bottom-hero


### PR DESCRIPTION
Resolves #1783 

- Reduce `PageHero` top spacing on `xs` screens
- Rename VueTelescope link
- Categories are now horizontally scrollable
- Selecting a new category scrolls to the top of the list
- If a category translation is missing, fallback to the original category name

@Atinux I couldn't simply hide the browser extensions on mobile devices. I think this requires a refactor of the `PageHero`, to make the `bottom` slot hidable on `xs` (which is used on the homepage and other pages) or make a new slot "optional" on `xs`.