### PR TITLE
chore: redirect `/modules` to `modules.nuxtjs.org`

### DIFF
--- a/content/en/_collections/navigations/footer.md
+++ b/content/en/_collections/navigations/footer.md
@@ -1,81 +1,55 @@
 ---
 links:
-  -
-    title: 'About'
+  - title: 'About'
     items:
-      -
-        title: 'Contact us'
+      - title: 'Contact us'
         href: 'mailto:hello@nuxtjs.com'
-      -
-        title: 'Enterprise support'
+      - title: 'Enterprise support'
         to: '/support'
-      -
-        title: 'NuxtLabs company'
+      - title: 'NuxtLabs company'
         href: 'https://nuxtlabs.com/'
-      -
-        title: 'Open Source Software'
+      - title: 'Open Source Software'
         href: 'https://github.com/nuxt'
-      -
-        title: 'Partnerships'
+      - title: 'Partnerships'
         to: '/partners'
-      -
-        title: 'Telemetry'
+      - title: 'Telemetry'
         href: 'https://github.com/nuxt/telemetry'
-  -
-    title: 'Ecosystem'
+  - title: 'Ecosystem'
     items:
-      -
-        title: 'Announcements'
+      - title: 'Announcements'
         to: '/announcements'
-      -
-        title: 'Contribute'
+      - title: 'Contribute'
         to: '/contribution-guide'
-      -
-        title: 'Chat with us'
+      - title: 'Chat with us'
         href: 'https://discord.nuxtjs.org/'
-      -
-        title: 'Events'
+      - title: 'Events'
         to: '/events'
-      -
-        title: 'Sponsors'
+      - title: 'Sponsors'
         to: '/sponsors'
-      -
-        title: 'Teams'
+      - title: 'Teams'
         to: '/teams'
-      -
-        title: 'Tutorials'
+      - title: 'Tutorials'
         to: '/tutorials'
-      -
-        title: 'Video courses'
+      - title: 'Video courses'
         to: '/video-courses/'
-  -
-    title: 'Resources'
+  - title: 'Resources'
     items:
-      -
-        title: 'Design'
+      - title: 'Design'
         to: '/design'
-      -
-        title: 'Documentation'
+      - title: 'Documentation'
         to: '/docs'
-      -
-        title: 'Examples'
+      - title: 'Examples'
         to: '/examples'
-      -
-        title: 'Deployments'
+      - title: 'Deployments'
         to: '/deployments'
-      -
-        title: 'Master courses'
+      - title: 'Master courses'
         href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
-      -
-        title: 'Modules'
-        to: '/modules'
-      -
-        title: 'Releases'
+      - title: 'Modules'
+        href: 'https://modules.nuxtjs.org'
+      - title: 'Releases'
         to: '/releases'
-      -
-        title: 'Showcases'
+      - title: 'Showcases'
         to: '/showcases'
-      -
-        title: 'Themes'
+      - title: 'Themes'
         to: '/themes'
 ---

--- a/content/en/_collections/navigations/header.md
+++ b/content/en/_collections/navigations/header.md
@@ -1,137 +1,114 @@
 ---
 links:
-  -
-    title: "Discover"
+  - title: 'Discover'
     items:
-      -
-        title: "Showcases"
-        subtitle: "Selection of website built with Nuxt"
-        slug: "showcases"
-        to: "/showcases"
-        icon: "showcases.svg"
-        color: "bg-sand"
-      -
-        title: "Case studies"
-        subtitle: "How companies use Nuxt"
-        slug: "case-studies"
-        to: "/case-studies"
-        icon: "case-studies.svg"
-        color: "bg-sand-dark"
-      -
-        title: "Testimonials"
-        subtitle: "What they think about us"
-        slug: "testimonials"
-        to: "/testimonials"
-        icon: "testimonials.svg"
-        color: "bg-sand-darker"
-  -
-    title: "Learn"
+      - title: 'Showcases'
+        subtitle: 'Selection of website built with Nuxt'
+        slug: 'showcases'
+        to: '/showcases'
+        icon: 'showcases.svg'
+        color: 'bg-sand'
+      - title: 'Case studies'
+        subtitle: 'How companies use Nuxt'
+        slug: 'case-studies'
+        to: '/case-studies'
+        icon: 'case-studies.svg'
+        color: 'bg-sand-dark'
+      - title: 'Testimonials'
+        subtitle: 'What they think about us'
+        slug: 'testimonials'
+        to: '/testimonials'
+        icon: 'testimonials.svg'
+        color: 'bg-sand-darker'
+  - title: 'Learn'
     items:
-      -
-        title: "Docs"
-        subtitle: "Create fast websites easily"
-        slug: "docs"
-        to: "/docs"
-        icon: "docs.svg"
-        color: "bg-green-500"
+      - title: 'Docs'
+        subtitle: 'Create fast websites easily'
+        slug: 'docs'
+        to: '/docs'
+        icon: 'docs.svg'
+        color: 'bg-green-500'
 
-      -
-        title: "Examples"
-        subtitle: "Understand everything in Nuxt"
-        slug: "examples"
-        to: "/examples"
-        icon: "examples.svg"
-        color: "bg-green-600"
-      -
-        title: "Tutorials"
-        subtitle: "Learn with concrete cases"
-        slug: "tutorials"
-        to: "/tutorials"
-        icon: "tutorials.svg"
-        color: "bg-green-700"
-      -
-        title: "Master courses"
-        subtitle: "Learn more with experts"
-        href: "https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite"
-        icon: "master-courses.svg"
-        color: "bg-green-800"
-  -
-    title: "Explore"
+      - title: 'Examples'
+        subtitle: 'Understand everything in Nuxt'
+        slug: 'examples'
+        to: '/examples'
+        icon: 'examples.svg'
+        color: 'bg-green-600'
+      - title: 'Tutorials'
+        subtitle: 'Learn with concrete cases'
+        slug: 'tutorials'
+        to: '/tutorials'
+        icon: 'tutorials.svg'
+        color: 'bg-green-700'
+      - title: 'Master courses'
+        subtitle: 'Learn more with experts'
+        href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
+        icon: 'master-courses.svg'
+        color: 'bg-green-800'
+  - title: 'Explore'
     items:
-      -
-        title: "Deployments"
-        subtitle: "How to Deploy Nuxt"
-        slug: "deployments"
-        to: "/deployments"
-        icon: "deployments.svg"
-        color: "bg-indigo-light"
-      -
-        title: "Modules"
-        subtitle: "Extend the power of Nuxt"
-        slug: "modules"
-        to: "/modules"
-        icon: "modules.svg"
-        color: "bg-indigo"
-      -
-        title: "Themes"
-        subtitle: "Get started with themes"
-        slug: "themes"
-        to: "/themes"
-        icon: "themes.svg"
-        color: "bg-indigo-dark"
-      -
-        title: "Video Courses"
-        subtitle: "Learn step by step"
-        slug: "video-courses"
-        to: "/video-courses"
-        icon: "video-courses.svg"
-        color: "bg-indigo-darker"
-  -
-    title: "Community"
+      - title: 'Deployments'
+        subtitle: 'How to Deploy Nuxt'
+        slug: 'deployments'
+        to: '/deployments'
+        icon: 'deployments.svg'
+        color: 'bg-indigo-light'
+      - title: 'Modules'
+        subtitle: 'Extend the power of Nuxt'
+        href: 'https://modules.nuxtjs.org'
+        icon: 'modules.svg'
+        color: 'bg-indigo'
+      - title: 'Themes'
+        subtitle: 'Get started with themes'
+        slug: 'themes'
+        to: '/themes'
+        icon: 'themes.svg'
+        color: 'bg-indigo-dark'
+      - title: 'Video Courses'
+        subtitle: 'Learn step by step'
+        slug: 'video-courses'
+        to: '/video-courses'
+        icon: 'video-courses.svg'
+        color: 'bg-indigo-darker'
+  - title: 'Community'
     items:
-      -
-        title: "Announcements"
-        subtitle: "Last news about Nuxt"
-        slug: "announcements"
-        to: "/announcements"
-        icon: "announcements.svg"
-        color: "bg-mint-light"
-      -
-        title: "Teams"
-        subtitle: "They are Nuxt"
-        slug: "teams"
-        to: "/teams"
-        icon: "teams.svg"
-        color: "bg-mint-light"
-      -
-        title: "Events"
-        subtitle: "When and where we gonna be"
-        slug: "events"
-        to: "/events"
-        icon: "events.svg"
-        color: "bg-mint"
-      -
-        title: "Releases"
-        subtitle: "All the code we released"
-        slug: "releases"
-        to: "/releases"
-        icon: "releases.svg"
-        color: "bg-mint"
-      -
-        title: "Sponsors"
-        subtitle: "They trust us"
-        slug: "sponsors"
-        to: "/sponsors"
-        icon: "sponsors.svg"
-        color: "bg-mint-dark"
-      -
-        title: "Tweets"
-        subtitle: "They talk about us"
-        href: "https://twitter.com/nuxt_js/timelines/1439936107421085704"
-        icon: "tweets.svg"
-        color: "bg-mint-dark"
-  -
-    title: "Partners"
-    slug: "partners"
-    to: "/partners"
+      - title: 'Announcements'
+        subtitle: 'Last news about Nuxt'
+        slug: 'announcements'
+        to: '/announcements'
+        icon: 'announcements.svg'
+        color: 'bg-mint-light'
+      - title: 'Teams'
+        subtitle: 'They are Nuxt'
+        slug: 'teams'
+        to: '/teams'
+        icon: 'teams.svg'
+        color: 'bg-mint-light'
+      - title: 'Events'
+        subtitle: 'When and where we gonna be'
+        slug: 'events'
+        to: '/events'
+        icon: 'events.svg'
+        color: 'bg-mint'
+      - title: 'Releases'
+        subtitle: 'All the code we released'
+        slug: 'releases'
+        to: '/releases'
+        icon: 'releases.svg'
+        color: 'bg-mint'
+      - title: 'Sponsors'
+        subtitle: 'They trust us'
+        slug: 'sponsors'
+        to: '/sponsors'
+        icon: 'sponsors.svg'
+        color: 'bg-mint-dark'
+      - title: 'Tweets'
+        subtitle: 'They talk about us'
+        href: 'https://twitter.com/nuxt_js/timelines/1439936107421085704'
+        icon: 'tweets.svg'
+        color: 'bg-mint-dark'
+  - title: 'Partners'
+    slug: 'partners'
+    to: '/partners'
 ---

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -19,10 +19,9 @@ Build your next Vue.js application with confidence using Nuxt.<br class="hidden 
 :app-button[Get started]{ to="/docs/get-started/installation" }
 ::
 
-::home-learn-master
----
-category: Learn
----
+## ::home-learn-master
+
+## category: Learn
 
 #title
 [Easy]{.text-primary} to learn. [Easy]{.text-primary} to master
@@ -34,73 +33,88 @@ Learn everything you need to know, from beginner to master.
 :app-button[Start learning]{to="/docs/get-started/installation"}
 ::
 
-::home-features
----
-category: Features
----
+## ::home-features
 
-::section-content-item
----
+## category: Features
+
+## ::section-content-item
+
 title: Zero Configuration
 description: 'Start coding your app right away, Nuxt takes care of the rest.'
 image: /img/home/discover/dx/zero-config.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: File-system Routing
 description: 'Automatic routing and code-splitting for every page.'
 image: /img/home/discover/dx/file-system-routing.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Rendering Modes
 description: 'Switch between static-site generation or on-demand server rendering.'
 image: /img/home/discover/dx/hybrid.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Data Fetching
 description: 'Fetch your content from any source in your Vue components, SSR ready.'
 image: /img/home/discover/dx/fetch.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Strong Conventions
 description: 'Efficient teamwork with a strong directory structure and conventions.'
 image: /img/home/discover/dx/conventions.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: SEO Friendly
 description: 'Meta tag management and faster time-to-content for great indexing.'
 image: /img/home/discover/dx/seo.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Components Auto-import
 description: 'Use your components, Nuxt will import them with smart code-splitting.'
 image: /img/home/discover/dx/auto-inject.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Modules Ecosystem
 description: 'Extend your app with 160+ Nuxt modules and create your own.'
 image: /img/home/discover/dx/modular.svg
