### PR TITLE
Add master courses button un aside bottom component

### DIFF
--- a/components/theme/app/AsideBottom.vue
+++ b/components/theme/app/AsideBottom.vue
@@ -1,13 +1,46 @@
 <template>
-  <div v-if="$docus.currentPath.value.startsWith('/docs')">
-    <AppLink v-if="lastRelease" to="/releases" class="flex items-center group nuxt-text-highlight-hover mt-4">
-      <IconNuxt class="w-5 h-5 mr-2" />
-      <span>{{ $t('common.version') }}: {{ lastRelease }}</span>
-    </AppLink>
-    <AppLink href="https://v3.nuxtjs.org" class="flex items-center group nuxt-text-highlight-hover mt-4">
-      <IconNuxt class="w-5 h-5 mr-2 text-primary" />
-      <span>{{ $t('common.version') }}: v3.x (Beta)</span>
-    </AppLink>
+  <div>
+    <a
+      v-if="
+        masterCoursesLink &&
+        ($docus.currentPath.value.startsWith('/docs') || $docus.currentPath.value.startsWith('/examples'))
+      "
+      :href="masterCoursesLink.href"
+      rel="noopener nofollow noreferrer"
+      target="_blank"
+      :aria-label="masterCoursesLink.title"
+      class="
+        mt-2
+        flex
+        font-medium
+        rounded-md
+        hover:text-sky-black
+        dark:hover:text-white
+        bg-gray-100
+        dark:bg-white dark:bg-opacity-10 dark:bg-opacity-10
+        hover:bg-opacity-9
+      "
+    >
+      <div class="p-2 flex space-x-2">
+        <div class="mt-1 rounded-md w-8 h-8 p-2 bg-green-800 flex-shrink-0">
+          <img :src="`/img/header/${masterCoursesLink.icon}`" :alt="masterCoursesLink.title" />
+        </div>
+        <div>
+          <h5 class="font-bold text-sm">{{ masterCoursesLink.title }}</h5>
+          <p class="text-xs">{{ masterCoursesLink.subtitle }}</p>
+        </div>
+      </div>
+    </a>
+    <div v-if="$docus.currentPath.value.startsWith('/docs')">
+      <AppLink v-if="lastRelease" to="/releases" class="flex items-center group nuxt-text-highlight-hover mt-4">
+        <IconNuxt class="w-5 h-5 mr-2" />
+        <span>{{ $t('common.version') }}: {{ lastRelease }}</span>
+      </AppLink>
+      <AppLink href="https://v3.nuxtjs.org" class="flex items-center group nuxt-text-highlight-hover mt-4">
+        <IconNuxt class="w-5 h-5 mr-2 text-primary" />
+        <span>{{ $t('common.version') }}: v3.x (Beta)</span>
+      </AppLink>
+    </div>
   </div>
 </template>
 
@@ -16,8 +49,12 @@ import { defineComponent, useContext, useFetch, ref } from '@nuxtjs/composition-
 
 export default defineComponent({
   setup() {
-    const { $docus } = useContext()
+    const {
+      $docus,
+      app: { i18n }
+    } = useContext()
     const lastRelease = ref(null)
+    const masterCoursesLink = ref(null)
 
     useFetch(async () => {
       const { body } = await $docus.data('github-releases')
@@ -25,9 +62,15 @@ export default defineComponent({
       if (body?.releases?.length) {
         lastRelease.value = body.releases[0].name
       }
+
+      const header = await $docus
+        .search('/collections/navigations', { deep: true })
+        .where({ slug: { $in: 'header' }, language: i18n.locale })
+        .fetch()
+      masterCoursesLink.value = header[0].links[1].items[3]
     })
 
-    return { lastRelease }
+    return { lastRelease, masterCoursesLink }
   }
 })
 </script>


### PR DESCRIPTION
This PR adds a "Master courses" button in the `AsideBottom` component. The link data is taken from the `collections.navigation.header.links`, to match the link displayed in the "Learn" dropdown.

Screenshots:

![button](https://user-images.githubusercontent.com/3766839/155703358-e50bebed-c479-4411-ac78-53daf5c91f05.png)
![button2](https://user-images.githubusercontent.com/3766839/155703380-1e0b29b9-fc60-4170-ba35-a8e4ee8b226f.png)

