### PR TITLE
docs: typo fix (`as` -> `and`)

### DIFF
--- a/content/en/integrations/deployments/nginx.md
+++ b/content/en/integrations/deployments/nginx.md
@@ -52,7 +52,7 @@ Below is an example configuration. Keep in mind that:
 
 - root folder should be the same as set by [configuration generate.dir](/docs/configuration-glossary/configuration-generate#dir)
 - expire headers set by Nuxt are stripped (due to the cache)
-- both Nuxt as nginx can set additional headers, it's advised to choose one (if in doubt, choose nginx)
+- both Nuxt and nginx can set additional headers, it's advised to choose one (if in doubt, choose nginx)
 - if your site is mostly static, increase the `proxy_cache_path inactive` and `proxy_cache_valid` numbers
 
 If you don't generate your routes but still wish to benefit from nginx cache:


### PR DESCRIPTION
Typo fixes.