+
 ---
+
 ::
 
 #title
@@ -110,10 +124,9 @@ Intuitive [D]{.text-primary}eveloper E[x]{.text-primary}perience
 Nuxt is shipped with plenty of features to boost developer productivity and the end user experience.
 ::
 
-::home-discover-partners
----
-category: Partners
----
+## ::home-discover-partners
+
+## category: Partners
 
 #title
 Sustainable [_Development_]{.text-primary}
@@ -122,83 +135,98 @@ Sustainable [_Development_]{.text-primary}
 Nuxt development is carried out by passionate developers, but the amount of effort needed to maintain and develop new features is not sustainable without proper financial backing. We are thankful for our sponsors and partners, who help make Nuxt possible.<br>
 
 #partners-card
-  ::home-partners-card
-  ---
-  icon: technology.svg
-  category: technology
-  ---
-  #title
-  Technology partners
+::home-partners-card
 
-  #description
-  Technology partners offer services that empower Nuxt developers, such as CMS, Hosting, Database, and more.
+---
 
-  #button
-  Discover our technology partners
-  ::
+icon: technology.svg
+category: technology
 
-  ::home-partners-card
-  ---
-  icon: agency.svg
-  category: agency
-  ---
-  #title
-  Agency partners
+---
 
-  #description
-  Agency partners are trusted web and consulting agencies that can provide Nuxt development and support for your projects.
+#title
+Technology partners
 
-  #button
-  Find a Nuxt expert
-  ::
+#description
+Technology partners offer services that empower Nuxt developers, such as CMS, Hosting, Database, and more.
 
-#bottom
-  :app-button[Become a partner]{href="mailto:partners@nuxtlabs.com"}
+#button
+Discover our technology partners
 ::
 
-::home-learn-guides
----
-category: Learn
+::home-partners-card
+
 ---
 
-::section-content-item
+icon: agency.svg
+category: agency
+
 ---
+
+#title
+Agency partners
+
+#description
+Agency partners are trusted web and consulting agencies that can provide Nuxt development and support for your projects.
+
+#button
+Find a Nuxt expert
+::
+
+#bottom
+:app-button[Become a partner]{href="mailto:partners@nuxtlabs.com"}
+::
+
+## ::home-learn-guides
+
+## category: Learn
+
+## ::section-content-item
+
 title: Documentation
 description: 'Discover Nuxt concepts and find a complete API reference.'
 image: /img/home/learn/guides/gem-1.svg
 to: '/docs/get-started/installation'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Examples
 description: "Learn by examples produced by the community."
 image: /img/home/learn/guides/gem-2.svg
 to: '/examples'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Releases
 description: 'Find out what has changed before upgrading.'
 image: /img/home/learn/guides/gem-3.svg
 to: '/releases'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Master Courses
 description: 'Watch a complete series of videos to learn Nuxt with our partner Vue School.'
 image: /img/home/learn/guides/gem-4.svg
 to: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
 #title
@@ -208,37 +236,46 @@ Follow our [_Guides_]{.text-primary}
 From an idea to a masterpiece, guides take you on the path to becoming a Nuxter.
 ::
 
-::home-explore
----
-category: Explore
----
+## ::home-explore
 
-::section-content-item
----
+## category: Explore
+
+## ::section-content-item
+
 title: 'Deployments'
 description: 'Extend and automate your workflow by using deployments for your favorite tools.'
 image: '/img/home/explore/gem-explore-1.svg'
 to: '/deployments'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 ::section-content-item
+
 ---
+
 title: 'Modules'
 description: 'Discover our list of modules to supercharge your Nuxt project. Created by the Nuxt team and community.'
 image: '/img/home/explore/gem-explore-2.svg'
-to: '/modules'
+to: 'https://modules.nuxtjs.org'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 ::section-content-item
+
 ---
+
 title: 'Themes'
 description: 'See how a real world application is built using the Nuxt stack with the themes built by our partners.'
 image: '/img/home/explore/gem-explore-3.svg'
 to: '/themes'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 
 #title
@@ -248,12 +285,13 @@ Moving forward? So much to [_Explore_]{.text-primary}
 Discover powerful modules, integrate with your favorite providers and start quickly with themes.
 ::
 
-::home-community
----
+## ::home-community
+
 category: Community
 announcementsCategory: Announcements
 eventsCategory: Events
 articleLinkTitle: Get infos
+
 ---
 
 #title
@@ -263,10 +301,10 @@ Sharing is [Caring]{.text-sky-lighter}
 Discover articles from the framework team and community about Nuxt. Tips and tricks included!
 ::
 
-::home-testimonials
----
-category: Community
----
+## ::home-testimonials
+
+## category: Community
+
 #title
 Testimonials
 
@@ -274,9 +312,13 @@ Testimonials
 Learn what the experts love about Nuxt.
 
 #testimonials
-  :::testimonials
-  ---
-  home: true
-  ---
-  :::
+:::testimonials
+
+---
+
+home: true
+
+---
+
+:::
 ::

--- a/content/es/_collections/navigations/footer.md
+++ b/content/es/_collections/navigations/footer.md
@@ -1,81 +1,55 @@
 ---
 links:
-  -
-    title: 'About'
+  - title: 'About'
     items:
-      -
-        title: 'Contact us'
+      - title: 'Contact us'
         href: 'mailto:hello@nuxtjs.com'
-      -
-        title: 'Enterprise support'
+      - title: 'Enterprise support'
         to: '/support'
-      -
-        title: 'NuxtLabs company'
+      - title: 'NuxtLabs company'
         href: 'https://nuxtlabs.com/'
-      -
-        title: 'Open Source Software'
+      - title: 'Open Source Software'
         href: 'https://github.com/nuxt'
-      -
-        title: 'Partnerships'
+      - title: 'Partnerships'
         to: '/partners'
-      -
-        title: 'Telemetry'
+      - title: 'Telemetry'
         href: 'https://github.com/nuxt/telemetry'
-  -
-    title: 'Ecosystem'
+  - title: 'Ecosystem'
     items:
-      -
-        title: 'Announcements'
+      - title: 'Announcements'
         to: '/announcements'
-      -
-        title: 'Contribute'
+      - title: 'Contribute'
         to: '/contribution-guide'
-      -
-        title: 'Chat with us'
+      - title: 'Chat with us'
         href: 'https://discord.nuxtjs.org/'
-      -
-        title: 'Events'
+      - title: 'Events'
         to: '/events'
-      -
-        title: 'Sponsors'
+      - title: 'Sponsors'
         to: '/sponsors'
-      -
-        title: 'Teams'
+      - title: 'Teams'
         to: '/teams'
-      -
-        title: 'Tutorials'
+      - title: 'Tutorials'
         to: '/tutorials'
-      -
-        title: 'Video courses'
+      - title: 'Video courses'
         to: '/video-courses/'
-  -
-    title: 'Resources'
+  - title: 'Resources'
     items:
-      -
-        title: 'Design'
+      - title: 'Design'
         to: '/design'
-      -
-        title: 'Documentation'
+      - title: 'Documentation'
         to: '/docs'
-      -
-        title: 'Examples'
+      - title: 'Examples'
         to: '/examples'
-      -
-        title: 'Deployments'
+      - title: 'Deployments'
         to: '/deployments'
-      -
-        title: 'Master courses'
+      - title: 'Master courses'
         href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
-      -
-        title: 'Modules'
-        to: '/modules'
-      -
-        title: 'Releases'
+      - title: 'Modules'
+        href: 'https://modules.nuxtjs.org'
+      - title: 'Releases'
         to: '/releases'
-      -
-        title: 'Showcases'
+      - title: 'Showcases'
         to: '/showcases'
-      -
-        title: 'Themes'
+      - title: 'Themes'
         to: '/themes'
 ---

--- a/content/es/_collections/navigations/header.md
+++ b/content/es/_collections/navigations/header.md
@@ -1,137 +1,114 @@
 ---
 links:
-  -
-    title: "Discover"
+  - title: 'Discover'
     items:
-      -
-        title: "Showcases"
-        subtitle: "Selection of website built with Nuxt"
-        slug: "showcases"
-        to: "/showcases"
-        icon: "showcases.svg"
-        color: "bg-sand"
-      -
-        title: "Case studies"
-        subtitle: "How companies use Nuxt"
-        slug: "case-studies"
-        to: "/case-studies"
-        icon: "case-studies.svg"
-        color: "bg-sand-dark"
-      -
-        title: "Testimonials"
-        subtitle: "What they think about us"
-        slug: "testimonials"
-        to: "/testimonials"
-        icon: "testimonials.svg"
-        color: "bg-sand-darker"
-  -
-    title: "Learn"
+      - title: 'Showcases'
+        subtitle: 'Selection of website built with Nuxt'
+        slug: 'showcases'
+        to: '/showcases'
+        icon: 'showcases.svg'
+        color: 'bg-sand'
+      - title: 'Case studies'
+        subtitle: 'How companies use Nuxt'
+        slug: 'case-studies'
+        to: '/case-studies'
+        icon: 'case-studies.svg'
+        color: 'bg-sand-dark'
+      - title: 'Testimonials'
+        subtitle: 'What they think about us'
+        slug: 'testimonials'
+        to: '/testimonials'
+        icon: 'testimonials.svg'
+        color: 'bg-sand-darker'
+  - title: 'Learn'
     items:
-      -
-        title: "Docs"
-        subtitle: "Create fast websites easily"
-        slug: "docs"
-        to: "/docs"
-        icon: "docs.svg"
-        color: "bg-green-500"
+      - title: 'Docs'
+        subtitle: 'Create fast websites easily'
+        slug: 'docs'
+        to: '/docs'
+        icon: 'docs.svg'
+        color: 'bg-green-500'
 
-      -
-        title: "Examples"
-        subtitle: "Understand everything in Nuxt"
-        slug: "examples"
-        to: "/examples"
-        icon: "examples.svg"
-        color: "bg-green-600"
-      -
-        title: "Tutorials"
-        subtitle: "Learn with concrete cases"
-        slug: "tutorials"
-        to: "/tutorials"
-        icon: "tutorials.svg"
-        color: "bg-green-700"
-      -
-        title: "Master courses"
-        subtitle: "Learn more with experts"
-        href: "https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite"
-        icon: "master-courses.svg"
-        color: "bg-green-800"
-  -
-    title: "Explore"
+      - title: 'Examples'
+        subtitle: 'Understand everything in Nuxt'
+        slug: 'examples'
+        to: '/examples'
+        icon: 'examples.svg'
+        color: 'bg-green-600'
+      - title: 'Tutorials'
+        subtitle: 'Learn with concrete cases'
+        slug: 'tutorials'
+        to: '/tutorials'
+        icon: 'tutorials.svg'
+        color: 'bg-green-700'
+      - title: 'Master courses'
+        subtitle: 'Learn more with experts'
+        href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
+        icon: 'master-courses.svg'
+        color: 'bg-green-800'
+  - title: 'Explore'
     items:
