### PR TITLE
docs: remove lingering fibers dependency recommendations

### DIFF
--- a/content/en/deployments/github-pages.md
+++ b/content/en/deployments/github-pages.md
@@ -68,7 +68,7 @@ First install it:
 
 ::code-group
 ```bash [Yarn]
-yarn add -D push-dir
+yarn add --dev push-dir
 ```
 ```bash [NPM]
 npm install push-dir --save-dev

--- a/content/en/docs/3.features/6.configuration.md
+++ b/content/en/docs/3.features/6.configuration.md
@@ -77,8 +77,8 @@ To use these pre-processors, we need to install their webpack loaders:
 
 ::code-group
 ```bash [Yarn]
-yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10
+yarn add --dev pug pug-plain-loader
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader

--- a/content/en/docs/4.directory-structure/2.assets.md
+++ b/content/en/docs/4.directory-structure/2.assets.md
@@ -62,15 +62,11 @@ In case you want to use `sass` make sure that you have installed `sass` and�
 
 ::code-group
 ```bash [Yarn]
-yarn add -D sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 Nuxt will automatically guess the file type by its extension and use the appropriate pre-processor loader for webpack. You will still need to install the required loader if you need to use them.

--- a/content/en/docs/4.directory-structure/8.modules.md
+++ b/content/en/docs/4.directory-structure/8.modules.md
@@ -365,7 +365,7 @@ export default {
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/eslint-module
+yarn add --dev @nuxtjs/eslint-module
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/eslint-module

--- a/content/en/tutorials/3.going-dark-with-nuxtjs-color-mode.md
+++ b/content/en/tutorials/3.going-dark-with-nuxtjs-color-mode.md
@@ -68,7 +68,7 @@ First of all you need to install the module as a dependency to your Nuxt project
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/color-mode
+yarn add --dev @nuxtjs/color-mode
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/color-mode

--- a/content/es/docs/3.features/6.configuration.md
+++ b/content/es/docs/3.features/6.configuration.md
@@ -77,8 +77,8 @@ To use these pre-processors, we need to install their webpack loaders:
 
 ::code-group
 ```bash [Yarn]
-yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10
+yarn add --dev pug pug-plain-loader
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader

--- a/content/es/docs/4.directory-structure/2.assets.md
+++ b/content/es/docs/4.directory-structure/2.assets.md
@@ -62,15 +62,11 @@ In case you want to use `sass` make sure that you have installed `sass` and�
 
 ::code-group
 ```bash [Yarn]
-yarn add -D sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 Nuxt will automatically guess the file type by its extension and use the appropriate pre-processor loader for webpack. You will still need to install the required loader if you need to use them.

--- a/content/es/docs/4.directory-structure/8.modules.md
+++ b/content/es/docs/4.directory-structure/8.modules.md
@@ -365,7 +365,7 @@ export default {
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/eslint-module
+yarn add --dev @nuxtjs/eslint-module
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/eslint-module

--- a/content/es/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/es/docs/5.configuration-glossary/5.configuration-css.md
@@ -15,15 +15,11 @@ In case you want to use `sass` make sure that you have installed `sass` and `sas
 
 ::code-group
 ```sh [Yarn]
-yarn add --dev sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```sh [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 - Type: `Array`

--- a/content/es/tutorials/3.going-dark-with-nuxtjs-color-mode.md
+++ b/content/es/tutorials/3.going-dark-with-nuxtjs-color-mode.md
@@ -68,7 +68,7 @@ First of all you need to install the module as a dependency to your Nuxt project
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/color-mode
+yarn add --dev @nuxtjs/color-mode
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/color-mode

--- a/content/fr/docs/3.features/6.configuration.md
+++ b/content/fr/docs/3.features/6.configuration.md
@@ -76,8 +76,8 @@ Pour utiliser ces pré-processeurs, nous avons besoin d'installer leurs loaders 
 
 ::code-group
 ```bash [Yarn]
-yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10
+yarn add --dev pug pug-plain-loader
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader

--- a/content/fr/docs/4.directory-structure/2.assets.md
+++ b/content/fr/docs/4.directory-structure/2.assets.md
@@ -63,15 +63,12 @@ Dans le cas où l'on veut utiliser `SASS`, il faut bien faire attention à insta
 ::
 
 ::code-group
-
 ```bash [Yarn]
-yarn add -D sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
-
 ```bash [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-
 ::
 
 Nuxt va automatiquement deviner le type de fichier grâce à son extension et utiliser le loader webpack approprié pour le pré-processeur. Nous aurons cependant besoin d'installer le loader requis si nous avons besoin de l'utiliser.

--- a/content/fr/docs/4.directory-structure/8.modules.md
+++ b/content/fr/docs/4.directory-structure/8.modules.md
@@ -368,7 +368,7 @@ export default {
 ::code-group
 
 ```bash [Yarn]
-yarn add -D @nuxtjs/eslint-module
+yarn add --dev @nuxtjs/eslint-module
 ```
 
 ```bash [NPM]

--- a/content/fr/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/fr/docs/5.configuration-glossary/5.configuration-css.md
@@ -15,15 +15,11 @@ Si on veut utiliser `SASS`, il faut bien faire attention à avoir les packages `
 
 ::code-group
 ```sh [Yarn]
-yarn add --dev sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```sh [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Compilation synchrone avec `sass` (augmentation de la vitesse 2x) [est activée automatiquement] (https://github.com/webpack-contrib/sass-loader) lorsque `fibers` est installé.
 ::
 
 - Type: `Array`

--- a/content/fr/tutorials/3.going-dark-with-nuxtjs-color-mode.md
+++ b/content/fr/tutorials/3.going-dark-with-nuxtjs-color-mode.md
@@ -68,7 +68,7 @@ First of all you need to install the module as a dependency to your Nuxt project
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/color-mode
+yarn add --dev @nuxtjs/color-mode
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/color-mode

--- a/content/ja/docs/3.features/6.configuration.md
+++ b/content/ja/docs/3.features/6.configuration.md
@@ -77,8 +77,8 @@ export default {
 
 ::code-group
 ```bash [Yarn]
-yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10
+yarn add --dev pug pug-plain-loader
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader

--- a/content/ja/docs/4.directory-structure/2.assets.md
+++ b/content/ja/docs/4.directory-structure/2.assets.md
@@ -62,15 +62,11 @@ export default {
 
 ::code-group
 ```bash [Yarn]
-yarn add -D sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-`fibers` がインストールされている場合、 `sass` の同期コンパイル（2 倍速）が [自動的に有効になります](https://github.com/webpack-contrib/sass-loader)。
 ::
 
 Nuxt は拡張子からファイルの種類を自動的に推測して webpack に適したプリプロセッサローダーを使用します。それでも必要な場合は、必要なローダーをインストールする必要があります。

--- a/content/ja/docs/4.directory-structure/8.modules.md
+++ b/content/ja/docs/4.directory-structure/8.modules.md
@@ -366,7 +366,7 @@ export default {
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/eslint-module
+yarn add --dev @nuxtjs/eslint-module
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/eslint-module

--- a/content/ja/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/ja/docs/5.configuration-glossary/5.configuration-css.md
@@ -15,15 +15,11 @@ Nuxt ではグローバルに適用したい（すべてのページにインク
 
 ::code-group
 ```sh [Yarn]
-yarn add --dev sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```sh [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-`fibers` がインストールされている場合、 `sass` の同期コンパイル（2 倍速）が [自動的に有効になります](https://github.com/webpack-contrib/sass-loader)。
 ::
 
 - 型: `Array`

--- a/content/ja/tutorials/3.going-dark-with-nuxtjs-color-mode.md
+++ b/content/ja/tutorials/3.going-dark-with-nuxtjs-color-mode.md
@@ -68,7 +68,7 @@ First of all you need to install the module as a dependency to your Nuxt project
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/color-mode
+yarn add --dev @nuxtjs/color-mode
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/color-mode

--- a/content/pt/docs/3.features/6.configuration.md
+++ b/content/pt/docs/3.features/6.configuration.md
@@ -77,8 +77,8 @@ To use these pre-processors, we need to install their webpack loaders:
 
 ::code-group
 ```bash [Yarn]
-yarn add -D pug pug-plain-loader
-yarn add -D sass sass-loader@10
+yarn add --dev pug pug-plain-loader
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
 npm install --save-dev pug pug-plain-loader

--- a/content/pt/docs/4.directory-structure/2.assets.md
+++ b/content/pt/docs/4.directory-structure/2.assets.md
@@ -62,15 +62,11 @@ In case you want to use `sass` make sure that you have installed `sass` and�
 
 ::code-group
 ```bash [Yarn]
-yarn add -D sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```bash [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 Nuxt will automatically guess the file type by its extension and use the appropriate pre-processor loader for webpack. You will still need to install the required loader if you need to use them.

--- a/content/pt/docs/4.directory-structure/8.modules.md
+++ b/content/pt/docs/4.directory-structure/8.modules.md
@@ -365,7 +365,7 @@ export default {
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/eslint-module
+yarn add --dev @nuxtjs/eslint-module
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/eslint-module

--- a/content/pt/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/pt/docs/5.configuration-glossary/5.configuration-css.md
@@ -15,15 +15,11 @@ In case you want to use `sass` make sure that you have installed `sass` and `sas
 
 ::code-group
 ```sh [Yarn]
-yarn add --dev sass sass-loader@10 fibers
+yarn add --dev sass sass-loader@10
 ```
 ```sh [NPM]
-npm install --save-dev sass sass-loader@10 fibers
+npm install --save-dev sass sass-loader@10
 ```
-::
-
-::alert{type="info"}
-Synchronous compilation with `sass` (2x speed increase) [is enabled automatically](https://github.com/webpack-contrib/sass-loader) when `fibers` is installed.
 ::
 
 - Type: `Array`

--- a/content/pt/tutorials/3.going-dark-with-nuxtjs-color-mode.md
+++ b/content/pt/tutorials/3.going-dark-with-nuxtjs-color-mode.md
@@ -68,7 +68,7 @@ First of all you need to install the module as a dependency to your Nuxt project
 
 ::code-group
 ```bash [Yarn]
-yarn add -D @nuxtjs/color-mode
+yarn add --dev @nuxtjs/color-mode
 ```
 ```bash [NPM]
 npm install --save-dev @nuxtjs/color-mode


### PR DESCRIPTION
First PR to Nuxt 🙂

Because #1966 and #1921 are not complete, I have definitely deleted the recommendation.
I also harmonized the `yarn add` command.
In several places we had `-D` option and in other places `--dev`. I chose `--dev` because it's understandable to everyone, and fits well with the `--save-dev` of npm.