### PR TITLE
docs: recommend Volar instead of Vetur

### DIFF
--- a/content/en/docs/1.get-started/1.installation.md
+++ b/content/en/docs/1.get-started/1.installation.md
@@ -24,7 +24,7 @@ You can play with Nuxt online directly on CodeSandbox or StackBlitz:
 ## Prerequisites
 
 - [node](https://nodejs.org) - _We recommend you have the latest LTS version installed_.
-- A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension or [WebStorm](https://www.jetbrains.com/webstorm/).
+- A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) extension or [WebStorm](https://www.jetbrains.com/webstorm/).
 - A terminal, we recommend using VS Code's [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal) or [WebStorm terminal](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
 ## Using create-nuxt-app

--- a/content/es/docs/1.get-started/1.installation.md
+++ b/content/es/docs/1.get-started/1.installation.md
@@ -24,7 +24,7 @@ You can play with Nuxt online directly on CodeSandbox or StackBlitz:
 ## Prerequisites
 
 - [node](https://nodejs.org) - _We recommend you have the latest LTS version installed_.
-- A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension or [WebStorm](https://www.jetbrains.com/webstorm/)
+- A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) extension or [WebStorm](https://www.jetbrains.com/webstorm/)
 - A terminal, we recommend using VS Code's [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal) or [WebStorm terminal](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
 ## Using create-nuxt-app

--- a/content/fr/docs/1.get-started/1.installation.md
+++ b/content/fr/docs/1.get-started/1.installation.md
@@ -25,7 +25,7 @@ Vous pouvez essayer Nuxt en ligne sur CodeSandbox ou StackBlitz:
 ## Prérequis
 
 - [node](https://nodejs.org) - au moins v10.13 _Nous vous recommandons d'installer la dernière version LTS._
-- Un éditeur de texte, nous recommandons [VSCode](https://code.visualstudio.com/) avec l'extension [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) ou [WebStorm](https://www.jetbrains.com/webstorm/)
+- Un éditeur de texte, nous recommandons [VSCode](https://code.visualstudio.com/) avec l'extension [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) ou [WebStorm](https://www.jetbrains.com/webstorm/)
 - Un terminal, nous vous recommandons d'utiliser [le terminal intégré de VSCode](https://code.visualstudio.com/docs/editor/integrated-terminal) ou le [terminal de Webstorm](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
 ## Utiliser create-nuxt-app

--- a/content/ja/docs/1.get-started/1.installation.md
+++ b/content/ja/docs/1.get-started/1.installation.md
@@ -23,7 +23,7 @@ CodeSandbox や StackBlitz で直接 Nuxt をオンラインで試すことが�
 ## 前提条件
 
 - [Node.js](https://nodejs.org) - _最新の LTS バージョンのインストールを推奨します。_
-- テキストエディタ、[VS Code](https://code.visualstudio.com/) と [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) 拡張、または [WebStorm](https://www.jetbrains.com/webstorm/) を推奨します。
+- テキストエディタ、[VS Code](https://code.visualstudio.com/) と [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) 拡張、または [WebStorm](https://www.jetbrains.com/webstorm/) を推奨します。
 - ターミナル、 VS Code に [統合されたターミナル](https://code.visualstudio.com/docs/editor/integrated-terminal) または [WebStorm ターミナル](https://www.jetbrains.com/help/webstorm/terminal-emulator.html) を推奨します。
 
 ## create-nuxt-app の使用

--- a/content/pt-br/docs/1.get-started/1.installation.md
+++ b/content/pt-br/docs/1.get-started/1.installation.md
@@ -24,7 +24,7 @@ Você pode se divertir com o Nuxt de forma online, diretamente pelo CodeSandbox 
 ## Pré-requisitos
 
 - [node](https://nodejs.org) - _Nós recomendamos que você tenha a última versão LTS instalada_.
-- Um editor de texto, nós recomendamos [VS Code](https://code.visualstudio.com/) com a extensão [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) ou [WebStorm](https://www.jetbrains.com/webstorm/)
+- Um editor de texto, nós recomendamos [VS Code](https://code.visualstudio.com/) com a extensão [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) ou [WebStorm](https://www.jetbrains.com/webstorm/)
 - Um terminal, nós recomendamos utilizar o [terminal integrado](https://code.visualstudio.com/docs/editor/integrated-terminal) do VS Code ou [terminal WebStorm](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
 ## Usando create-nuxt-app

--- a/content/pt/docs/1.get-started/1.installation.md
+++ b/content/pt/docs/1.get-started/1.installation.md
@@ -24,7 +24,7 @@ Você pode divertir-se com o Nuxt de forma online, diretamente pelo CodeSandbox 
 ## Pré-requisitos
 
 - [node](https://nodejs.org) - _Nós recomendamos que você tenha a última versão LTS instalada_.
-- Um editor de texto, nós recomendamos [VS Code](https://code.visualstudio.com/) com a extensão [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) ou [WebStorm](https://www.jetbrains.com/webstorm/)
+- Um editor de texto, nós recomendamos [VS Code](https://code.visualstudio.com/) com a extensão [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) ou [WebStorm](https://www.jetbrains.com/webstorm/)
 - Um terminal, nós recomendamos utilizar o [terminal integrado](https://code.visualstudio.com/docs/editor/integrated-terminal) do VS Code ou [terminal WebStorm](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
 ## Usando create-nuxt-app


### PR DESCRIPTION
Volar is the recommended extension for [Vue 3 local setup](https://vuejs.org/guide/quick-start.html#with-build-tools) with VS Code.

I would think this should be the same for Nuxt 3?