-      -
-        title: "Deployments"
-        subtitle: "How to Deploy Nuxt"
-        slug: "deployments"
-        to: "/deployments"
-        icon: "deployments.svg"
-        color: "bg-indigo-light"
-      -
-        title: "Modules"
-        subtitle: "Extend the power of Nuxt"
-        slug: "modules"
-        to: "/modules"
-        icon: "modules.svg"
-        color: "bg-indigo"
-      -
-        title: "Themes"
-        subtitle: "Get started with themes"
-        slug: "themes"
-        to: "/themes"
-        icon: "themes.svg"
-        color: "bg-indigo-dark"
-      -
-        title: "Video Courses"
-        subtitle: "Learn step by step"
-        slug: "video-courses"
-        to: "/video-courses"
-        icon: "video-courses.svg"
-        color: "bg-indigo-darker"
-  -
-    title: "Community"
+      - title: 'Deployments'
+        subtitle: 'How to Deploy Nuxt'
+        slug: 'deployments'
+        to: '/deployments'
+        icon: 'deployments.svg'
+        color: 'bg-indigo-light'
+      - title: 'Modules'
+        subtitle: 'Extend the power of Nuxt'
+        href: 'https://modules.nuxtjs.org'
+        icon: 'modules.svg'
+        color: 'bg-indigo'
+      - title: 'Themes'
+        subtitle: 'Get started with themes'
+        slug: 'themes'
+        to: '/themes'
+        icon: 'themes.svg'
+        color: 'bg-indigo-dark'
+      - title: 'Video Courses'
+        subtitle: 'Learn step by step'
+        slug: 'video-courses'
+        to: '/video-courses'
+        icon: 'video-courses.svg'
+        color: 'bg-indigo-darker'
+  - title: 'Community'
     items:
-      -
-        title: "Announcements"
-        subtitle: "Last news about Nuxt"
-        slug: "announcements"
-        to: "/announcements"
-        icon: "announcements.svg"
-        color: "bg-mint-light"
-      -
-        title: "Teams"
-        subtitle: "They are Nuxt"
-        slug: "teams"
-        to: "/teams"
-        icon: "teams.svg"
-        color: "bg-mint-light"
-      -
-        title: "Events"
-        subtitle: "When and where we gonna be"
-        slug: "events"
-        to: "/events"
-        icon: "events.svg"
-        color: "bg-mint"
-      -
-        title: "Releases"
-        subtitle: "All the code we released"
-        slug: "releases"
-        to: "/releases"
-        icon: "releases.svg"
-        color: "bg-mint"
-      -
-        title: "Sponsors"
-        subtitle: "They trust us"
-        slug: "sponsors"
-        to: "/sponsors"
-        icon: "sponsors.svg"
-        color: "bg-mint-dark"
-      -
-        title: "Tweets"
-        subtitle: "They talk about us"
-        href: "https://twitter.com/nuxt_js/timelines/1439936107421085704"
-        icon: "tweets.svg"
-        color: "bg-mint-dark"
-  -
-    title: "Partners"
-    slug: "partners"
-    to: "/partners"
+      - title: 'Announcements'
+        subtitle: 'Last news about Nuxt'
+        slug: 'announcements'
+        to: '/announcements'
+        icon: 'announcements.svg'
+        color: 'bg-mint-light'
+      - title: 'Teams'
+        subtitle: 'They are Nuxt'
+        slug: 'teams'
+        to: '/teams'
+        icon: 'teams.svg'
+        color: 'bg-mint-light'
+      - title: 'Events'
+        subtitle: 'When and where we gonna be'
+        slug: 'events'
+        to: '/events'
+        icon: 'events.svg'
+        color: 'bg-mint'
+      - title: 'Releases'
+        subtitle: 'All the code we released'
+        slug: 'releases'
+        to: '/releases'
+        icon: 'releases.svg'
+        color: 'bg-mint'
+      - title: 'Sponsors'
+        subtitle: 'They trust us'
+        slug: 'sponsors'
+        to: '/sponsors'
+        icon: 'sponsors.svg'
+        color: 'bg-mint-dark'
+      - title: 'Tweets'
+        subtitle: 'They talk about us'
+        href: 'https://twitter.com/nuxt_js/timelines/1439936107421085704'
+        icon: 'tweets.svg'
+        color: 'bg-mint-dark'
+  - title: 'Partners'
+    slug: 'partners'
+    to: '/partners'
 ---

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -19,10 +19,9 @@ Cree su próxima aplicación Vue.js con confianza usando Nuxt.<br class="hidden 
 :app-button[Comenzar]{ to="/docs/get-started/installation" }
 ::
 
-::home-learn-master
----
-category: Aprender
----
+## ::home-learn-master
+
+## category: Aprender
 
 #title
 [Fácil]{.text-primary} de aprender. [Fácil]{.text-primary} de dominar
@@ -34,73 +33,88 @@ Aprende todo lo que usted necesita saber, desde principiante hasta maestro.
 :app-button[Empieza a aprender]{to="/docs/get-started/installation"}
 ::
 
-::home-features
----
-category: Características
----
+## ::home-features
 
-::section-content-item
----
+## category: Características
+
+## ::section-content-item
+
 title: Sin configuraciones
 description: 'Comience a programar su aplicación de inmediato, Nuxt se encarga del resto.'
 image: /img/home/discover/dx/zero-config.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Enrutamiento basado en archivos
 description: 'Enrutamiento automático y división de código para cada página.'
 image: /img/home/discover/dx/file-system-routing.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Modos de renderizado
 description: 'Cambie entre la generación de sitios estáticos o renderizado en el servidor bajo demanda.'
 image: /img/home/discover/dx/hybrid.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Obtención de datos
 description: 'Obtenga su contenido de cualquier fuente en sus componentes de Vue, listo para SSR.'
 image: /img/home/discover/dx/fetch.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Convenios fuertes
 description: 'Trabajo en equipo eficiente con una sólida estructura de directorios y convenciones.'
 image: /img/home/discover/dx/conventions.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: SEO amigable
 description: 'Gestión de metaetiquetas y un tiempo de acceso al contenido más rápido para una excelente indexación.'
 image: /img/home/discover/dx/seo.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Importación automática de componentes
 description: 'Use sus componentes, Nuxt los importará con división de código inteligente.'
 image: /img/home/discover/dx/auto-inject.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Ecosistema de módulos
 description: 'Amplíe su aplicación con más de 160 módulos para Nuxt y cree los suyos propios.'
 image: /img/home/discover/dx/modular.svg
+
 ---
+
 ::
 
 #title
@@ -110,10 +124,9 @@ Intuitivo [D]{.text-primary}eveloper E[x]{.text-primary}perience
 Nuxt se produce con muchas características para aumentar la productividad del desarrollador y la experiencia del usuario final.
 ::
 
-::home-discover-partners
----
-category: Partners
----
+## ::home-discover-partners
+
+## category: Partners
 
 #title
 Desarrollo [_Sostenible_]{.text-primary}
@@ -122,83 +135,98 @@ Desarrollo [_Sostenible_]{.text-primary}
 El desarrollo de Nuxt lo llevan a cabo desarrolladores apasionados, pero la cantidad de esfuerzo necesario para mantener y desarrollar nuevas funciones no es sostenible sin el respaldo financiero adecuado. Agradecemos a nuestros patrocinadores y socios, que ayudan a hacer posible Nuxt.<br>
 
 #partners-card
-  ::home-partners-card
-  ---
-  icon: technology.svg
-  category: technology
-  ---
-  #title
-  Technology partners
+::home-partners-card
 
-  #description
-  Technology partners offer services that empower Nuxt developers, such as CMS, Hosting, Database, and more.
+---
 
-  #button
-  Discover our technology partners
-  ::
+icon: technology.svg
+category: technology
 
-  ::home-partners-card
-  ---
-  icon: agency.svg
-  category: agency
-  ---
-  #title
-  Agency partners
+---
 
-  #description
-  Agency partners are trusted web and consulting agencies that can provide Nuxt development and support for your projects.
+#title
+Technology partners
 
-  #button
-  Find a Nuxt expert
-  ::
+#description
+Technology partners offer services that empower Nuxt developers, such as CMS, Hosting, Database, and more.
 
-#bottom
-  :app-button[Conviertete en un patrocinador]{href="mailto:partners@nuxtlabs.com"}
+#button
+Discover our technology partners
 ::
 
-::home-learn-guides
----
-category: Aprender
+::home-partners-card
+
 ---
 
-::section-content-item
+icon: agency.svg
+category: agency
+
 ---
+
+#title
+Agency partners
+
+#description
+Agency partners are trusted web and consulting agencies that can provide Nuxt development and support for your projects.
+
+#button
+Find a Nuxt expert
+::
+
+#bottom
+:app-button[Conviertete en un patrocinador]{href="mailto:partners@nuxtlabs.com"}
+::
+
+## ::home-learn-guides
+
+## category: Aprender
+
+## ::section-content-item
+
 title: Documentación
 description: 'Descubra los conceptos de Nuxt y encuentre una referencia completa del API.'
 image: /img/home/learn/guides/gem-1.svg
 to: '/docs/get-started/installation'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Ejemplos
 description: "Aprenda con ejemplos producidos por la comunidad."
 image: /img/home/learn/guides/gem-2.svg
 to: '/examples'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Lanzamientos
 description: 'Descubra qué ha cambiado antes de actualizar.'
 image: /img/home/learn/guides/gem-3.svg
 to: '/releases'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Cursos de Maestría
 description: 'Vea una serie completa de videos para aprender Nuxt con nuestro socio Vue School.'
 image: /img/home/learn/guides/gem-4.svg
 to: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
 #title
@@ -208,37 +236,46 @@ Sigue nuestra [_Guías_]{.text-primary}
 Desde una idea hasta una obra maestra, las guías lo llevarán por el camino para convertirse en un Nuxter.
 ::
 
-::home-explore
----
-category: Explorar
----
+## ::home-explore
 
-::section-content-item
----
+## category: Explorar
+
+## ::section-content-item
+
 title: 'Integraciones'
 description: 'Amplíe y automatice su flujo de trabajo utilizando integraciones para sus herramientas favoritas.'
 image: '/img/home/explore/gem-explore-1.svg'
 to: '/deployments'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 ::section-content-item
+
 ---
+
 title: 'Módulos'
 description: 'Descubra nuestra lista de módulos para potenciar su proyecto Nuxt. Creado por el equipo y la comunidad de Nuxt.'
 image: '/img/home/explore/gem-explore-2.svg'
-to: '/modules'
+to: 'https://modules.nuxtjs.org'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 ::section-content-item
+
 ---
+
 title: 'Temas'
 description: 'Vea cómo se crea una aplicación del mundo real utilizando el stack de Nuxt con los temas creados por nuestros socios.'
 image: '/img/home/explore/gem-explore-3.svg'
 to: '/themes'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 
 #title
@@ -248,12 +285,13 @@ hoverClass: 'hover:bg-sky-surface'
 Descubra módulos potentes, intégrelos con sus proveedores favoritos y comience rápidamente con los temas.
 ::
 
-::home-campfire
----
+## ::home-campfire
+
 category: Comunidad
 announcementsCategory: Anuncios
 eventsCategory: Eventos
 articleLinkTitle: Obtener información
+
 ---
 
 #title
@@ -263,10 +301,10 @@ Compartir es [Demostrar interés]{.text-sky-lighter}
 Descubra artículos del equipo del framework y la comunidad sobre Nuxt. ¡Consejos y trucos incluidos!
 ::
 
-::home-testimonials
----
-category: Comunidad
----
+## ::home-testimonials
+
+## category: Comunidad
+
 #title
 Testimonios
 
@@ -274,9 +312,13 @@ Testimonios
 Aprende lo que a los expertos les encanta de Nuxt.
 
 #testimonials
-  :::testimonials
-  ---
-  home: true
-  ---
-  :::
+:::testimonials
+
+---
+
+home: true
+
+---
+
+:::
 ::

--- a/content/fr/_collections/navigations/footer.md
+++ b/content/fr/_collections/navigations/footer.md
@@ -1,81 +1,55 @@
 ---
 links:
-  -
-    title: 'À propos'
+  - title: 'À propos'
     items:
-      -
-        title: 'Nous contacter'
+      - title: 'Nous contacter'
         href: 'mailto:hello@nuxtjs.com'
-      -
-        title: 'Support'
+      - title: 'Support'
         to: '/support'
-      -
-        title: 'NuxtLabs company'
+      - title: 'NuxtLabs company'
         href: 'https://nuxtlabs.com/'
-      -
-        title: 'Open source softwares'
+      - title: 'Open source softwares'
         href: 'https://github.com/nuxt'
