### PR TITLE
docs: fix typo

### DIFF
--- a/content/en/docs/6.internals-glossary/1.context.md
+++ b/content/en/docs/6.internals-glossary/1.context.md
@@ -160,4 +160,4 @@ The route navigated from.
 
 `nuxtState` _(Object)_
 
-Nuxt state, useful for plugins which uses `beforeNuxtRender` to get the nuxt state on client-side before hydration. **Available only in `universal` mode**.
+Nuxt state, useful for plugins which use `beforeNuxtRender` to get the nuxt state on client-side before hydration. **Available only in `universal` mode**.


### PR DESCRIPTION
I think `plugins which uses` should be `plugins which use` instead in the following line.
https://github.com/nuxt/nuxtjs.org/blob/cdcb2cea9221a30aefb518ef4bf8f936333c1170/content/en/docs/6.internals-glossary/1.context.md?plain=1#L163