### PR TITLE
docs: remove `fibers` dependency recommendation

### DIFF
--- a/content/en/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/en/docs/5.configuration-glossary/5.configuration-css.md
@@ -15,15 +15,11 @@ In case you want to use `sass` make sure that you have installed `sass` and `sas
 
 ::code-group
 ```sh [Yarn]
-yarn add --dev sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```sh [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 - Type: `Array`


### PR DESCRIPTION
As of April 2021 maintainers of `fibers` announced it does not work with the current LTS version of Node (16.x) and "[recommends you avoid its use if possible](https://github.com/laverdet/node-fibers/blob/8f2809869cc92c28c92880c4a38317ae3dbe654d/README.md?plain=1#L1)". The authors README.md commit titled "[the end](https://github.com/laverdet/node-fibers/commit/8f2809869cc92c28c92880c4a38317ae3dbe654d)" along with the verbiage "_inevitable that one day this library will abruptly stop working and no one will be able to do anything about it_" suggest this package will not be maintained going forward.

Other benefits of the change:
- Bring this page into alignment with [The Nuxt Configuration Guide](https://nuxtjs.org/docs/features/configuration/) which does not suggest users install fibers.
- Reduce [startup headaches](https://github.com/laverdet/node-fibers/issues/451) for users creating new projects using the latest LTS version of node.