-      -
-        title: 'Partenariat'
+      - title: 'Partenariat'
         href: '/partners'
-      -
-        title: 'Telemetry'
+      - title: 'Telemetry'
         href: 'https://github.com/nuxt/telemetry'
-  -
-    title: 'Écosystème'
+  - title: 'Écosystème'
     items:
-      -
-        title: 'Annonces'
+      - title: 'Annonces'
         to: '/announcements'
-      -
-        title: 'Contribuer'
+      - title: 'Contribuer'
         to: '/contribution-guide'
-      -
-        title: 'Discutez avec nous'
+      - title: 'Discutez avec nous'
         href: 'https://discord.nuxtjs.org/'
-      -
-        title: 'Événements'
+      - title: 'Événements'
         to: '/events'
-      -
-        title: 'Sponsors'
+      - title: 'Sponsors'
         to: '/sponsors'
-      -
-        title: 'Équipes'
+      - title: 'Équipes'
         to: '/teams'
-      -
-        title: 'Tutoriels'
+      - title: 'Tutoriels'
         to: '/tutorials'
-      -
-        title: 'Cours vidéo'
+      - title: 'Cours vidéo'
         to: '/video-courses'
-  -
-    title: 'Ressources'
+  - title: 'Ressources'
     items:
-      -
-        title: 'Design'
+      - title: 'Design'
         to: '/design'
-      -
-        title: 'Documentation'
+      - title: 'Documentation'
         to: '/docs'
-      -
-        title: 'Exemples'
+      - title: 'Exemples'
         to: '/examples'
-      -
-        title: 'Déploiements'
+      - title: 'Déploiements'
         to: '/deployments'
-      -
-        title: 'Master courses'
+      - title: 'Master courses'
         href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
-      -
-        title: 'Modules'
-        to: '/modules'
-      -
-        title: 'Notes de version'
+      - title: 'Modules'
+        href: 'https://modules.nuxtjs.org'
+      - title: 'Notes de version'
         to: '/releases'
-      -
-        title: 'Showcases'
+      - title: 'Showcases'
         to: '/showcases'
-      -
-        title: 'Thèmes'
+      - title: 'Thèmes'
         to: '/themes'
 ---

--- a/content/fr/_collections/navigations/header.md
+++ b/content/fr/_collections/navigations/header.md
@@ -1,136 +1,113 @@
 ---
 links:
-  -
-    title: 'Découvrir'
+  - title: 'Découvrir'
     items:
-      -
-        title: "Showcases"
-        subtitle: "Sélection de sites créés avec Nuxt"
-        slug: "showcases"
-        to: "/showcases"
-        icon: "showcases.svg"
-        color: "bg-sand"
-      -
-        title: "Étude de cas"
-        subtitle: "Comment Nuxt est utilisé par les entreprises"
-        slug: "case-studies"
-        to: "/case-studies"
-        icon: "case-studies.svg"
-        color: "bg-sand-dark"
-      -
-        title: "Témoignages"
+      - title: 'Showcases'
+        subtitle: 'Sélection de sites créés avec Nuxt'
+        slug: 'showcases'
+        to: '/showcases'
+        icon: 'showcases.svg'
+        color: 'bg-sand'
+      - title: 'Étude de cas'
+        subtitle: 'Comment Nuxt est utilisé par les entreprises'
+        slug: 'case-studies'
+        to: '/case-studies'
+        icon: 'case-studies.svg'
+        color: 'bg-sand-dark'
+      - title: 'Témoignages'
         subtitle: "Ce qu'ils pensent de nous"
-        slug: "testimonials"
-        to: "/testimonials"
-        icon: "testimonials.svg"
-        color: "bg-sand-darker"
-  -
-    title: 'Apprendre'
+        slug: 'testimonials'
+        to: '/testimonials'
+        icon: 'testimonials.svg'
+        color: 'bg-sand-darker'
+  - title: 'Apprendre'
     items:
-      -
-        title: "Docs"
-        subtitle: "Créez un site web facilement"
-        slug: "docs"
-        to: "/docs"
-        icon: "docs.svg"
-        color: "bg-green-500"
-      -
-        title: "Exemples"
-        subtitle: "Comprendre tout sur Nuxt"
-        slug: "examples"
-        to: "/examples"
-        icon: "examples.svg"
-        color: "bg-green-600"
-      -
-        title: "Tutoriels"
-        subtitle: "Apprenez avec des cas concrets"
-        slug: "tutorials"
-        to: "/tutorials"
-        icon: "tutorials.svg"
-        color: "bg-green-700"
-      -
-        title: "Master courses"
-        subtitle: "Apprenez en plus grâce aux experts"
-        href: "https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite"
-        icon: "master-courses.svg"
-        color: "bg-green-800"
-  -
-    title: 'Explorer'
+      - title: 'Docs'
+        subtitle: 'Créez un site web facilement'
+        slug: 'docs'
+        to: '/docs'
+        icon: 'docs.svg'
+        color: 'bg-green-500'
+      - title: 'Exemples'
+        subtitle: 'Comprendre tout sur Nuxt'
+        slug: 'examples'
+        to: '/examples'
+        icon: 'examples.svg'
+        color: 'bg-green-600'
+      - title: 'Tutoriels'
+        subtitle: 'Apprenez avec des cas concrets'
+        slug: 'tutorials'
+        to: '/tutorials'
+        icon: 'tutorials.svg'
+        color: 'bg-green-700'
+      - title: 'Master courses'
+        subtitle: 'Apprenez en plus grâce aux experts'
+        href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
+        icon: 'master-courses.svg'
+        color: 'bg-green-800'
+  - title: 'Explorer'
     items:
-      -
-        title: "Déploiements"
-        subtitle: "Comment déployer Nuxt"
-        slug: "deployments"
-        to: "/deployments"
-        icon: "deployments.svg"
-        color: "bg-indigo-light"
-      -
-        title: "Modules"
-        subtitle: "Toute la puissance de Nuxt"
-        slug: "modules"
-        to: "/modules"
-        icon: "modules.svg"
-        color: "bg-indigo"
-      -
-        title: "Thèmes"
-        subtitle: "Commencez avec les thèmes"
-        slug: "themes"
-        to: "/themes"
-        icon: "themes.svg"
-        color: "bg-indigo-dark"
-      -
-        title: "Cours vidéo"
-        subtitle: "Apprendre étape par étape"
-        slug: "video-courses"
-        to: "/video-courses"
-        icon: "video-courses.svg"
-        color: "bg-indigo-darker"
-  -
-    title: 'Communauté'
+      - title: 'Déploiements'
+        subtitle: 'Comment déployer Nuxt'
+        slug: 'deployments'
+        to: '/deployments'
+        icon: 'deployments.svg'
+        color: 'bg-indigo-light'
+      - title: 'Modules'
+        subtitle: 'Toute la puissance de Nuxt'
+        href: 'https://modules.nuxtjs.org'
+        icon: 'modules.svg'
+        color: 'bg-indigo'
+      - title: 'Thèmes'
+        subtitle: 'Commencez avec les thèmes'
+        slug: 'themes'
+        to: '/themes'
+        icon: 'themes.svg'
+        color: 'bg-indigo-dark'
+      - title: 'Cours vidéo'
+        subtitle: 'Apprendre étape par étape'
+        slug: 'video-courses'
+        to: '/video-courses'
+        icon: 'video-courses.svg'
+        color: 'bg-indigo-darker'
+  - title: 'Communauté'
     items:
-      -
-        title: "Annonces"
-        subtitle: "Les dernières nouvelles concerant Nuxt"
-        slug: "announcements"
-        to: "/announcements"
-        icon: "announcements.svg"
-        color: "bg-mint-light"
-      -
-        title: "Équipes"
-        subtitle: "Nous sommes Nuxt"
-        slug: "teams"
-        to: "/teams"
-        icon: "teams.svg"
-        color: "bg-mint-light"
-      -
-        title: "Événements"
-        subtitle: "Quand et où nous trouver"
-        slug: "events"
-        to: "/events"
-        icon: "events.svg"
-        color: "bg-mint"
-      -
-        title: "Notes de version"
-        subtitle: "Tout le code que nous avons publié"
-        slug: "releases"
-        to: "/releases"
-        icon: "releases.svg"
-        color: "bg-mint"
-      -
-        title: "Sponsors"
-        subtitle: "Ils croient en nous"
-        slug: "sponsors"
-        to: "/sponsors"
-        icon: "sponsors.svg"
-        color: "bg-mint-dark"
-      -
-        title: "Tweets"
-        subtitle: "Ils parlent de nous"
-        href: "https://twitter.com/nuxt_js/timelines/1439936107421085704"
-        icon: "tweets.svg"
-        color: "bg-mint-dark"
-  -
-    title: "Partenaires"
-    slug: "partners"
-    to: "/partners"
+      - title: 'Annonces'
+        subtitle: 'Les dernières nouvelles concerant Nuxt'
+        slug: 'announcements'
+        to: '/announcements'
+        icon: 'announcements.svg'
+        color: 'bg-mint-light'
+      - title: 'Équipes'
+        subtitle: 'Nous sommes Nuxt'
+        slug: 'teams'
+        to: '/teams'
+        icon: 'teams.svg'
+        color: 'bg-mint-light'
+      - title: 'Événements'
+        subtitle: 'Quand et où nous trouver'
+        slug: 'events'
+        to: '/events'
+        icon: 'events.svg'
+        color: 'bg-mint'
+      - title: 'Notes de version'
+        subtitle: 'Tout le code que nous avons publié'
+        slug: 'releases'
+        to: '/releases'
+        icon: 'releases.svg'
+        color: 'bg-mint'
+      - title: 'Sponsors'
+        subtitle: 'Ils croient en nous'
+        slug: 'sponsors'
+        to: '/sponsors'
+        icon: 'sponsors.svg'
+        color: 'bg-mint-dark'
+      - title: 'Tweets'
+        subtitle: 'Ils parlent de nous'
+        href: 'https://twitter.com/nuxt_js/timelines/1439936107421085704'
+        icon: 'tweets.svg'
+        color: 'bg-mint-dark'
+  - title: 'Partenaires'
+    slug: 'partners'
+    to: '/partners'
 ---

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -19,10 +19,9 @@ Construisez votre prochaine application Vue.js en toute confiance avec Nuxt.<br 
 :app-button[Commencer]{ to="/docs/get-started/installation" extraClass="text-black bg-primary-500 hover:bg-primary-400 focus:ring-primary-600 py-4" }
 ::
 
-::home-learn-master
----
-category: Apprendre
----
+## ::home-learn-master
+
+## category: Apprendre
 
 #title
 [_Facile_]{.text-primary} à apprendre. [_Facile_]{.text-primary} à maîtriser
@@ -34,67 +33,100 @@ Tout ce que vous devez savoir, pour passer de débutant à expert.
 :app-button[Commencer le voyage]{href="/docs/get-started/installation" size="medium"}
 ::
 
-::home-features
+## ::home-features
+
+## category: Fonctionnalités
+
+::section-content-item
+
 ---
-category: Fonctionnalités
+
+title: Zero Configuration
+description: "Commencez tout de suite à coder, Nuxt s'occupe du reste."
+image: /img/home/discover/dx/zero-config.svg
+
 ---
-  ::section-content-item
-  ---
-  title: Zero Configuration
-  description: "Commencez tout de suite à coder, Nuxt s'occupe du reste."
-  image: /img/home/discover/dx/zero-config.svg
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: Routing par système de fichiers
-  description: 'Routing automatique et code-splitting sur chaque page.'
-  image: /img/home/discover/dx/file-system-routing.svg
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: Modes de rendu
-  description: "Passez d'une génération statique à un rendu côté serveur à la demande."
-  image: /img/home/discover/dx/hybrid.svg
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: Récupération de données
-  description: "Récupérez votre contenu depuis n'importe quelle source, dans vos composants Vue, prêts pour un rendu serveur."
-  image: /img/home/discover/dx/fetch.svg
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: Conventions fortes
-  description: "Un travail d'équipe efficace avec une structure de dossiers et des conventions fortes."
-  image: /img/home/discover/dx/conventions.svg
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: SEO Friendly
-  description: "Gestion des balises Meta et time-to-content plus rapide pour une bonne indexation."
-  image: /img/home/discover/dx/seo.svg
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: Auto-import des composants
-  description: "Utilisez vos composants, Nuxt les importera avec un code-splitting intelligent."
-  image: /img/home/discover/dx/auto-inject.svg
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: Ecosystème de modules
-  description: "Etendez votre application avec plus de 160 modules Nuxt, et créez le vôtre."
-  image: /img/home/discover/dx/modular.svg
-  ---
+
+::
+::section-content-item
+
 ---
