### PR TITLE
docs: add template wrapper for client-only placeholder

### DIFF
--- a/content/en/docs/3.features/8.nuxt-components.md
+++ b/content/en/docs/3.features/8.nuxt-components.md
@@ -328,7 +328,9 @@ Use a slot as placeholder until `<client-only />` is mounted on client-side.
       <comments />
 
       <!-- loading indicator, rendered on server-side -->
-      <comments-placeholder slot="placeholder" />
+      <template #placeholder>
+        <comments-placeholder />        
+      </template>
     </client-only>
   </div>
 </template>

--- a/content/en/docs/3.features/8.nuxt-components.md
+++ b/content/en/docs/3.features/8.nuxt-components.md
@@ -328,7 +328,7 @@ Use a slot as placeholder until `<client-only />` is mounted on client-side.
       <comments />
 
       <!-- loading indicator, rendered on server-side -->
-      <comments-placeholder #placeholder />
+      <comments-placeholder slot="placeholder" />
     </client-only>
   </div>
 </template>


### PR DESCRIPTION
I've tried to add `#placeholder` in my placeholder component inside `client-only` but it didn't work.
It worked after changing it into `slot="placeholder"`
