### PR TITLE
Fix landscape tablet viewport banner background

### DIFF
--- a/components/organisms/ads/BannerMasteringNuxt.vue
+++ b/components/organisms/ads/BannerMasteringNuxt.vue
@@ -10,12 +10,12 @@
     <div class="absolute z-0 h-full w-full flex justify-center">
       <img
         :src="`/img/banners/mastering-nuxt/bg-desktop.png`"
-        class="h-full hidden xl:inline-block"
+        class="h-full hidden max-w-none xl:inline-block"
         alt="Banner Background"
       />
       <img
         :src="`/img/banners/mastering-nuxt/bg-tablet.png`"
-        class="h-full md:inline-block xl:hidden"
+        class="h-full hidden w-full md:inline-block xl:hidden"
         alt="Banner Background"
       />
     </div>


### PR DESCRIPTION
This PR fixes a minor visual bug in the background of the Black Friday banner on landscape tablet viewport.

**Before:**
![Screen Shot 2021-11-18 at 11 57 49](https://user-images.githubusercontent.com/3766839/142440985-5884d70a-5e79-45f2-a6f2-d16e5b49ae50.png)


**After:**
![Screen Shot 2021-11-18 at 11 57 08](https://user-images.githubusercontent.com/3766839/142441008-65ad73b4-697d-4e4e-b425-32bf423ff7fe.png)


Related to https://github.com/nuxt/nuxtjs.org/pull/1940