### PR TITLE
chore(env): fix env variables usage on runtime

### DIFF
--- a/components/molecules/EditOnGithub.vue
+++ b/components/molecules/EditOnGithub.vue
@@ -65,7 +65,9 @@ export default defineComponent({
   },
   setup(props) {
     const contributors = ref([])
-    const { $docus } = useContext()
+    const { $docus, $config } = useContext()
+
+    const apiURL = $config.apiURL || 'https://api.nuxtjs.org'
 
     const { value: settings } = computed(() => $docus.settings)
 
@@ -98,7 +100,7 @@ export default defineComponent({
       props.page.source
     ].join('/')
     useFetch(async () => {
-      contributors.value = await $fetch(`https://api.nuxtjs.org/api/contributors/${path}`)
+      contributors.value = await $fetch(`${apiURL}/api/contributors/${path}`)
     })
     return {
       link,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -174,6 +174,7 @@ export default withDocus({
     fallback: 'light'
   },
   publicRuntimeConfig: {
+    apiURL: process.env.API_URL,
     plausible: {
       domain: process.env.PLAUSIBLE_DOMAIN
     },

--- a/plugins/modules.js
+++ b/plugins/modules.js
@@ -1,8 +1,5 @@
-import { ssrRef } from '@nuxtjs/composition-api'
+import { useContext, ssrRef } from '@nuxtjs/composition-api'
 import { $fetch } from 'ohmyfetch'
-
-// Nuxt API URL
-const apiURL = 'https://api.nuxtjs.org/api'
 
 // Modules reference
 const modules = ssrRef([], 'modulesRef')
@@ -14,10 +11,15 @@ const categories = ssrRef([], 'categoriesRef')
  * Modules helpers
  */
 export function useModules() {
+  const { $config } = useContext()
+
+  // Nuxt API URL
+  const apiURL = $config.apiURL || 'https://api.nuxtjs.org'
+
   // Fetch modules and categories
   const fetch = async () => {
     // Get modules
-    modules.value = await $fetch(`${apiURL}/modules`)
+    modules.value = await $fetch(`${apiURL}/api/modules`)
 
     // Extract categories out of modules
     categories.value = Object.entries(

--- a/plugins/newsletter.js
+++ b/plugins/newsletter.js
@@ -3,11 +3,12 @@ import { $fetch } from 'ohmyfetch'
 
 export function useNewsletter() {
   // @ts-ignore
-  const { query } = useContext()
+  const { query, $config } = useContext()
   const email = ref('')
   const newsletterResult = ref('')
   const pending = ref(false)
-  const apiURL = process.env.NUXT_ORG_API || 'https://api.nuxtjs.org'
+
+  const apiURL = $config.apiURL || 'https://api.nuxtjs.org'
 
   const subscribe = () => {
     // Cancel empty email

--- a/plugins/partner.js
+++ b/plugins/partner.js
@@ -3,9 +3,9 @@ import { $fetch } from 'ohmyfetch'
 
 export function usePartnerContact(partnersEmail) {
   // @ts-ignore
-  const { $recaptcha } = useContext()
+  const { $recaptcha, $config } = useContext()
 
-  const apiURL = process.env.NUXT_ORG_API || 'https://api.nuxtjs.org'
+  const apiURL = $config.apiURL || 'https://api.nuxtjs.org'
 
   const form = reactive({
     first_name: '',


### PR DESCRIPTION
Fixes the usage of environnement variables on runtime. Should use `publicRuntimeConfig` instead of `process.env`.