### PR TITLE
docs: fix page filename and typo

### DIFF
--- a/content/en/examples/5.seo/2.twitter-og.md
+++ b/content/en/examples/5.seo/2.twitter-og.md
@@ -14,9 +14,9 @@ In this example:
 
 `components/SocialHead` uses the `head` property to show `meta` for both Twitter and Open Graph social sharing using props.
 
-`pages/mountains/slug.vue` uses the `SocialHead` component passing the mountain's title, description and image as the values for props. It also uses the head tag to set the canonical link.
+`pages/mountains/_slug.vue` uses the `SocialHead` component passing the mountain's title, description and image as the values for props. It also uses the head tag to set the canonical link.
 
-`nuxtconfig.js` shows the head tag with default meta for social sharing for when the the `SocialHead` component is not used as well as the canonical link.
+`nuxtconfig.js` shows the head tag with default meta for social sharing for when the `SocialHead` component is not used as well as the canonical link.
 
 ::alert{type="next"}
 Learn more about the options available for `head`, in the [vue-meta documentation](https://vue-meta.nuxtjs.org/api/#metainfo-properties).


### PR DESCRIPTION
Updated file name and removed duplicated "the" article