-  ::
+
+title: Routing par système de fichiers
+description: 'Routing automatique et code-splitting sur chaque page.'
+image: /img/home/discover/dx/file-system-routing.svg
+
+---
+
+::
+::section-content-item
+
+---
+
+title: Modes de rendu
+description: "Passez d'une génération statique à un rendu côté serveur à la demande."
+image: /img/home/discover/dx/hybrid.svg
+
+---
+
+::
+::section-content-item
+
+---
+
+title: Récupération de données
+description: "Récupérez votre contenu depuis n'importe quelle source, dans vos composants Vue, prêts pour un rendu serveur."
+image: /img/home/discover/dx/fetch.svg
+
+---
+
+::
+::section-content-item
+
+---
+
+title: Conventions fortes
+description: "Un travail d'équipe efficace avec une structure de dossiers et des conventions fortes."
+image: /img/home/discover/dx/conventions.svg
+
+---
+
+::
+::section-content-item
+
+---
+
+title: SEO Friendly
+description: "Gestion des balises Meta et time-to-content plus rapide pour une bonne indexation."
+image: /img/home/discover/dx/seo.svg
+
+---
+
+::
+::section-content-item
+
+---
+
+title: Auto-import des composants
+description: "Utilisez vos composants, Nuxt les importera avec un code-splitting intelligent."
+image: /img/home/discover/dx/auto-inject.svg
+
+---
+
+::
+::section-content-item
+
+---
+
+title: Ecosystème de modules
+description: "Etendez votre application avec plus de 160 modules Nuxt, et créez le vôtre."
+image: /img/home/discover/dx/modular.svg
+
+---
+
+---
+
+::
 #title
 Intuitive [D]{.text-primary}eveloper E[x]{.text-primary}perience
 
@@ -102,10 +134,9 @@ Intuitive [D]{.text-primary}eveloper E[x]{.text-primary}perience
 Nuxt contient de nombreuses fonctionnalités améliorant l'expérience de développement et l'expérience de l'utilisateur final.
 ::
 
-::home-discover-partners
----
-category: Partenaires
----
+## ::home-discover-partners
+
+## category: Partenaires
 
 #title
 Un [_développement_]{.text-primary} soutenu
@@ -114,83 +145,107 @@ Un [_développement_]{.text-primary} soutenu
 Nuxt est construit et maintenu par des développeurs passionnés mais il serait impossible de fournir les efforts nécessaires pour développer et maintenir de nouvelles fonctionnalités sans une réelle contribution financière. Nous remercions nos sponsors et partenaires qui rendent cela possible.<br>
 
 #partners-card
-  ::home-partners-card
-  ---
-  icon: technology.svg
-  category: technology
-  ---
-  #title
-  Technology partners
+::home-partners-card
 
-  #description
-  Les Technology partners offrent des services aux développeurs Nuxt, tels que CMS, hébergement, base de données, et plus encore...
+---
 
-  #button
-  Découvrez nos Technology Partners
-  ::
+icon: technology.svg
+category: technology
 
-  ::home-partners-card
-  ---
-  icon: agency.svg
-  category: agency
-  ---
-  #title
-  Agency partners
+---
 
-  #description
-  Les Agency partners sont des agences web reconnues qui proposent du support et du développement d'applications avec Nuxt.
+#title
+Technology partners
 
-  #button
-  Trouvez un expert Nuxt
-  ::
+#description
+Les Technology partners offrent des services aux développeurs Nuxt, tels que CMS, hébergement, base de données, et plus encore...
 
-#bottom
-  :app-button[Devenez un partenaire]{href="mailto:partners@nuxtlabs.com"}
+#button
+Découvrez nos Technology Partners
 ::
 
-::home-learn-guides
+::home-partners-card
+
 ---
-category: Apprendre
+
+icon: agency.svg
+category: agency
+
 ---
-  ::section-content-item
-  ---
-  title: Documentation
-  description: "Apprenez les concepts et fonctionnalités de Nuxt, du débutant à l'expert."
-  image: /img/home/learn/guides/gem-1.svg
-  to: '/docs/get-started/installation'
-  hoverClass: 'hover:bg-sky-darker'
-  ---
-  ::
 
-  ::section-content-item
-  ---
-  title: Exemples
-  description: "Apprenez grâce aux exemples créés par la communauté."
-  image: /img/home/learn/guides/gem-2.svg
-  to: '/examples'
-  hoverClass: 'hover:bg-sky-darker'
-  ---
-  ::
+#title
+Agency partners
 
-  ::section-content-item
-  ---
-  title: Notes de version
-  description: "Découvrez ce qui a changé dans chaque mise à jour."
-  image: /img/home/learn/guides/gem-3.svg
-  to: '/releases'
-  hoverClass: 'hover:bg-sky-darker'
-  ---
-  ::
+#description
+Les Agency partners sont des agences web reconnues qui proposent du support et du développement d'applications avec Nuxt.
 
-  ::section-content-item
-  ---
-  title: Master Courses
-  description: 'Visionnez une série complète de vidéos pour apprendre Nuxt avec notre partenaire Vue School.'
-  image: /img/home/learn/guides/gem-4.svg
-  to: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
-  hoverClass: 'hover:bg-sky-darker'
-  ---
-  ::
+#button
+Trouvez un expert Nuxt
+::
+
+#bottom
+:app-button[Devenez un partenaire]{href="mailto:partners@nuxtlabs.com"}
+::
+
+## ::home-learn-guides
+
+## category: Apprendre
+
+::section-content-item
+
+---
+
+title: Documentation
+description: "Apprenez les concepts et fonctionnalités de Nuxt, du débutant à l'expert."
+image: /img/home/learn/guides/gem-1.svg
+to: '/docs/get-started/installation'
+hoverClass: 'hover:bg-sky-darker'
+
+---
+
+::
+
+::section-content-item
+
+---
+
+title: Exemples
+description: "Apprenez grâce aux exemples créés par la communauté."
+image: /img/home/learn/guides/gem-2.svg
+to: '/examples'
+hoverClass: 'hover:bg-sky-darker'
+
+---
+
+::
+
+::section-content-item
+
+---
+
+title: Notes de version
+description: "Découvrez ce qui a changé dans chaque mise à jour."
+image: /img/home/learn/guides/gem-3.svg
+to: '/releases'
+hoverClass: 'hover:bg-sky-darker'
+
+---
+
+::
+
+::section-content-item
+
+---
+
+title: Master Courses
+description: 'Visionnez une série complète de vidéos pour apprendre Nuxt avec notre partenaire Vue School.'
+image: /img/home/learn/guides/gem-4.svg
+to: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
+hoverClass: 'hover:bg-sky-darker'
+
+---
+
+::
 
 #title
 Suivez nos [_Guides_]{.text-primary}
@@ -199,37 +254,49 @@ Suivez nos [_Guides_]{.text-primary}
 From an Idea to a Masterpiece, guides show the path to become a Nuxter.
 ::
 
-::home-explore
+## ::home-explore
+
+## category: Explorez
+
+::section-content-item
+
 ---
-category: Explorez
+
+title: 'Déploiements'
+description: "Étendez et automatisez votre flux de travail en utilisant les déploiements pour vos outils préférés."
+image: '/img/home/explore/gem-explore-1.svg'
+to: '/deployments'
+hoverClass: 'hover:bg-sky-surface'
+
 ---
-  ::section-content-item
-  ---
-  title: 'Déploiements'
-  description: "Étendez et automatisez votre flux de travail en utilisant les déploiements pour vos outils préférés."
-  image: '/img/home/explore/gem-explore-1.svg'
-  to: '/deployments'
-  hoverClass: 'hover:bg-sky-surface'
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: 'Modules'
-  description: "Découvrez la liste des modules pour étendre vos projects Nuxt. Créés par l'équipe de Nuxt et sa communauté"
-  image: '/img/home/explore/gem-explore-2.svg'
-  to: '/modules'
-  hoverClass: 'hover:bg-sky-surface'
-  ---
-  ::
-  ::section-content-item
-  ---
-  title: 'Themes'
-  description: "Découvrez comment une application du monde réel est construite à l'aide de Nuxt avec les thèmes construits par nos partenaires."
-  image: '/img/home/explore/gem-explore-3.svg'
-  to: '/themes'
-  hoverClass: 'hover:bg-sky-surface'
-  ---
-  ::
+
+::
+::section-content-item
+
+---
+
+title: 'Modules'
+description: "Découvrez la liste des modules pour étendre vos projects Nuxt. Créés par l'équipe de Nuxt et sa communauté"
+image: '/img/home/explore/gem-explore-2.svg'
+to: 'https://modules.nuxtjs.org'
+hoverClass: 'hover:bg-sky-surface'
+
+---
+
+::
+::section-content-item
+
+---
+
+title: 'Themes'
+description: "Découvrez comment une application du monde réel est construite à l'aide de Nuxt avec les thèmes construits par nos partenaires."
+image: '/img/home/explore/gem-explore-3.svg'
+to: '/themes'
+hoverClass: 'hover:bg-sky-surface'
+
+---
+
+::
 
 #title
 Besoin d'aller plus loin ? Il y a tellement à [_Explorer_]{.text-primary}
@@ -239,12 +306,13 @@ Nuxt a beaucoup de dimensions à explorer, apprenez par l'exemple, intégrez des
 
 ::
 
-::home-community
----
+## ::home-community
+
 category: Communauté
 announcementsCategory: Annonces
 eventsCategory: Evénements
 articleLinkTitle: Informations
+
 ---
 
 #title
@@ -254,10 +322,10 @@ Sharing is [_Caring_]{.text-primary}
 Lisez nos articles rédigés par l'équipe Nuxt et la communauté, trucs et astuces inclus !
 ::
 
-::home-testimonials
----
-category: Communauté
----
+## ::home-testimonials
+
+## category: Communauté
+
 #title
 Témoignages
 
@@ -265,9 +333,13 @@ Témoignages
 Apprenez ce que les experts aiment chez Nuxt.
 
 #testimonials
-  :::testimonials
-  ---
-  home: true
-  ---
-  :::
+:::testimonials
+
+---
+
+home: true
+
+---
+
+:::
 ::

--- a/content/ja/_collections/navigations/footer.md
+++ b/content/ja/_collections/navigations/footer.md
@@ -1,81 +1,55 @@
 ---
 links:
-  -
-    title: '私たちについて'
+  - title: '私たちについて'
     items:
-      -
-        title: '連絡先'
+      - title: '連絡先'
         href: 'mailto:hello@nuxtjs.com'
-      -
-        title: 'エンタープライズサポート'
+      - title: 'エンタープライズサポート'
         to: '/support'
-      -
-        title: 'NuxtLabs について'
+      - title: 'NuxtLabs について'
         href: 'https://nuxtlabs.com/'
-      -
-        title: 'オープンソースソフトウェア'
+      - title: 'オープンソースソフトウェア'
         href: 'https://github.com/nuxt'
-      -
-        title: 'パートナーシップ'
+      - title: 'パートナーシップ'
         to: '/partners'
-      -
-        title: 'テレメトリ'
+      - title: 'テレメトリ'
         href: 'https://github.com/nuxt/telemetry'
-  -
-    title: 'エコシステム'
+  - title: 'エコシステム'
     items:
-      -
-        title: 'お知らせ'
+      - title: 'お知らせ'
         to: '/announcements'
