### PR TITLE
docs: link to pages

### DIFF
--- a/content/en/docs/2.concepts/1.views.md
+++ b/content/en/docs/2.concepts/1.views.md
@@ -44,7 +44,7 @@ Every Page component is a Vue component but Nuxt adds special attributes and fun
 There are many properties of the page component such as the head property in the example above.
 
 ::alert{type="next"}
-See the [Directory Structure book](/docs/directory-structure/nuxt) to learn more about all the properties can use on your page
+See the [Directory Structure book](/docs/directory-structure/pages) to learn more about all the properties can use on your page
 ::
 
 ## Layouts

--- a/content/en/docs/2.concepts/1.views.md
+++ b/content/en/docs/2.concepts/1.views.md
@@ -44,7 +44,7 @@ Every Page component is a Vue component but Nuxt adds special attributes and fun
 There are many properties of the page component such as the head property in the example above.
 
 ::alert{type="next"}
-See the [Directory Structure book](/docs/directory-structure/pages) to learn more about all the properties can use on your page
+See the [Directory Structure book](/docs/directory-structure/pages) to learn more about all the properties you can use on your page
 ::
 
 ## Layouts


### PR DESCRIPTION
Since we want to show page properties we should open appropriate page