### PR TITLE
docs(en): fix typos on Examples -> Plugins -> Vue Plugins

### DIFF
--- a/content/en/examples/9.plugins/1.vue.md
+++ b/content/en/examples/9.plugins/1.vue.md
@@ -12,7 +12,7 @@ In this example we show how to add a vue plugin to your application
 
 In this example:
 
-`plugins/vue-tooltip.js` imports our tooltip and tells Vue to use.
+`plugins/vue-tooltip.js` imports our tooltip and tells Vue to use it.
 
 `pages/index.vue` uses our plugin.
 

--- a/content/en/examples/9.plugins/1.vue.md
+++ b/content/en/examples/9.plugins/1.vue.md
@@ -12,13 +12,13 @@ In this example we show how to add a vue plugin to your application
 
 In this example:
 
-`plugins/vue-tooltip.js` imports our tooltip and tells Vue to use..
+`plugins/vue-tooltip.js` imports our tooltip and tells Vue to use.
 
 `pages/index.vue` uses our plugin.
 
 `nuxt.config.js` contains the `plugins` property to register our plugin and the `css` property to add our tooltip css.
 
-`package.json` show our tooltip package has been installed.
+`package.json` shows our tooltip package has been installed.
 
 ::alert{type="next"}
 Learn more in the Directory Structure book in the [plugins](/docs/directory-structure/plugins#vue-plugins) chapter.


### PR DESCRIPTION
Hi! I'm a first-time contributor, please let me know if there is any specific reading on contributing to Nuxt!

This is a minor docs fix for a couple of types on the Plugins example page.
- Remove a double period
- show -> shows