### PR TITLE
Fix Japanese translation

### DIFF
--- a/content/ja/docs/1.get-started/2.routing.md
+++ b/content/ja/docs/1.get-started/2.routing.md
@@ -29,7 +29,7 @@ src: https://www.youtube.com/watch?v=cKutrcn-hdE
 
 ## ナビゲーション
 
-アプリケーションのページ間を遷移するには、[NuxtLink](/docs/features/nuxt-components#the-nuxtlink-component) コンポーネントを使用する必要があります。このコンポーネントは Nuxt に含まれているため、他のコンポーネントのようにインポートする必要はありません。HTML の `<a>` タグに似ていますが、`href="/about"` の代わりに `to="/about"` を使用します。もし以前に `vue-router` を使ったことがある場合は、`<NuxtLink>` を `<NuxtLink>` の代わりと考えることができます。
+アプリケーションのページ間を遷移するには、[NuxtLink](/docs/features/nuxt-components#the-nuxtlink-component) コンポーネントを使用する必要があります。このコンポーネントは Nuxt に含まれているため、他のコンポーネントのようにインポートする必要はありません。HTML の `<a>` タグに似ていますが、`href="/about"` の代わりに `to="/about"` を使用します。もし以前に `vue-router` を使ったことがある場合は、`<NuxtLink>` を `<RouterLink>` の代わりと考えることができます。
 
 `pages` フォルダにある `index.vue` へのシンプルなリンク:
 


### PR DESCRIPTION
English text

```
If you have used vue-router before, you can think of the <NuxtLink> as a replacement for <RouterLink>
```