### PR TITLE
Update Vercel deployment documentation.

### DIFF
--- a/content/en/deployments/0.vercel.md
+++ b/content/en/deployments/0.vercel.md
@@ -1,42 +1,52 @@
 ---
 template: guide
 title: Vercel
-description: How to deploy a Nuxt app with Vercel?
+description: Learn how to deploy a Nuxt app to Vercel that supports both static and server-rendered pages.
 target: Static & Server
 category: deployment
 logo:
   light: "/img/companies/square/light/vercel.svg"
   dark: "/img/companies/square/dark/vercel.svg"
 ---
+
 # Deploy Nuxt with Vercel
 
-How to deploy a Nuxt app with Vercel?
+Learn how to deploy a Nuxt app to Vercel that supports both static and server-rendered pages.
 
 ---
 
+To get started with Nuxt 3 on [Vercel](http://vercel.com), you can clone an example using the Vercel CLI:
+
+```bash
+$ npm i -g vercel
+$ vercel init nuxtjs
+Vercel CLI
+> Success! Initialized "nuxtjs" example in ~/your-folder.
+- To deploy, `cd nuxtjs` and run `vercel`.
+```
+
 ## Static site with Vercel
 
-If you would like to deploy a static site on Vercel, no configuration is necessary. Vercel will detect that you are using Nuxt and will enable the correct settings for your deployment. For more information, see [this Vercel guide](https://vercel.com/guides/deploying-nuxtjs-with-vercel).
+If you would like to deploy a static site on Vercel, **no configuration is necessary**. Vercel will detect that you are using Nuxt and will enable the correct settings for your deployment.
 
 ## SSR with Vercel
 
-To deploy a serverless Nuxt runtime with [Vercel](https://vercel.com), the Nuxt team and contributors have produced an official [@nuxtjs/vercel-builder](https://github.com/nuxt/vercel-builder) package.
+If you would like to server-render pages on Vercel, **no configuration is necessary for Nuxt 3 applications**. Vercel will detect that you are using Nuxt and will enable the correct settings for your deployment.
 
-All you have to do is to setup a `vercel.json` file:
+To server-render pages with Nuxt v2, create a `vercel.json` file at the root of your project as follows:
 
-```json
+```jsx
 {
   "builds": [
     {
       "src": "nuxt.config.js",
-      "use": "@nuxtjs/vercel-builder",
-      "config": {}
+      "use": "@nuxtjs/vercel-builder"
     }
   ]
 }
 ```
 
-Check out [the documentation](https://github.com/nuxt/vercel-builder) for more information.
+Check out [the documentation](https://github.com/nuxt/vercel-builder) for more information.
 
 ### Service Worker with Nuxt PWA Module
 
@@ -44,14 +54,10 @@ To avoid 404 for Service Workers, make sure to include `sw` to your routes setti
 
 ```json
 {
-  "version": 2,
   "builds": [
     {
       "src": "nuxt.config.js",
       "use": "@nuxtjs/vercel-builder",
-      "config": {
-        "serverFiles": ["package.json"]
-      }
     }
   ],
   "routes": [
@@ -67,4 +73,4 @@ To avoid 404 for Service Workers, make sure to include `sw` to your routes setti
 }
 ```
 
-You can learn more and see examples on https://github.com/nuxt/vercel-builder
+Check out [the documentation](https://github.com/nuxt/vercel-builder) for more information.

--- a/content/en/docs/1.get-started/4.commands.md
+++ b/content/en/docs/1.get-started/4.commands.md
@@ -48,13 +48,13 @@ You can run different commands depending on the [target](/docs/features/deployme
 
 - **nuxt dev** - Launch the development server.
 - **nuxt build** - Build and optimize your application with webpack for production.
-- **nuxt start** - Start the production server (after running `nuxt build`). Use it for Node.js hosting like Heroku, Digital Ocean, etc.
+- **nuxt start** - Start the production server (after running `nuxt build`). Use it for platforms like Heroku, Digital Ocean, and Vercel.
 
 ### target: `static`
 
 - **nuxt dev** - Launch the development server.
 - **nuxt generate** - Build the application (if needed), generate every route as a HTML file and statically export to `dist/` directory (used for static hosting).
-- **nuxt start** - serve the `dist/` directory like your static hosting would do (Netlify, Vercel, Surge, etc), great for testing before deploying.
+- **nuxt start** - serve the `dist/` directory like your static hosting would do (Netlify, Surge, etc), great for testing before deploying.
 
 ## Webpack Config Inspection
 

--- a/content/es/deployments/0.vercel.md
+++ b/content/es/deployments/0.vercel.md
@@ -1,57 +1,63 @@
 ---
 template: guide
 title: Vercel
-description: How to deploy a Nuxt app with Vercel?
+description: Aprenda a implementar una aplicación de Nuxt en Vercel que admita páginas estáticas y renderizadas por el servidor.
 target: Static & Server
 category: deployment
 logo:
   light: "/img/companies/square/light/vercel.svg"
   dark: "/img/companies/square/dark/vercel.svg"
 ---
-# Deploy Nuxt with Vercel
 
-How to deploy a Nuxt app with Vercel?
+# Implementar Nuxt con Vercel
+
+Aprenda a implementar una aplicación de Nuxt en Vercel que admita páginas estáticas y renderizadas por el servidor.
 
 ---
 
-## Static site with Vercel
+Para comenzar con Nuxt 3 en [Vercel](http://vercel.com), puede clonar un ejemplo utilizando la Vercel CLI:
 
-If you would like to deploy a static site on Vercel, no configuration is necessary. Vercel will detect that you are using Nuxt and will enable the correct settings for your deployment. For more information, see [this Vercel guide](https://vercel.com/guides/deploying-nuxtjs-with-vercel).
+```bash
+$ npm i -g vercel
+$ vercel init nuxtjs
+Vercel CLI
+> ¡Éxito! Ejemplo de "nuxtjs" inicializado en ~/your-folder.
+- Para desplegar, `cd nuxtjs` y ejecutar `vercel`.
+```
 
-## SSR with Vercel
+## Sitio estático con Vercel
 
-To deploy a serverless Nuxt runtime with [Vercel](https://vercel.com), the Nuxt team and contributors have produced an official [@nuxtjs/vercel-builder](https://github.com/nuxt/vercel-builder) package.
+Si desea implementar un sitio estático en Vercel, **no es necesaria ninguna configuración**. Vercel detectará que está utilizando Nuxt y habilitará la configuración correcta para su implementación.
 
-All you have to do is to setup a `vercel.json` file:
+## SSR con Vercel
 
-```json
+Si desea renderizar páginas de servidor en Vercel, **no es necesaria ninguna configuración para las aplicaciones Nuxt 3**. Vercel detectará que está utilizando Nuxt y habilitará la configuración correcta para su implementación.
+
+Para renderizar páginas en el servidor con Nuxt v2, cree un archivo `vercel.json` en la raíz de su proyecto de la siguiente manera:
+
+```jsx
 {
   "builds": [
     {
       "src": "nuxt.config.js",
-      "use": "@nuxtjs/vercel-builder",
-      "config": {}
+      "use": "@nuxtjs/vercel-builder"
     }
   ]
 }
 ```
 
-Check out [the documentation](https://github.com/nuxt/vercel-builder) for more information.
+Consulte [la documentación](https://github.com/nuxt/vercel-builder) para obtener más información.
 
-### Service Worker with Nuxt PWA Module
+### Trabajador de servicio con módulo Nuxt PWA
 
-To avoid 404 for Service Workers, make sure to include `sw` to your routes settings.
+Para evitar 404 para Service Workers, asegúrese de incluir `sw` en la configuración de sus rutas.
 
 ```json
 {
-  "version": 2,
   "builds": [
     {
       "src": "nuxt.config.js",
       "use": "@nuxtjs/vercel-builder",
-      "config": {
-        "serverFiles": ["package.json"]
-      }
     }
   ],
   "routes": [
@@ -67,4 +73,4 @@ To avoid 404 for Service Workers, make sure to include `sw` to your routes setti
 }
 ```
 
-You can learn more and see examples on https://github.com/nuxt/vercel-builder
+Consulte [la documentación](https://github.com/nuxt/vercel-builder) para obtener más información.

--- a/content/fr/deployments/0.vercel.md
+++ b/content/fr/deployments/0.vercel.md
@@ -1,72 +1,76 @@
 ---
 template: guide
 title: Vercel
-description: Comment déployer une application Nuxt avec Vercel?
+description: Découvrez comment déployer une application Nuxt sur Vercel qui prend en charge les pages statiques et rendues par le serveur.
 target: Static & Server
 category: deployment
 logo:
   light: "/img/companies/square/light/vercel.svg"
   dark: "/img/companies/square/dark/vercel.svg"
 ---
+
 # Déployer Nuxt avec Vercel
 
-Comment déployer Nuxt avec Vercel ?
+Découvrez comment déployer une application Nuxt sur Vercel qui prend en charge les pages statiques et rendues par le serveur.
 
 ---
 
-## Static avec Vercel
+Pour démarrer avec Nuxt 3 sur [Vercel](http://vercel.com), vous pouvez cloner un exemple à l'aide de la Vercel CLI:
 
-Si vous souhaitez déployer un site statique sur Vercel, aucune configuration n'est nécessaire. Vercel détectera que vous utilisez Nuxt et activera les bons paramètres pour votre déploiement. Pour plus d'informations, consultez [ce guide Vercel](https://vercel.com/guides/deploying-nuxtjs-with-vercel).
+```bash
+$ npm i -g vercel
+$ vercel init nuxtjs
+Vercel CLI
+> Succès ! Exemple "nuxtjs" initialisé dans ~/votre-dossier.
+- Pour déployer, `cd nuxtjs` et lancez `vercel`.
+```
+
+## Site statique avec Vercel
+
+Si vous souhaitez déployer un site statique sur Vercel, **aucune configuration n'est nécessaire**. Vercel détectera que vous utilisez Nuxt et activera les paramètres corrects pour votre déploiement.
 
 ## SSR avec Vercel
 
-Pour déployer un runtime Nuxt serverless avec [Vercel](https://vercel.com), l'équipe et les contributeurs Nuxt ont produit un [@nuxtjs/vercel-builder](https://github.com/nuxt/vercel-builder) package.
+Si vous souhaitez rendre des pages serveur sur Vercel, **aucune configuration n'est nécessaire pour les applications Nuxt 3**. Vercel détectera que vous utilisez Nuxt et activera les paramètres corrects pour votre déploiement.
 
-Vous n'avez qu'à configurer le fichier `vercel.json`:
+Pour rendre les pages du serveur avec Nuxt v2, créez un fichier `vercel.json` à la racine de votre projet comme suit :
 
-```json
+```jsx
 {
   "builds": [
     {
       "src": "nuxt.config.js",
-      "use": "@nuxtjs/vercel-builder",
-      "config": {}
+      "use": "@nuxtjs/vercel-builder"
     }
   ]
 }
 ```
 
-Consultez [la documentation](https://github.com/nuxt/vercel-builder) pour plus d'informations.
+Consultez [la documentation](https://github.com/nuxt/vercel-builder) pour plus d'informations.
 
-### Service Worker avec Nuxt PWA Module
+### Service Worker avec le module Nuxt PWA
 
-Pour éviter une 404 avec le Service Workers, assurez-vous d'inclure `sw` dans vos paramètres de routes.
+Pour éviter 404 pour les Service Workers, assurez-vous d'inclure `sw` dans vos paramètres d'itinéraires.
 
 ```json
 {
-  "version": 2,
   "builds": [
     {
       "src": "nuxt.config.js",
       "use": "@nuxtjs/vercel-builder",
-      "config": {
-        "serverFiles": ["package.json"]
-      }
     }
   ],
   "routes": [
-    { "src": "/_nuxt/.+", "headers": { "Cache-Control": "max-age=31557600" } },
     {
       "src": "/sw.js",
-      "dest": "/_nuxt/static/sw.js",
+      "continue": true,
       "headers": {
-        "cache-control": "public, max-age=43200, immutable",
+        "Cache-Control": "public, max-age=0, must-revalidate",
         "Service-Worker-Allowed": "/"
       }
-    },
-    { "src": "/(.*)", "dest": "/" }
+    }
   ]
 }
 ```
 
-Vous pouvez en savoir plus et voir des exemples sur https://github.com/nuxt/vercel-builder
+Consultez [la documentation](https://github.com/nuxt/vercel-builder) pour plus d'informations.

--- a/content/ja/deployments/0.vercel.md
+++ b/content/ja/deployments/0.vercel.md
@@ -1,7 +1,7 @@
 ---
 template: guide
 title: Vercel
-description: Nuxt アプリケーションを Vercel にどうやってデプロイするのか？
+description: 静的ページとサーバーレンダリングページの両方をサポートするNuxtアプリをVercelにデプロイする方法を学びます。
 target: Static & Server
 category: deployment
 logo:
@@ -11,19 +11,29 @@ logo:
 
 # Nuxt を Vercel にデプロイする
 
-Nuxt アプリケーションを Vercel にどうやってデプロイするのか？
+静的ページとサーバーレンダリングページの両方をサポートするNuxtアプリをVercelにデプロイする方法を学びます。
 
 ---
 
-## Vercel による静的サイト
+[Vercel](http://vercel.com）でNuxt 3の使用を開始するには、VercelCLIを使用して例のクローンを作成できます。
 
-Vercel で静的サイトをデプロイする場合、設定は必要ありません。Vercel は、お客様が Nuxt を使用していることを検出し、デプロイメントに適した設定を有効にします。詳しくは、[Vercel ガイド](https://vercel.com/guides/deploying-nuxtjs-with-vercel)をご覧ください。
+```bash
+$ npm i -g vercel
+$ vercel init nuxtjs
+Vercel CLI
+> Success! Initialized "nuxtjs" example in ~/your-folder.
+- To deploy, `cd nuxtjs` and run `vercel`.
+```
 
-## Vercel による SSR
+## Vercelを使用した静的サイト
 
-[Vercel](https://vercel.com) を使ってサーバーレスの Nuxt ランタイムをデプロイするために、Nuxt チームとコントリビューターが公式の[@nuxtjs/vercel-builder](https://github.com/nuxt/vercel-builder)パッケージを作成しました。
+Vercelに静的サイトを展開する場合は、**構成は必要ありません**。 Vercelは、Nuxtを使用していることを検出し、展開の正しい設定を有効にします。
 
-必要なのは、`vercel.json` ファイルをセットアップすることだけです：
+## Vercelを使用したSSR
+
+Vercelでページをサーバーレンダリングする場合は、** Nuxt3アプリケーションの構成は必要ありません**。 Vercelは、Nuxtを使用していることを検出し、展開の正しい設定を有効にします。
+
+Nuxt v2を使用してページをサーバーレンダリングするには、次のようにプロジェクトのルートに `vercel.json`ファイルを作成します。
 
 ```json
 {
@@ -31,7 +41,6 @@ Vercel で静的サイトをデプロイする場合、設定は必要ありま�
     {
       "src": "nuxt.config.js",
       "use": "@nuxtjs/vercel-builder",
-      "config": {}
     }
   ]
 }
@@ -45,14 +54,10 @@ Service Worker の 404 を回避するには、ルートの設定に `sw` を含
 
 ```json
 {
-  "version": 2,
   "builds": [
     {
       "src": "nuxt.config.js",
-      "use": "@nuxtjs/vercel-builder",
-      "config": {
-        "serverFiles": ["package.json"]
-      }
+      "use": "@nuxtjs/vercel-builder"
     }
   ],
   "routes": [
@@ -68,4 +73,4 @@ Service Worker の 404 を回避するには、ルートの設定に `sw` を含
 }
 ```
 
-詳しくは、https://github.com/nuxt/vercel-builder で紹介しています。
+詳しくは[ドキュメント](https://github.com/nuxt/vercel-builder)をご覧ください。

--- a/content/pt-br/deployments/0.vercel.md
+++ b/content/pt-br/deployments/0.vercel.md
@@ -1,57 +1,63 @@
 ---
 template: guide
 title: Vercel
-description: How to deploy a Nuxt app with Vercel?
+description: Saiba como implantar um aplicativo Nuxt no Vercel que oferece suporte a páginas estáticas e renderizadas pelo servidor.
 target: Static & Server
 category: deployment
 logo:
   light: "/img/companies/square/light/vercel.svg"
   dark: "/img/companies/square/dark/vercel.svg"
 ---
-# Deploy Nuxt with Vercel
 
-How to deploy a Nuxt app with Vercel?
+# Implantar Nuxt com Vercel
+
+Saiba como implantar um aplicativo Nuxt no Vercel que oferece suporte a páginas estáticas e renderizadas pelo servidor.
 
 ---
 
-## Static site with Vercel
+Para começar com o Nuxt 3 em [Vercel](http://vercel.com), você pode clonar um exemplo usando a CLI do Vercel:
 
-If you would like to deploy a static site on Vercel, no configuration is necessary. Vercel will detect that you are using Nuxt and will enable the correct settings for your deployment. For more information, see [this Vercel guide](https://vercel.com/guides/deploying-nuxtjs-with-vercel).
+```bash
+$ npm i -g vercel
+$ vercel init nuxtjs
+Vercel CLI
+> Success! Initialized "nuxtjs" example in ~/your-folder.
+- To deploy, `cd nuxtjs` and run `vercel`.
+```
 
-## SSR with Vercel
+## Site estático com Vercel
 
-To deploy a serverless Nuxt runtime with [Vercel](https://vercel.com), the Nuxt team and contributors have produced an official [@nuxtjs/vercel-builder](https://github.com/nuxt/vercel-builder) package.
+Se você deseja implantar um site estático no Vercel, **não é necessária nenhuma configuração**. O Vercel detectará que você está usando o Nuxt e habilitará as configurações corretas para sua implantação.
 
-All you have to do is to setup a `vercel.json` file:
+## SSR com Vercel
 
-```json
+Se você quiser renderizar páginas no Vercel, **nenhuma configuração é necessária para aplicativos Nuxt 3**. O Vercel detectará que você está usando o Nuxt e habilitará as configurações corretas para sua implantação.
+
+Para renderizar páginas de servidor com Nuxt v2, crie um arquivo `vercel.json` na raiz do seu projeto da seguinte maneira:
+
+```jsx
 {
   "builds": [
     {
       "src": "nuxt.config.js",
-      "use": "@nuxtjs/vercel-builder",
-      "config": {}
+      "use": "@nuxtjs/vercel-builder"
     }
   ]
 }
 ```
 
-Check out [the documentation](https://github.com/nuxt/vercel-builder) for more information.
+Confira [a documentação](https://github.com/nuxt/vercel-builder) para mais informações.
 
-### Service Worker with Nuxt PWA Module
+### Service Worker com módulo Nuxt PWA
 
-To avoid 404 for Service Workers, make sure to include `sw` to your routes settings.
+Para evitar 404 para Service Workers, certifique-se de incluir `sw` em suas configurações de rotas.
 
 ```json
 {
-  "version": 2,
   "builds": [
     {
       "src": "nuxt.config.js",
       "use": "@nuxtjs/vercel-builder",
-      "config": {
-        "serverFiles": ["package.json"]
-      }
     }
   ],
   "routes": [
@@ -67,4 +73,4 @@ To avoid 404 for Service Workers, make sure to include `sw` to your routes setti
 }
 ```
 
-You can learn more and see examples on https://github.com/nuxt/vercel-builder
+Confira [a documentação](https://github.com/nuxt/vercel-builder) para mais informações.

--- a/content/pt/deployments/0.vercel.md
+++ b/content/pt/deployments/0.vercel.md
@@ -1,57 +1,63 @@
 ---
 template: guide
 title: Vercel
-description: How to deploy a Nuxt app with Vercel?
+description: Saiba como implantar um aplicativo Nuxt no Vercel que oferece suporte a páginas estáticas e renderizadas pelo servidor.
 target: Static & Server
 category: deployment
 logo:
   light: "/img/companies/square/light/vercel.svg"
   dark: "/img/companies/square/dark/vercel.svg"
 ---
-# Deploy Nuxt with Vercel
 
-How to deploy a Nuxt app with Vercel?
+# Implantar Nuxt com Vercel
+
+Saiba como implantar um aplicativo Nuxt no Vercel que oferece suporte a páginas estáticas e renderizadas pelo servidor.
 
 ---
 
-## Static site with Vercel
+Para começar com o Nuxt 3 em [Vercel](http://vercel.com), você pode clonar um exemplo usando a CLI do Vercel:
 
-If you would like to deploy a static site on Vercel, no configuration is necessary. Vercel will detect that you are using Nuxt and will enable the correct settings for your deployment. For more information, see [this Vercel guide](https://vercel.com/guides/deploying-nuxtjs-with-vercel).
+```bash
+$ npm i -g vercel
+$ vercel init nuxtjs
+Vercel CLI
+> Success! Initialized "nuxtjs" example in ~/your-folder.
+- To deploy, `cd nuxtjs` and run `vercel`.
+```
 
-## SSR with Vercel
+## Site estático com Vercel
 
-To deploy a serverless Nuxt runtime with [Vercel](https://vercel.com), the Nuxt team and contributors have produced an official [@nuxtjs/vercel-builder](https://github.com/nuxt/vercel-builder) package.
+Se você deseja implantar um site estático no Vercel, **não é necessária nenhuma configuração**. O Vercel detectará que você está usando o Nuxt e habilitará as configurações corretas para sua implantação.
 
-All you have to do is to setup a `vercel.json` file:
+## SSR com Vercel
 
-```json
+Se você quiser renderizar páginas no Vercel, **nenhuma configuração é necessária para aplicativos Nuxt 3**. O Vercel detectará que você está usando o Nuxt e habilitará as configurações corretas para sua implantação.
+
+Para renderizar páginas de servidor com Nuxt v2, crie um arquivo `vercel.json` na raiz do seu projeto da seguinte maneira:
+
+```jsx
 {
   "builds": [
     {
       "src": "nuxt.config.js",
-      "use": "@nuxtjs/vercel-builder",
-      "config": {}
+      "use": "@nuxtjs/vercel-builder"
     }
   ]
 }
 ```
 
-Check out [the documentation](https://github.com/nuxt/vercel-builder) for more information.
+Confira [a documentação](https://github.com/nuxt/vercel-builder) para mais informações.
 
-### Service Worker with Nuxt PWA Module
+### Service Worker com módulo Nuxt PWA
 
-To avoid 404 for Service Workers, make sure to include `sw` to your routes settings.
+Para evitar 404 para Service Workers, certifique-se de incluir `sw` em suas configurações de rotas.
 
 ```json
 {
-  "version": 2,
   "builds": [
     {
       "src": "nuxt.config.js",
       "use": "@nuxtjs/vercel-builder",
-      "config": {
-        "serverFiles": ["package.json"]
-      }
     }
   ],
   "routes": [
@@ -67,4 +73,4 @@ To avoid 404 for Service Workers, make sure to include `sw` to your routes setti
 }
 ```
 
-You can learn more and see examples on https://github.com/nuxt/vercel-builder
+Confira [a documentação](https://github.com/nuxt/vercel-builder) para mais informações.


### PR DESCRIPTION
Ensures documentation reflects Nuxt 3 being zero configuration on Vercel, and includes example command to scaffold application. This also adds translations for other languages (please correct any translations if not 100% accurate).