### PR TITLE
docs: handle additional case when extending plugins

### DIFF
--- a/content/en/docs/5.configuration-glossary/10.configuration-extend-plugins.md
+++ b/content/en/docs/5.configuration-glossary/10.configuration-extend-plugins.md
@@ -22,7 +22,7 @@ Example of changing plugins order:
 export default {
   extendPlugins(plugins) {
     const pluginIndex = plugins.findIndex(
-      ({ src }) => src === '~/plugins/shouldBeFirst.js'
+      plugin => (typeof plugin === 'string' ? plugin : plugin.src) === '~/plugins/shouldBeFirst.js'
     )
     const shouldBeFirstPlugin = plugins[pluginIndex]
 


### PR DESCRIPTION
according to the docs https://nuxtjs.org/docs/configuration-glossary/configuration-plugins#the-plugins-property, plugin array is array of string or objects. We have encountered with an issue with @nuxtjs/composition-api which has not object structure.