-      -
-        title: '貢献'
+      - title: '貢献'
         to: '/contribution-guide'
-      -
-        title: 'チャット'
+      - title: 'チャット'
         href: 'https://discord.nuxtjs.org/'
-      -
-        title: 'イベント'
+      - title: 'イベント'
         to: '/events'
-      -
-        title: 'スポンサー'
+      - title: 'スポンサー'
         to: '/sponsors'
-      -
-        title: 'チーム'
+      - title: 'チーム'
         to: '/teams'
-      -
-        title: 'チュートリアル'
+      - title: 'チュートリアル'
         to: '/tutorials'
-      -
-        title: 'ビデオコース'
+      - title: 'ビデオコース'
         to: '/video-courses'
-  -
-    title: 'リソース'
+  - title: 'リソース'
     items:
-      -
-        title: 'デザイン'
+      - title: 'デザイン'
         to: '/design'
-      -
-        title: 'ドキュメント'
+      - title: 'ドキュメント'
         to: '/docs'
-      -
-        title: '例'
+      - title: '例'
         to: '/examples'
-      -
-        title: 'デプロイ'
+      - title: 'デプロイ'
         to: '/deployments'
-      -
-        title: 'マスターコース'
+      - title: 'マスターコース'
         href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
-      -
-        title: 'モジュール'
-        to: '/modules'
-      -
-        title: 'リリース'
+      - title: 'モジュール'
+        href: 'https://modules.nuxtjs.org'
+      - title: 'リリース'
         to: '/releases'
-      -
-        title: '導入事例'
+      - title: '導入事例'
         to: '/showcases'
-      -
-        title: 'テーマ'
+      - title: 'テーマ'
         to: '/themes'
 ---

--- a/content/ja/_collections/navigations/header.md
+++ b/content/ja/_collections/navigations/header.md
@@ -1,136 +1,113 @@
 ---
 links:
-  -
-    title: '見る'
+  - title: '見る'
     items:
-      -
-        title: "導入事例"
-        subtitle: "Nuxt で作られた Web サイトセレクション"
-        slug: "showcases"
-        to: "/showcases"
-        icon: "showcases.svg"
-        color: "bg-sand"
-      -
-        title: "事例紹介"
-        subtitle: "企業による Nuxt の活用方法"
-        slug: "case-studies"
-        to: "/case-studies"
-        icon: "case-studies.svg"
-        color: "bg-sand-dark"
-      -
-        title: "著名人の声"
-        subtitle: "私たちのことをどう思っているのか"
-        slug: "testimonials"
-        to: "/testimonials"
-        icon: "testimonials.svg"
-        color: "bg-sand-darker"
-  -
-    title: '学ぶ'
+      - title: '導入事例'
+        subtitle: 'Nuxt で作られた Web サイトセレクション'
+        slug: 'showcases'
+        to: '/showcases'
+        icon: 'showcases.svg'
+        color: 'bg-sand'
+      - title: '事例紹介'
+        subtitle: '企業による Nuxt の活用方法'
+        slug: 'case-studies'
+        to: '/case-studies'
+        icon: 'case-studies.svg'
+        color: 'bg-sand-dark'
+      - title: '著名人の声'
+        subtitle: '私たちのことをどう思っているのか'
+        slug: 'testimonials'
+        to: '/testimonials'
+        icon: 'testimonials.svg'
+        color: 'bg-sand-darker'
+  - title: '学ぶ'
     items:
-      -
-        title: "ドキュメント"
-        subtitle: "高速な Web サイトを簡単に作成する"
-        slug: "docs"
-        to: "/docs"
-        icon: "docs.svg"
-        color: "bg-green-500"
-      -
-        title: "例"
-        subtitle: "Nuxt のすべてを理解する"
-        slug: "examples"
-        to: "/examples"
-        icon: "examples.svg"
-        color: "bg-green-600"
-      -
-        title: "チュートリアル"
-        subtitle: "具体的なケースで学習する"
-        slug: "tutorials"
-        to: "/tutorials"
-        icon: "tutorials.svg"
-        color: "bg-green-700"
-      -
-        title: "マスターコース"
-        subtitle: "エキスパートといっしょにもっと学習する"
-        href: "https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite"
-        icon: "master-courses.svg"
-        color: "bg-green-800"
-  -
-    title: '探す'
+      - title: 'ドキュメント'
+        subtitle: '高速な Web サイトを簡単に作成する'
+        slug: 'docs'
+        to: '/docs'
+        icon: 'docs.svg'
+        color: 'bg-green-500'
+      - title: '例'
+        subtitle: 'Nuxt のすべてを理解する'
+        slug: 'examples'
+        to: '/examples'
+        icon: 'examples.svg'
+        color: 'bg-green-600'
+      - title: 'チュートリアル'
+        subtitle: '具体的なケースで学習する'
+        slug: 'tutorials'
+        to: '/tutorials'
+        icon: 'tutorials.svg'
+        color: 'bg-green-700'
+      - title: 'マスターコース'
+        subtitle: 'エキスパートといっしょにもっと学習する'
+        href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
+        icon: 'master-courses.svg'
+        color: 'bg-green-800'
+  - title: '探す'
     items:
-      -
-        title: "デプロイ"
-        subtitle: "Nuxt のデプロイの仕方"
-        slug: "deployments"
-        to: "/deployments"
-        icon: "deployments.svg"
-        color: "bg-indigo-light"
-      -
-        title: "モジュール"
-        subtitle: "Nuxt のパワーを拡張する"
-        slug: "modules"
-        to: "/modules"
-        icon: "modules.svg"
-        color: "bg-indigo"
-      -
-        title: "テーマ"
-        subtitle: "テーマで始める"
-        slug: "themes"
-        to: "/themes"
-        icon: "themes.svg"
-        color: "bg-indigo-dark"
-      -
-        title: "ビデオコース"
-        subtitle: "ステップバイステップで学習する"
-        slug: "video-courses"
-        to: "/video-courses"
-        icon: "video-courses.svg"
-        color: "bg-indigo-darker"
-  -
-    title: 'コミュニティ'
+      - title: 'デプロイ'
+        subtitle: 'Nuxt のデプロイの仕方'
+        slug: 'deployments'
+        to: '/deployments'
+        icon: 'deployments.svg'
+        color: 'bg-indigo-light'
+      - title: 'モジュール'
+        subtitle: 'Nuxt のパワーを拡張する'
+        href: 'https://modules.nuxtjs.org'
+        icon: 'modules.svg'
+        color: 'bg-indigo'
+      - title: 'テーマ'
+        subtitle: 'テーマで始める'
+        slug: 'themes'
+        to: '/themes'
+        icon: 'themes.svg'
+        color: 'bg-indigo-dark'
+      - title: 'ビデオコース'
+        subtitle: 'ステップバイステップで学習する'
+        slug: 'video-courses'
+        to: '/video-courses'
+        icon: 'video-courses.svg'
+        color: 'bg-indigo-darker'
+  - title: 'コミュニティ'
     items:
-      -
-        title: "お知らせ"
-        subtitle: "Nuxt について最新ニュース"
-        slug: "announcements"
-        to: "/announcements"
-        icon: "announcements.svg"
-        color: "bg-mint-light"
-      -
-        title: "チーム"
-        subtitle: "They are Nuxt"
-        slug: "teams"
-        to: "/teams"
-        icon: "teams.svg"
-        color: "bg-mint-light"
-      -
-        title: "イベント"
-        subtitle: "いつ、そしてどこで開催されるのか"
-        slug: "events"
-        to: "/events"
-        icon: "events.svg"
-        color: "bg-mint"
-      -
-        title: "リリース"
-        subtitle: "私たちがリリースしたすべてのコード"
-        slug: "releases"
-        to: "/releases"
-        icon: "releases.svg"
-        color: "bg-mint"
-      -
-        title: "スポンサー"
-        subtitle: "私たちを信頼しています"
-        slug: "sponsors"
-        to: "/sponsors"
-        icon: "sponsors.svg"
-        color: "bg-mint-dark"
-      -
-        title: "ツイート"
-        subtitle: "私たちについて話しています"
-        href: "https://twitter.com/nuxt_js/timelines/1439936107421085704"
-        icon: "tweets.svg"
-        color: "bg-mint-dark"
-  -
-    title: "パートナー"
-    slug: "partners"
-    to: "/partners"
+      - title: 'お知らせ'
+        subtitle: 'Nuxt について最新ニュース'
+        slug: 'announcements'
+        to: '/announcements'
+        icon: 'announcements.svg'
+        color: 'bg-mint-light'
+      - title: 'チーム'
+        subtitle: 'They are Nuxt'
+        slug: 'teams'
+        to: '/teams'
+        icon: 'teams.svg'
+        color: 'bg-mint-light'
+      - title: 'イベント'
+        subtitle: 'いつ、そしてどこで開催されるのか'
+        slug: 'events'
+        to: '/events'
+        icon: 'events.svg'
+        color: 'bg-mint'
+      - title: 'リリース'
+        subtitle: '私たちがリリースしたすべてのコード'
+        slug: 'releases'
+        to: '/releases'
+        icon: 'releases.svg'
+        color: 'bg-mint'
+      - title: 'スポンサー'
+        subtitle: '私たちを信頼しています'
+        slug: 'sponsors'
+        to: '/sponsors'
+        icon: 'sponsors.svg'
+        color: 'bg-mint-dark'
+      - title: 'ツイート'
+        subtitle: '私たちについて話しています'
+        href: 'https://twitter.com/nuxt_js/timelines/1439936107421085704'
+        icon: 'tweets.svg'
+        color: 'bg-mint-dark'
+  - title: 'パートナー'
+    slug: 'partners'
+    to: '/partners'
 ---

--- a/content/ja/index.md
+++ b/content/ja/index.md
@@ -19,10 +19,9 @@ Nuxt を使って信頼ある次世代の Vue.js アプリケーションを構�
 :app-button[はじめる]{ to="/docs/get-started/installation" extraClass="text-black bg-primary-500 hover:bg-primary-400 focus:ring-primary-600 py-4" }
 ::
 
-::home-learn-master
----
-category: 学ぶ
----
+## ::home-learn-master
+
+## category: 学ぶ
 
 #title
 学習も[簡単]{.text-primary}、マスターも[簡単]{.text-primary}
@@ -34,73 +33,88 @@ Nuxt コミュニティに参加し私達を助け Nuxtify な世界にします
 :app-button[全てを学習する]{to="/docs/get-started/installation"}
 ::
 
-::home-features
----
-category: 機能
----
+## ::home-features
 
-::section-content-item
----
+## category: 機能
+
+## ::section-content-item
+
 title: ゼロコンフィグレーション
 description: '素早くアプリケーションのコーディングを開始し、Nuxt が面倒を見てくれます。'
 image: /img/home/discover/dx/zero-config.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: ファイルシステムルーティング
 description: '自動ルーティングとページごとにコード分割します。'
 image: /img/home/discover/dx/file-system-routing.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: レンダリングモード
 description: '静的サイト生成とオンデマンドのサーバーレンダリングを切り替えることができます。'
 image: /img/home/discover/dx/hybrid.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: データフェッチング
 description: 'SSR に対応した Vue コンポーネントで、任意のソースからコンテンツを取得できます。'
 image: /img/home/discover/dx/fetch.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: 強力な規約
 description: '強力なディレクトリ構造と規約による効率的なチームワーク。'
 image: /img/home/discover/dx/conventions.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: SEO フレンドリー
 description: 'メタタグ管理と優れたインデックスに対して速いコンテンツへの到達時間を実現。'
 image: /img/home/discover/dx/seo.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: コンポーネント自動インポート
 description: 'コンポーネントを使って、Nuxt はそれらをスマートなコード分割によってインポートします。'
 image: /img/home/discover/dx/auto-inject.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: モジュールエコシステム
