### PR TITLE
fix: BannerMasteringNuxt image overflow

### DIFF
--- a/components/organisms/ads/BannerMasteringNuxt.vue
+++ b/components/organisms/ads/BannerMasteringNuxt.vue
@@ -10,7 +10,7 @@
     <div class="absolute z-0 h-full w-full flex justify-center">
       <img
         :src="`/img/banners/mastering-nuxt/bg-desktop.png`"
-        class="h-full hidden max-w-none xl:inline-block"
+        class="h-full hidden max-w-full xl:inline-block"
         alt="Banner Background"
       />
       <img


### PR DESCRIPTION
fixed banner's background image overflow

<img width="1440" alt="Screenshot 2021-11-26 at 12 01 20 AM" src="https://user-images.githubusercontent.com/6649533/143488441-b2f3e7a6-7cff-4515-bde6-60bf56e2b372.png">


