### PR TITLE
docs: fix typo

### DIFF
--- a/content/en/tutorials/1.creating-blog-with-nuxt-content.md
+++ b/content/en/tutorials/1.creating-blog-with-nuxt-content.md
@@ -819,7 +819,7 @@ And of course we should link from our blog post to our new author page.
 
 ```html{}[components/Author.vue]
 <NuxtLink :to="`/blog/author/${author.name}`">
-  <img :src="author.img" />
+  <img :src="author.image" />
   <div>
     <h4>Author</h4>
     <p>{{ author.name }}</p>


### PR DESCRIPTION
Fix incorrect image link for `Author.vue` `NuxtLink` example.

In the first example we create the author like this:
```markdown
---
author:
  name: Benjamin
  bio: All about Benjamin
  image: https://images.unsplash.com/.....
---
```

And yet in the example when we wrap it in `<NuxtLink>` the code wrongly displays `author.img`.