-description: '160以上による Nuxt モジュールでアプリケーションを拡張し、あなた自身で作成できます。'
+description: '160 以上による Nuxt モジュールでアプリケーションを拡張し、あなた自身で作成できます。'
 image: /img/home/discover/dx/modular.svg
+
 ---
+
 ::
 
 #title
@@ -110,10 +124,9 @@ image: /img/home/discover/dx/modular.svg
 Nuxt は開発者の生産性やエンドユーザーの体験を向上させるための機能が数多く搭載されています。
 ::
 
-::home-discover-partners
----
-category: パートナー
----
+## ::home-discover-partners
+
+## category: パートナー
 
 #title
 持続可能な[開発]{.text-primary}
@@ -122,83 +135,98 @@ category: パートナー
 Nuxt の開発は情熱を持った開発者によって作られますが、メンテナンスするための必要な労力と新機能開発には、適切な資金のサポートなしには持続できません。これを可能にするのは、スポンサーやパートナーの皆様のおかげです。<br>
 
 #partners-card
-  ::home-partners-card
-  ---
-  icon: technology.svg
-  category: technology
-  ---
-  #title
-  テクノロジーパートナー
+::home-partners-card
 
-  #description
-  テクノロジーパートナーは、CMS、ホスティング、データベースなど、Nuxt 開発者を支援するサービスを提供しています。
+---
 
-  #button
-  私達のテクノロジーパートナーを見つける
-  ::
+icon: technology.svg
+category: technology
 
-  ::home-partners-card
-  ---
-  icon: agency.svg
-  category: agency
-  ---
-  #title
-  代理店パートナー
+---
 
-  #description
-  代理店パートナーはあなたのプロジェクトに Nuxt を使った開発を提供する信頼された Web そして代理店です。
+#title
+テクノロジーパートナー
 
-  #button
-  Nuxt エキスパートを探す
-  ::
+#description
+テクノロジーパートナーは、CMS、ホスティング、データベースなど、Nuxt 開発者を支援するサービスを提供しています。
 
-#bottom
-  :app-button[Become a partner]{href="mailto:partners@nuxtlabs.com"}
+#button
+私達のテクノロジーパートナーを見つける
 ::
 
-::home-learn-guides
----
-category: 学ぶ
+::home-partners-card
+
 ---
 
-::section-content-item
+icon: agency.svg
+category: agency
+
 ---
+
+#title
+代理店パートナー
+
+#description
+代理店パートナーはあなたのプロジェクトに Nuxt を使った開発を提供する信頼された Web そして代理店です。
+
+#button
+Nuxt エキスパートを探す
+::
+
+#bottom
+:app-button[Become a partner]{href="mailto:partners@nuxtlabs.com"}
+::
+
+## ::home-learn-guides
+
+## category: 学ぶ
+
+## ::section-content-item
+
 title: ドキュメント
 description: 'Nuxt のすべてのコンセプトを理解し、完全な API リファレンスを見つけることができます。'
 image: /img/home/learn/guides/gem-1.svg
 to: '/docs/get-started/installation'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: 例
 description: "コミュニティによって提供された例を使って学ぶことができます。"
 image: /img/home/learn/guides/gem-2.svg
 to: '/examples'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: リリース
 description: '何が変わったのかを確認してからアップグレードすることができます。'
 image: /img/home/learn/guides/gem-3.svg
 to: '/releases'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: マスタリングコース
 description: 'パートナーの Vue School と一緒に Nuxt を学ぶための完全なビデオシリーズをご覧ください。'
 image: /img/home/learn/guides/gem-4.svg
 to: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
 #title
@@ -208,37 +236,46 @@ hoverClass: 'hover:bg-sky-darker'
 着想から名作まで、ガイドは Nuxter になるためのパスを示します。
 ::
 
-::home-explore
----
-category: 探す
----
+## ::home-explore
 
-::section-content-item
----
+## category: 探す
+
+## ::section-content-item
+
 title: 'インテグレーション'
 description: 'お気に入りのツールの統合を利用して、ワークフローを拡張、自動化することができます。'
 image: '/img/home/explore/gem-explore-1.svg'
 to: '/deployments'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 ::section-content-item
+
 ---
+
 title: 'モジュール'
 description: 'あなたの Nuxt プロジェクトを強化するモジュールのリストをご覧ください。Nuxt チームとコミュニティによって作られています。'
 image: '/img/home/explore/gem-explore-2.svg'
-to: '/modules'
+to: 'https://modules.nuxtjs.org'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 ::section-content-item
+
 ---
+
 title: 'テーマ'
 description: 'パートナー企業が構築したテーマを使って、Nuxt スタックを使った実世界のアプリケーションがどのように構築されているかをご覧ください。'
 image: '/img/home/explore/gem-explore-3.svg'
 to: '/themes'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 
 #title
@@ -248,12 +285,13 @@ hoverClass: 'hover:bg-sky-surface'
 Nuxt には、例で学習したり、お気に入りのプロバイダと統合したり、そしてテーマを使ってすぐに始められる領域がたくさんあります。
 ::
 
-::home-community
----
+## ::home-community
+
 category: コミュニティ
 announcementsCategory: お知らせ
 eventsCategory: イベント
 articleLinkTitle: 情報を得る
+
 ---
 
 #title
@@ -263,20 +301,24 @@ articleLinkTitle: 情報を得る
 Nuxt チームと Nuxt コミュニティによる、Nuxt のヒントややり方に関する記事をご覧ください！
 ::
 
-::home-testimonials
----
-category: コミュニティ
----
+## ::home-testimonials
+
+## category: コミュニティ
+
 #title
 著名人の声
 
 #description
-エキスパートが語るNuxtの魅力とは？
+エキスパートが語る Nuxt の魅力とは？
 
 #testimonials
-  :::testimonials
-  ---
-  home: true
-  ---
-  :::
+:::testimonials
+
+---
+
+home: true
+
+---
+
+:::
 ::

--- a/content/pt/_collections/navigations/footer.md
+++ b/content/pt/_collections/navigations/footer.md
@@ -1,81 +1,55 @@
 ---
 links:
-  -
-    title: 'About'
+  - title: 'About'
     items:
-      -
-        title: 'Contact us'
+      - title: 'Contact us'
         href: 'mailto:hello@nuxtjs.com'
-      -
-        title: 'Enterprise support'
+      - title: 'Enterprise support'
         to: '/support'
-      -
-        title: 'NuxtLabs company'
+      - title: 'NuxtLabs company'
         href: 'https://nuxtlabs.com/'
-      -
-        title: 'Open Source Software'
+      - title: 'Open Source Software'
         href: 'https://github.com/nuxt'
-      -
-        title: 'Partnerships'
+      - title: 'Partnerships'
         to: '/partners'
-      -
-        title: 'Telemetry'
+      - title: 'Telemetry'
         href: 'https://github.com/nuxt/telemetry'
-  -
-    title: 'Ecosystem'
+  - title: 'Ecosystem'
     items:
-      -
-        title: 'Announcements'
+      - title: 'Announcements'
         to: '/announcements'
-      -
-        title: 'Contribute'
+      - title: 'Contribute'
         to: '/contribution-guide'
-      -
-        title: 'Chat with us'
+      - title: 'Chat with us'
         href: 'https://discord.nuxtjs.org/'
-      -
-        title: 'Events'
+      - title: 'Events'
         to: '/events'
-      -
-        title: 'Sponsors'
+      - title: 'Sponsors'
         to: '/sponsors'
-      -
-        title: 'Teams'
+      - title: 'Teams'
         to: '/teams'
-      -
-        title: 'Tutorials'
+      - title: 'Tutorials'
         to: '/tutorials'
-      -
-        title: 'Video courses'
+      - title: 'Video courses'
         to: '/video-courses/'
-  -
-    title: 'Resources'
+  - title: 'Resources'
     items:
-      -
-        title: 'Design'
+      - title: 'Design'
         to: '/design'
-      -
-        title: 'Documentation'
+      - title: 'Documentation'
         to: '/docs'
-      -
-        title: 'Examples'
+      - title: 'Examples'
         to: '/examples'
-      -
-        title: 'Deployments'
+      - title: 'Deployments'
         to: '/deployments'
-      -
-        title: 'Master courses'
+      - title: 'Master courses'
         href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
-      -
-        title: 'Modules'
-        to: '/modules'
-      -
-        title: 'Releases'
+      - title: 'Modules'
+        href: 'https://modules.nuxtjs.org'
+      - title: 'Releases'
         to: '/releases'
-      -
-        title: 'Showcases'
+      - title: 'Showcases'
         to: '/showcases'
-      -
-        title: 'Themes'
+      - title: 'Themes'
         to: '/themes'
 ---

--- a/content/pt/_collections/navigations/header.md
+++ b/content/pt/_collections/navigations/header.md
@@ -1,136 +1,113 @@
 ---
 links:
-  -
-    title: "Discover"
+  - title: 'Discover'
     items:
-      -
-        title: "Showcases"
-        subtitle: "Selection of website built with Nuxt"
-        slug: "showcases"
-        to: "/showcases"
-        icon: "showcases.svg"
-        color: "bg-sand"
-      -
-        title: "Case studies"
-        subtitle: "How companies use Nuxt"
-        slug: "case-studies"
-        to: "/case-studies"
-        icon: "case-studies.svg"
-        color: "bg-sand-dark"
-      -
-        title: "Testimonials"
-        subtitle: "What they think about us"
-        slug: "testimonials"
-        to: "/testimonials"
-        icon: "testimonials.svg"
-        color: "bg-sand-darker"
-  -
-    title: "Learn"
+      - title: 'Showcases'
+        subtitle: 'Selection of website built with Nuxt'
+        slug: 'showcases'
+        to: '/showcases'
+        icon: 'showcases.svg'
+        color: 'bg-sand'
+      - title: 'Case studies'
+        subtitle: 'How companies use Nuxt'
+        slug: 'case-studies'
+        to: '/case-studies'
+        icon: 'case-studies.svg'
+        color: 'bg-sand-dark'
+      - title: 'Testimonials'
+        subtitle: 'What they think about us'
+        slug: 'testimonials'
+        to: '/testimonials'
+        icon: 'testimonials.svg'
+        color: 'bg-sand-darker'
+  - title: 'Learn'
     items:
-      -
-        title: "Docs"
-        subtitle: "Create fast websites easily"
-        slug: "docs"
-        to: "/docs"
-        icon: "docs.svg"
-        color: "bg-green-500"
-      -
-        title: "Examples"
-        subtitle: "Understand everything in Nuxt"
-        slug: "examples"
-        to: "/examples"
-        icon: "examples.svg"
-        color: "bg-green-600"
-      -
-        title: "Tutorials"
-        subtitle: "Learn with concrete cases"
-        slug: "tutorials"
-        to: "/tutorials"
-        icon: "tutorials.svg"
-        color: "bg-green-700"
-      -
-        title: "Master courses"
-        subtitle: "Learn more with experts"
-        href: "https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite"
-        icon: "master-courses.svg"
-        color: "bg-green-800"
-  -
-    title: "Explore"
+      - title: 'Docs'
+        subtitle: 'Create fast websites easily'
+        slug: 'docs'
+        to: '/docs'
+        icon: 'docs.svg'
+        color: 'bg-green-500'
+      - title: 'Examples'
+        subtitle: 'Understand everything in Nuxt'
+        slug: 'examples'
+        to: '/examples'
+        icon: 'examples.svg'
+        color: 'bg-green-600'
+      - title: 'Tutorials'
+        subtitle: 'Learn with concrete cases'
+        slug: 'tutorials'
+        to: '/tutorials'
+        icon: 'tutorials.svg'
+        color: 'bg-green-700'
+      - title: 'Master courses'
+        subtitle: 'Learn more with experts'
+        href: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
+        icon: 'master-courses.svg'
+        color: 'bg-green-800'
+  - title: 'Explore'
     items:
