### PR TITLE
Fix typo in generate routes() docs

### DIFF
--- a/content/en/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/en/docs/5.configuration-glossary/11.configuration-generate.md
@@ -201,9 +201,7 @@ Interval in milliseconds between two render cycles to avoid flooding a potential
 - Type: `Array`
 
 ::alert{type="info"}
-As of Nuxt v2.13 there is a crawler installed that will crawl your link tags and generate your routes when running `nuxt generate`.
-
-If have unlinked pages (such as secret pages) and you would like these to also be generated then you can use the `generate.routes` property.
+As of Nuxt v2.13 there is a crawler installed that will crawl your link tags and generate your routes when running `nuxt generate`. If you have unlinked pages (such as secret pages) and you would like these to also be generated then you can use the `generate.routes` property.
 ::
 
 ::alert{type="warning"}


### PR DESCRIPTION
Add missing `you` and space between `.` and `If`.