### PR TITLE
fix(content): fix EN doc + update localised doc

### DIFF
--- a/content/en/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/en/docs/5.configuration-glossary/5.configuration-css.md
@@ -20,6 +20,7 @@ yarn add --dev sass sass-loader@10 fibers
 ```sh [NPM]
 npm install --save-dev sass sass-loader@10 fibers
 ```
+::
 
 ::alert{type="info"}
 Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.

--- a/content/fr/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/fr/docs/5.configuration-glossary/5.configuration-css.md
@@ -11,11 +11,16 @@ Nuxt permet aux fichiers/modules/librairies que l'on veut d'être définis de ma
 
 ---
 
-Si on veut utiliser `SASS`, il faut bien faire attention à avoir les packages `node-sass` et `sass-loader` d'installés. Si ce n'est pas encore le cas, on peut faire:
+Si on veut utiliser `SASS`, il faut bien faire attention à avoir les packages `sass` et `sass-loader` d'installés. Si ce n'est pas encore le cas, on peut faire:
 
-```sh
-npm install --save-dev node-sass sass-loader
+::code-group
+```sh [Yarn]
+yarn add --dev sass sass-loader@10 fibers
 ```
+```sh [NPM]
+npm install --save-dev sass sass-loader@10 fibers
+```
+::
 
 ::alert{type="info"}
 Compilation synchrone avec `sass` (augmentation de la vitesse 2x) [est activée automatiquement] (https://github.com/webpack-contrib/sass-loader) lorsque `fibers` est installé.

--- a/content/ja/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/ja/docs/5.configuration-glossary/5.configuration-css.md
@@ -13,9 +13,14 @@ Nuxt ではグローバルに適用したい（すべてのページにインク
 
 `sass` を利用したい場合は `sass` および `sass-loader` パッケージをインストールしてください。もしインストールしていない場合は以下のようにインストールしてください。
 
-```sh
+::code-group
+```sh [Yarn]
+yarn add --dev sass sass-loader@10 fibers
+```
+```sh [NPM]
 npm install --save-dev sass sass-loader@10 fibers
 ```
+::
 
 ::alert{type="info"}
 `fibers` がインストールされている場合、 `sass` の同期コンパイル（2 倍速）が [自動的に有効になります](https://github.com/webpack-contrib/sass-loader)。

--- a/content/pt/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/pt/docs/5.configuration-glossary/5.configuration-css.md
@@ -13,9 +13,14 @@ Nuxt lets you define the CSS files/modules/libraries you want to set globally (i
 
 In case you want to use `sass` make sure that you have installed `sass` and `sass-loader` packages. If you didn't just
 
-```sh
+::code-group
+```sh [Yarn]
+yarn add --dev sass sass-loader@10 fibers
+```
+```sh [NPM]
 npm install --save-dev sass sass-loader@10 fibers
 ```
+::
 
 ::alert{type="info"}
 Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.


### PR DESCRIPTION
Fixes EN content typo (missing `::`)
And updates other languages (sorry about FR diff, actually almost nothing changed)