-      -
-        title: "Deployments"
-        subtitle: "How to Deploy Nuxt"
-        slug: "deployments"
-        to: "/deployments"
-        icon: "deployments.svg"
-        color: "bg-indigo-light"
-      -
-        title: "Modules"
-        subtitle: "Extend the power of Nuxt"
-        slug: "modules"
-        to: "/modules"
-        icon: "modules.svg"
-        color: "bg-indigo"
-      -
-        title: "Themes"
-        subtitle: "Get started with themes"
-        slug: "themes"
-        to: "/themes"
-        icon: "themes.svg"
-        color: "bg-indigo-dark"
-      -
-        title: "Video Courses"
-        subtitle: "Learn step by step"
-        slug: "video-courses"
-        to: "/video-courses"
-        icon: "video-courses.svg"
-        color: "bg-indigo-darker"
-  -
-    title: "Community"
+      - title: 'Deployments'
+        subtitle: 'How to Deploy Nuxt'
+        slug: 'deployments'
+        to: '/deployments'
+        icon: 'deployments.svg'
+        color: 'bg-indigo-light'
+      - title: 'Modules'
+        subtitle: 'Extend the power of Nuxt'
+        href: 'https://modules.nuxtjs.org'
+        icon: 'modules.svg'
+        color: 'bg-indigo'
+      - title: 'Themes'
+        subtitle: 'Get started with themes'
+        slug: 'themes'
+        to: '/themes'
+        icon: 'themes.svg'
+        color: 'bg-indigo-dark'
+      - title: 'Video Courses'
+        subtitle: 'Learn step by step'
+        slug: 'video-courses'
+        to: '/video-courses'
+        icon: 'video-courses.svg'
+        color: 'bg-indigo-darker'
+  - title: 'Community'
     items:
-      -
-        title: "Announcements"
-        subtitle: "Last news about Nuxt"
-        slug: "announcements"
-        to: "/announcements"
-        icon: "announcements.svg"
-        color: "bg-mint-light"
-      -
-        title: "Teams"
-        subtitle: "They are Nuxt"
-        slug: "teams"
-        to: "/teams"
-        icon: "teams.svg"
-        color: "bg-mint-light"
-      -
-        title: "Events"
-        subtitle: "When and where we gonna be"
-        slug: "events"
-        to: "/events"
-        icon: "events.svg"
-        color: "bg-mint"
-      -
-        title: "Releases"
-        subtitle: "All the code we released"
-        slug: "releases"
-        to: "/releases"
-        icon: "releases.svg"
-        color: "bg-mint"
-      -
-        title: "Sponsors"
-        subtitle: "They trust us"
-        slug: "sponsors"
-        to: "/sponsors"
-        icon: "sponsors.svg"
-        color: "bg-mint-dark"
-      -
-        title: "Tweets"
-        subtitle: "They talk about us"
-        href: "https://twitter.com/nuxt_js/timelines/1439936107421085704"
-        icon: "tweets.svg"
-        color: "bg-mint-dark"
-  -
-    title: "Partners"
-    slug: "partners"
-    to: "/partners"
+      - title: 'Announcements'
+        subtitle: 'Last news about Nuxt'
+        slug: 'announcements'
+        to: '/announcements'
+        icon: 'announcements.svg'
+        color: 'bg-mint-light'
+      - title: 'Teams'
+        subtitle: 'They are Nuxt'
+        slug: 'teams'
+        to: '/teams'
+        icon: 'teams.svg'
+        color: 'bg-mint-light'
+      - title: 'Events'
+        subtitle: 'When and where we gonna be'
+        slug: 'events'
+        to: '/events'
+        icon: 'events.svg'
+        color: 'bg-mint'
+      - title: 'Releases'
+        subtitle: 'All the code we released'
+        slug: 'releases'
+        to: '/releases'
+        icon: 'releases.svg'
+        color: 'bg-mint'
+      - title: 'Sponsors'
+        subtitle: 'They trust us'
+        slug: 'sponsors'
+        to: '/sponsors'
+        icon: 'sponsors.svg'
+        color: 'bg-mint-dark'
+      - title: 'Tweets'
+        subtitle: 'They talk about us'
+        href: 'https://twitter.com/nuxt_js/timelines/1439936107421085704'
+        icon: 'tweets.svg'
+        color: 'bg-mint-dark'
+  - title: 'Partners'
+    slug: 'partners'
+    to: '/partners'
 ---

--- a/content/pt/index.md
+++ b/content/pt/index.md
@@ -19,10 +19,9 @@ Build your next Vue.js application with confidence using Nuxt.<br class="hidden 
 :app-button[Get started]{ to="/docs/get-started/installation" extraClass="text-black bg-primary-500 hover:bg-primary-400 focus:ring-primary-600 py-4" }
 ::
 
-::home-learn-master
----
-category: Learn
----
+## ::home-learn-master
+
+## category: Learn
 
 #title
 [Easy]{.text-primary} to learn. [Easy]{.text-primary} to master
@@ -34,73 +33,88 @@ Learn everything you need to know, from beginner to master.
 :app-button[Start learning]{to="/docs/get-started/installation"}
 ::
 
-::home-features
----
-category: Features
----
+## ::home-features
 
-::section-content-item
----
+## category: Features
+
+## ::section-content-item
+
 title: Zero Configuration
 description: 'Start coding your app right away, Nuxt takes care of the rest.'
 image: /img/home/discover/dx/zero-config.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: File-system Routing
 description: 'Automatic routing and code-splitting for every page.'
 image: /img/home/discover/dx/file-system-routing.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Rendering Modes
 description: 'Switch between static-site generation or on-demand server rendering.'
 image: /img/home/discover/dx/hybrid.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Data Fetching
 description: 'Fetch your content from any source in your Vue components, SSR ready.'
 image: /img/home/discover/dx/fetch.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Strong Conventions
 description: 'Efficient teamwork with a strong directory structure and conventions.'
 image: /img/home/discover/dx/conventions.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: SEO Friendly
 description: 'Meta tag management and faster time-to-content for great indexing.'
 image: /img/home/discover/dx/seo.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Components Auto-import
 description: 'Use your components, Nuxt will import them with smart code-splitting.'
 image: /img/home/discover/dx/auto-inject.svg
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Modules Ecosystem
 description: 'Extend your app with 160+ Nuxt modules and create your own.'
 image: /img/home/discover/dx/modular.svg
+
 ---
+
 ::
 
 #title
@@ -110,10 +124,9 @@ Intuitive [D]{.text-primary}eveloper E[x]{.text-primary}perience
 Nuxt is shipped with plenty of features to boost developer productivity and the end user experience.
 ::
 
-::home-discover-partners
----
-category: Partners
----
+## ::home-discover-partners
+
+## category: Partners
 
 #title
 Sustainable [_Development_]{.text-primary}
@@ -122,83 +135,98 @@ Sustainable [_Development_]{.text-primary}
 Nuxt development is carried out by passionate developers, but the amount of effort needed to maintain and develop new features is not sustainable without proper financial backing. We are thankful for our sponsors and partners, who help make Nuxt possible.<br>
 
 #partners-card
-  ::home-partners-card
-  ---
-  icon: technology.svg
-  category: technology
-  ---
-  #title
-  Technology partners
+::home-partners-card
 
-  #description
-  Technology partners offer services that empower Nuxt developers, such as CMS, Hosting, Database, and more.
+---
 
-  #button
-  Discover our technology partners
-  ::
+icon: technology.svg
+category: technology
 
-  ::home-partners-card
-  ---
-  icon: agency.svg
-  category: agency
-  ---
-  #title
-  Agency partners
+---
 
-  #description
-  Agency partners are trusted web and consulting agencies that can provide Nuxt development and support for your projects.
+#title
+Technology partners
 
-  #button
-  Find a Nuxt expert
-  ::
+#description
+Technology partners offer services that empower Nuxt developers, such as CMS, Hosting, Database, and more.
 
-#bottom
-  :app-button[Become a partner]{href="mailto:partners@nuxtlabs.com"}
+#button
+Discover our technology partners
 ::
 
-::home-learn-guides
----
-category: Learn
+::home-partners-card
+
 ---
 
-::section-content-item
+icon: agency.svg
+category: agency
+
 ---
+
+#title
+Agency partners
+
+#description
+Agency partners are trusted web and consulting agencies that can provide Nuxt development and support for your projects.
+
+#button
+Find a Nuxt expert
+::
+
+#bottom
+:app-button[Become a partner]{href="mailto:partners@nuxtlabs.com"}
+::
+
+## ::home-learn-guides
+
+## category: Learn
+
+## ::section-content-item
+
 title: Documentation
 description: 'Discover Nuxt concepts and find a complete API reference.'
 image: /img/home/learn/guides/gem-1.svg
 to: '/docs/get-started/installation'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Examples
 description: "Learn by examples produced by the community."
 image: /img/home/learn/guides/gem-2.svg
 to: '/examples'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Releases
 description: 'Find out what has changed before upgrading.'
 image: /img/home/learn/guides/gem-3.svg
 to: '/releases'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
-::section-content-item
----
+## ::section-content-item
+
 title: Master Courses
 description: 'Watch a complete series of videos to learn Nuxt with our partner Vue School.'
 image: /img/home/learn/guides/gem-4.svg
 to: 'https://masteringnuxt.com/?utm_source=nuxt&utm_medium=link&utm_campaign=nsite'
 hoverClass: 'hover:bg-sky-darker'
+
 ---
+
 ::
 
 #title
@@ -208,37 +236,46 @@ Follow our [_Guides_]{.text-primary}
 From an idea to a masterpiece, guides take you on the path to becoming a Nuxter.
 ::
 
-::home-explore
----
-category: Explore
----
+## ::home-explore
 
-::section-content-item
----
+## category: Explore
+
+## ::section-content-item
+
 title: 'Deployments'
 description: 'Extend and automate your workflow by using deployments for your favorite tools.'
 image: '/img/home/explore/gem-explore-1.svg'
 to: '/deployments'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 ::section-content-item
+
 ---
+
 title: 'Modules'
 description: 'Discover our list of modules to supercharge your Nuxt project. Created by the Nuxt team and community.'
 image: '/img/home/explore/gem-explore-2.svg'
-to: '/modules'
+to: 'https://modules.nuxtjs.org'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 ::section-content-item
+
 ---
+
 title: 'Themes'
 description: 'See how a real world application is built using the Nuxt stack with the themes built by our partners.'
 image: '/img/home/explore/gem-explore-3.svg'
 to: '/themes'
 hoverClass: 'hover:bg-sky-surface'
+
 ---
+
 ::
 
 #title
@@ -248,12 +285,13 @@ Moving forward? So much to [_Explore_]{.text-primary}
 Discover powerful modules, integrate with your favorite providers and start quickly with themes.
 ::
 
-::home-community
----
+## ::home-community
+
 category: Community
 announcementsCategory: Announcements
 eventsCategory: Events
 articleLinkTitle: Get infos
+
 ---
 
 #title
@@ -263,10 +301,10 @@ Sharing is [Caring]{.text-sky-lighter}
 Discover articles from the framework team and community about Nuxt. Tips and tricks included!
 ::
 
-::home-testimonials
----
-category: Community
----
+## ::home-testimonials
+
+## category: Community
+
 #title
 Testimonials
 
@@ -274,9 +312,13 @@ Testimonials
 Learn what the experts love about Nuxt.
 
 #testimonials
-  :::testimonials
-  ---
-  home: true
-  ---
-  :::
+:::testimonials
+
+---
+
+home: true
+
+---
+
+:::
 ::

--- a/static/_redirects
+++ b/static/_redirects
@@ -360,6 +360,10 @@
 /v3 https://v3.nuxtjs.org/ 302!
 /:locale/v3 https://v3.nuxtjs.org/ 302!
 
+#Modules
+/modules https://modules.nuxtjs.org/ 302!
+/:locale/modules https://modules.nuxtjs.org/ 302!
+
 # [LEGACY] Redirect GUIDE URLs
 /guide/themes /themes 301!
 /:locale/guide/themes /:locale/themes 301!


### PR DESCRIPTION
To merge even if https://modules.nuxtjs.org is not redesigned. At least it works well 🙂 