### PR TITLE
Update 10.configuration-extend-plugins.md

### DIFF
--- a/content/fr/docs/5.configuration-glossary/10.configuration-extend-plugins.md
+++ b/content/fr/docs/5.configuration-glossary/10.configuration-extend-plugins.md
@@ -4,7 +4,6 @@ navigation.title: extendPlugins
 description: La propriété extendPlugins permet de personnaliser les plugins de Nuxt.
 menu: extendPlugins
 category: configuration-glossary
-position: 9
 ---
 
 # La propriété extendPlugins


### PR DESCRIPTION
Il n'y a plus besoin de la clé "position", sinon elle fait remonter cette page en haut de la liste et perturbe le tri par défaut (alphabétique) qui est conforme sur la version anglaise.