### PR TITLE
Update 31.configuration-target.md

### DIFF
--- a/content/fr/docs/5.configuration-glossary/31.configuration-target.md
+++ b/content/fr/docs/5.configuration-glossary/31.configuration-target.md
@@ -4,7 +4,6 @@ navigation.title: target
 description: Change la cible par défaut nuxt de votre projet
 menu: target
 category: configuration-glossary
-position: 29
 ---
 
 # La propriété target


### PR DESCRIPTION
Il n'y a plus besoin de la clé "position", sinon elle fait remonter cette page en haut de la liste et perturbe le tri par défaut (alphabétique) qui est conforme sur la version anglaise.