### PR TITLE
docs(ja): fix mini typo 6.internals-glossary/9.nuxt.md

### DIFF
--- a/content/ja/docs/6.internals-glossary/9.nuxt.md
+++ b/content/ja/docs/6.internals-glossary/9.nuxt.md
@@ -33,7 +33,7 @@ if (isDev) {
 // `nuxt.render(req, res)` または `nuxt.renderRoute(route, context)` が使えます
 ```
 
-手っ取り早く始めるために [nuxt-express](https://github.com/nuxt/express) や adonuxt](https://github.com/nuxt/adonuxt) スターターを参照できます。
+手っ取り早く始めるために [nuxt-express](https://github.com/nuxt/express) や [adonuxt](https://github.com/nuxt/adonuxt) スターターを参照できます。
 
 ### デバッグログ
 


### PR DESCRIPTION
There was a very small typo, which has been corrected.