### PR TITLE
fix: z-index issue Discover Partners/Explore section in the home page

### DIFF
--- a/components/organisms/home/HomeDiscoverPartners.vue
+++ b/components/organisms/home/HomeDiscoverPartners.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative pb-48 sm:pb-56 md:pb-64 lg:pb-72 xl:pb-92 2xl:pb-128 bg-sky-surface">
-    <section class="relative pt-20 z-20">
+    <section class="relative pt-20 z-10">
       <NuxtContainer class="flex flex-col items-center xl:pt-10 text-sky-black">
         <div class="flex flex-col w-full items-center col-span-12">
           <div class="mb-2">
@@ -22,7 +22,7 @@
     <img
       loading="lazy"
       :src="`/img/home/discover/partners/partners-illustration.svg`"
-      class="absolute left-0 bottom-0 z-10 object-fill w-full -mt-28 sm:-mt-40 lg:-mt-60 xl:-mt-80"
+      class="absolute left-0 bottom-0 object-fill w-full -mt-28 sm:-mt-40 lg:-mt-60 xl:-mt-80"
       alt="A landscape image"
     />
   </div>

--- a/components/organisms/home/HomeDiscoverPartners.vue
+++ b/components/organisms/home/HomeDiscoverPartners.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative pb-48 sm:pb-56 md:pb-64 lg:pb-72 xl:pb-92 2xl:pb-128 bg-sky-surface">
-    <section class="relative pt-20">
+    <section class="relative pt-20 z-20">
       <NuxtContainer class="flex flex-col items-center xl:pt-10 text-sky-black">
         <div class="flex flex-col w-full items-center col-span-12">
           <div class="mb-2">

--- a/components/organisms/home/HomeExplore.vue
+++ b/components/organisms/home/HomeExplore.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative pb-20 sm:pb-28 md:pb-36 lg:pb-48">
-    <section class="bg-white">
+    <section class="relative z-10">
       <img
         loading="lazy"
         :src="`/img/home/explore/landscape-explore.svg`"
@@ -27,13 +27,13 @@
     <img
       loading="lazy"
       :src="`/img/home/campfire/campfire-illustration-big.svg`"
-      class="hidden xl:block absolute bottom-0 left-0 w-full object-fit z-10"
+      class="hidden xl:block absolute bottom-0 left-0 w-full object-fit"
       alt="A landscape image"
     />
     <img
       loading="lazy"
       :src="`/img/home/campfire/campfire-illustration.svg`"
-      class="absolute left-0 bottom-0 w-full object-fit z-10 xl:hidden"
+      class="absolute left-0 bottom-0 w-full object-fit xl:hidden"
       alt="A landscape image"
     />
   </div>


### PR DESCRIPTION
Hi. I realize Discover Partners section in the home page of nuxtjs.org has z-index issue on certain -especially high- resolutions. 

I just add "z-20" class to section and it is fixed.

Addition: I just realized that the same problem exists in the Explore section. :)

https://user-images.githubusercontent.com/6717356/149040131-5b8606ec-3879-49a5-b36a-7797d6d7b8f5.mov


