### PR TITLE
Fix spacing

### DIFF
--- a/content/en/docs/3.features/4.data-fetching.md
+++ b/content/en/docs/3.features/4.data-fetching.md
@@ -26,9 +26,9 @@ If you define `fetch` or `asyncData` inside a mixin and also have it defined in 
 ## The fetch hook
 
 ::alert{type="info"}
-**Before Nuxt 2.12, there was a different `fetch` hook that only worked for _page_  components and didn't have access to the component instance.**
+**Before Nuxt 2.12, there was a different `fetch` hook that only worked for _page_  components and didn't have access to the component instance.** 
 
-If your `fetch()` accepts a `context` argument, it will be treated like a legacy fetch hook. This functionality is deprecated, and should be replaced with either `asyncData` or an [anonymous middleware](/docs/directory-structure/middleware#anonymous-middleware).
+If your `fetch()` accepts a `context` argument, it will be treated like a legacy fetch hook. This functionality is deprecated, and should be replaced with either `asyncData` or an [anonymous middleware.](/docs/directory-structure/middleware#anonymous-middleware)
 ::
 
 `fetch` is a hook called during server-side rendering after the component instance is created, and on the client when navigating. The fetch hook should return a promise (whether explicitly, or implicitly using `async/await`) that will be resolved:


### PR DESCRIPTION
In the documentation, there was a spacing issue where two sentences ran together without a space after the period. 