### PR TITLE
fix(docs): remove install fibers

### DIFF
--- a/content/en/docs/3.features/6.configuration.md
+++ b/content/en/docs/3.features/6.configuration.md
@@ -78,16 +78,12 @@ To use these pre-processors, we need to install their webpack loaders:
 ::code-group
 ```bash [Yarn]
 yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10 fibers
+yarn add -D sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 ## External Resources

--- a/content/es/docs/3.features/6.configuration.md
+++ b/content/es/docs/3.features/6.configuration.md
@@ -78,16 +78,12 @@ To use these pre-processors, we need to install their webpack loaders:
 ::code-group
 ```bash [Yarn]
 yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10 fibers
+yarn add -D sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 ## External Resources

--- a/content/fr/docs/3.features/6.configuration.md
+++ b/content/fr/docs/3.features/6.configuration.md
@@ -77,16 +77,12 @@ Pour utiliser ces pré-processeurs, nous avons besoin d'installer leurs loaders 
 ::code-group
 ```bash [Yarn]
 yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10 fibers
+yarn add -D sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-La compilation synchrone avec `sass` (2x plus rapide) [est activée automatiquement](https://github.com/webpack-contrib/sass-loader) quand `fibers` est installé.
 ::
 
 ## JSX

--- a/content/ja/docs/3.features/6.configuration.md
+++ b/content/ja/docs/3.features/6.configuration.md
@@ -78,16 +78,12 @@ export default {
 ::code-group
 ```bash [Yarn]
 yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10 fibers
+yarn add -D sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-`fibers` がインストールされている場合、`sass` の同期コンパイル（2 倍速）が[自動的に有効になります](https://github.com/webpack-contrib/sass-loader)。
 ::
 
 ## 外部のリソース

--- a/content/pt/docs/3.features/6.configuration.md
+++ b/content/pt/docs/3.features/6.configuration.md
@@ -78,16 +78,12 @@ To use these pre-processors, we need to install their webpack loaders:
 ::code-group
 ```bash [Yarn]
 yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10 fibers
+yarn add -D sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 ## External Resources


### PR DESCRIPTION
Removed installation instructions from documentation as fibers does not support node16 and above

Also, since the latest version of node is 16 at the moment, I thought that the document based on the version before 16 is inappropriate.

> Fibers is not compatible with nodejs v16.0.0 or later. Unfortunately, v8 commit dacc2fee0f is a breaking change and workarounds are non-trivial.

https://github.com/laverdet/node-fibers