### PR TITLE
Add content/pt/examples section translated

### DIFF
--- a/content/pt/deployments/1.netlify.md
+++ b/content/pt/deployments/1.netlify.md
@@ -19,7 +19,7 @@ O centro do processo influencia o comando `nuxt generate`(<= v2.12) durante o de
 <div class="Promo__Video">
   <a href="https://explorers.netlify.com/learn/get-started-with-nuxt/nuxt-generate-and-deploy" target="_blank">
     <p class="Promo__Video__Icon">
-      Assista uma aula gratuita em <strong>Como fazer deploy de uma aplicação Nuxt no Netlify</strong> no Jamstack Explorers
+      Assista uma aula gratuita sobre <strong>Como desdobrar uma aplicação Nuxt no Netlify</strong> no Jamstack Explorers
     </p>
   </a>
 </div>

--- a/content/pt/examples/1.routing/1.hello-world.md
+++ b/content/pt/examples/1.routing/1.hello-world.md
@@ -1,21 +1,21 @@
 ---
 title: Hello World
-description: Routing with NuxtLink component showing page rendered on server side and on client side
+description: Roteando com o componente NuxtLink, mostrando a página renderizada no lado do servidor e no lado do cliente
 category: routing
 ---
 
 # Hello World
 
-Routing with NuxtLink component showing page rendered on server side and on client side
+Roteando com o componente NuxtLink, mostrando a página renderizada no lado do servidor e no lado do cliente
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/index.vue` and `pages/about.vue` show how Nuxt server renders the page on first load or on hard refresh and renders the page on client side when navigating using the `<NuxtLink>` component.
+- O `pages/index.vue` e o `pages/about.vue` mostram como o servidor Nuxt renderiza a página no primeiro carregamento ou no recarregamento e renderiza a página no lado do cliente quando estiver navegando usando o componente `<NuxtLink>`.
 
 ::alert{type="next"}
-Learn more in the Get Started book in the [Installation](/docs/get-started/installation) chapter.
+Saiba mais no livro Começar, no capítulo [instalação](/docs/get-started/installation).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/routing/hello-world?fontsize=14&hidenavigation=1&theme=dark&view=editor"}

--- a/content/pt/examples/1.routing/2.active-link-classes.md
+++ b/content/pt/examples/1.routing/2.active-link-classes.md
@@ -1,25 +1,25 @@
 ---
-title: Active Link Classes
-description: Change the default NuxtLink classes and style the active and exact active classes as well as disable prefetch for a specific link
+title: Classes de Ligação Ativa
+description: Mude as classes padrão do NuxtLink e estilize as classes active e exact active bem como desativar a pré-requisição para um ligação específica
 category: routing
 ---
 
-# Active Link Classes
+# Classes de Ligação Ativa
 
-Change the default NuxtLink classes and style the active and exact active classes as well as disable prefetch for a specific link
+Mude as classes padrão do NuxtLink e estilize as classes active e exact active bem como desativar a pré-requisição para um ligação específica
 
 ---
 
-In this example:
+Neste exemplo:
 
-`layouts/default.vue` shows the styles for `nuxt-link-active` and `nuxt-link-exact-active`.
+- O `layouts/default.vue` mostra os estilos para o `nuxt-link-active` e o `nuxt-link-exact-active`.
 
 ::alert{type="next"}
-Learn more about [vue routers](https://router.vuejs.org/api/#exact-active-class) active and exact active classes.
+Saiba mais sobre as classes `active` e `exact-active` do [roteador do vue](https://router.vuejs.org/api/#exact-active-class).
 ::
 
 ::alert{type="next"}
-Learn more about active classes in the Features book in the [Nuxt Components](/docs/features/nuxt-components#link-classes) chapter.
+Saiba mais sobre as classes `active` dentro do livro de Funcionalidades, no capítulo [Componentes do Nuxt](/docs/features/nuxt-components#link-classes).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/routing/active-link-classes?fontsize=14&hidenavigation=1&module=%2Flayouts%2Fdefault.vue&theme=dark&view=editor"}

--- a/content/pt/examples/1.routing/3.dynamic-pages.md
+++ b/content/pt/examples/1.routing/3.dynamic-pages.md
@@ -1,25 +1,25 @@
 ---
-title: Dynamic Pages
-description: Using dynamic pages to fetch data from an API and populate those pages
+title: Páginas Dinâmicas
+description: Usando páginas dinâmicas para requisitar dados de um API e popular aquelas páginas
 category: routing
 ---
 
-# Dynamic Pages
+# Páginas Dinâmicas
 
-Using dynamic pages to fetch data from an API and populate those pages
+Usando páginas dinâmicas para requisitar dados de um API e popular aquelas páginas
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/_slug.vue` shows data coming from the route params.
+- O `pages/_slug.vue` apresenta dados vindos dos parâmetros da rota.
 
-`pages/index.vue` fetches our mountains from our API.
+- O `pages/index.vue` requisita nossas montanhas a partir da nossa API.
 
-`pages/_continent/_mountain.vue` shows the detail page for each mountain in each continent.
+- O `pages/_continent/_mountain.vue` apresenta a página de detalhe de cada montanha em cada continente.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [pages](/docs/directory-structure/pages) chapter.
+Saiba mais dentro do livro da Estrutura de Diretório, no capítulo de [páginas](/docs/directory-structure/pages).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/routing/dynamic-pages?fontsize=14&hidenavigation=1&module=%2Fpages%2F_continent%2F_mountain.vue&theme=dark&view=editor"}

--- a/content/pt/examples/1.routing/4.nested-pages.md
+++ b/content/pt/examples/1.routing/4.nested-pages.md
@@ -1,25 +1,25 @@
 ---
-title: Nested Pages
-description: How to use the Nuxt Child component to create parent and child pages.
+title: Páginas Aninhadas
+description: Como usar o componente NuxtChild para criar as páginas pai e filho.
 category: routing
 ---
 
-# Nested Pages
+# Páginas Aninhadas
 
-How to use the Nuxt Child component to create parent and child pages.
+Como usar o componente NuxtChild para criar as páginas pai e filho.
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/parent.vue` contains the `<NuxtChild>` component. Everything on this page will be seen on both the parent and child pages.
+- O `pages/parent.vue` contém o componente `<NuxtChild>`. Tudo nesta página será visto em ambas páginas pai e filho.
 
-`pages/parent/index.vue` contains text that will be replaced when the child links are clicked.
+- O `pages/parent/index.vue` contém o texto que será substituído sempre o que as ligações filhos forem clicadas.
 
-`pages/parent/child.vue` and `pages/parent/child2.vue` will be rendered as parent/child and parent/child2.
+- O `pages/parent/child.vue` e o `pages/parent/child2.vue` serão renderizado como pai/filho e pai/filho2.
 
 ::alert{type="next"}
-Learn more in the Features book in the [Nuxt Components](/docs/features/nuxt-components#the-nuxtchild-component) chapter.
+Saiba mais no livro de Funcionalidades, no capítulo [Componentes do Nuxt](/docs/features/nuxt-components#o-componente-nuxtchild).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/routing/nested-pages?fontsize=14&hidenavigation=1&module=%2Fpages%2Fparent.vue&theme=dark&view=editor"}

--- a/content/pt/examples/1.routing/index.md
+++ b/content/pt/examples/1.routing/index.md
@@ -1,4 +1,5 @@
 ---
+title: Roteamento
 navigation:
   collapse: false
   redirect: /examples/routing/hello-world

--- a/content/pt/examples/10.modules/1.local.md
+++ b/content/pt/examples/10.modules/1.local.md
@@ -1,23 +1,25 @@
 ---
-title: Local Module
-description: Local Module for setting up a tunnel using ngrok
+title: Módulo Local
+description: Módulo Local para definição de um túnel com o uso do ngrok
 category: modules
 ---
 
-# Local Module
+# Módulo Local
 
-Local Module for setting up a tunnel using ngrok
+Módulo Local para definição de um túnel com o uso do ngrok
 
 ---
 
-In this example:
+Neste exemplo:
 
-- `modules/ngrok/index.js` adds a public URL from ngrok to the Nuxt CLI when in dev mode.
-- `pages/index.vue` shows the public URL from ngrok.
-- `nuxt.config.js` registers our module using the `buildModules` property.
+- O `modules/ngrok/index.js` adiciona uma URL pública a partir do ngrok para a interface de linha de comando do Nuxt quando estiver no modo de desenvolvimento.
+
+- O `pages/index.vue` mostra a URL pública do ngrok.
+
+- O ficheiro `nuxt.config.js` regista nosso módulo com o uso da propriedade `buildModules`.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [modules](/docs/directory-structure/modules) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [Módulos](/docs/directory-structure/modules).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/modules/local-module?fontsize=14&hidenavigation=1&module=%2Fmodules%2Fngrok%2Findex.js&theme=dark&view=editor"}

--- a/content/pt/examples/10.modules/2.axios.md
+++ b/content/pt/examples/10.modules/2.axios.md
@@ -1,30 +1,30 @@
 ---
-title: Axios usage
-description: In the first example we show how to use the env property in our `nuxt.config.js` file to add the URL of our API so that we can then easily make calls to it without having to use the URL on our page
+title: Uso do Axios
+description: Neste exemplo mostramos como usar a propriedade `env` dentro nosso ficheiro `nuxt.config.js` para adicionar a URL da nossa API para que assim nós possamos depois facilmente fazer chamadas para ela sem ter que usar a URL na nossa página
 category: modules
 ---
 
-# Axios usage
+# Uso do Axios
 
-In the first example we show how to use the env property in our `nuxt.config.js` file to add the URL of our API so that we can then easily make calls to it without having to use the URL on our page
+Neste exemplo mostramos como usar a propriedade `env` dentro nosso ficheiro `nuxt.config.js` para adicionar a URL da nossa API para que assim nós possamos depois facilmente fazer chamadas para ela sem ter que usar a URL na nossa página
 
 ---
 
-In this example:
+Neste exemplo:
 
-`nuxt.config.js` contains :
+- O ficheiro `nuxt.config.js` contém:
 
-- the `publicRuntimeConfig` property to add the URL of our API.
-- the `modules` property to register our `@nuxtjs/axios` module.
+  - a propriedade `publicRuntimeConfig` para adicionar a URL da nossa API.
+  - a propriedade `modules` para registar nosso módulo `@nuxtjs/axios`.
 
-`pages/index.vue` - uses `$axios` to fetch our data and `$config` to retrieve our API URL.
+- O `pages/index.vue` - usa `$axios` para requisitar nossos dados e o `$config` para recuperar a URL da nossa API.
 
 ::alert{type="next"}
-Learn more about the [axios module](https://axios.nuxtjs.org/).
+Saiba mais sobre o [Módulo de Axios](https://axios.nuxtjs.org/).
 ::
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [nuxt-config](/docs/directory-structure/nuxt-config) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [Configuração do Nuxt](/docs/directory-structure/nuxt-config).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/modules/axios-usage?fontsize=14&hidenavigation=1&module=%2Fnuxt.config.js&theme=dark&view=editor"}

--- a/content/pt/examples/10.modules/index.md
+++ b/content/pt/examples/10.modules/index.md
@@ -1,4 +1,5 @@
 ---
+title: Módulos
 navigation:
   collapse: true
   redirect: /examples/modules/local

--- a/content/pt/examples/2.data-fetching/1.async-data.md
+++ b/content/pt/examples/2.data-fetching/1.async-data.md
@@ -1,25 +1,25 @@
 ---
-title: asyncData Hook
-description: In this example we use asyncData to fetch our data from our API.
+title: O gatilho asyncData
+description: Neste exemplo nós usamos o gatilho asyncData para requisitar nossos dados da nossa API.
 category: dataFetching
 ---
 
-# asyncData Hook
+# O gatilho asyncData
 
-In this example we use asyncData to fetch our data from our API.
+Neste exemplo nós usamos o gatilho `asyncData` para requisitar nossos dados da nossa API.
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/index.vue` and `pages/posts/_id` use the `asyncData` hook and the `$http` module to fetch our list of mountains from our API.
+- O `pages/index.vue` e o `pages/posts/_id` usam o gatilho `asyncData` e o módulo `$http` para requisitar nossa lista de montanhas da nossa API.
 
 ::alert{type="next"}
-Learn more about the [http module](https://http.nuxtjs.org/).
+Saiba mais sobre o [módulo http](https://http.nuxtjs.org/).
 ::
 
 ::alert{type="next"}
-Learn more about the asyncData hook the Features book in the [Data Fetching](/docs/features/data-fetching) chapter.
+Saiba mais sobre o gatilho `asyncData` no livro de Funcionalidades, no capítulo [Requisição de Dados](/docs/features/data-fetching).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/data-fetching/async-data-hook?fontsize=14&hidenavigation=1&theme=dark&view=editor"}

--- a/content/pt/examples/2.data-fetching/2.fetch-hook.md
+++ b/content/pt/examples/2.data-fetching/2.fetch-hook.md
@@ -1,29 +1,29 @@
 ---
-title: fetch Hook
-description: In this example we use the fetch hook to fetch data from components and from pages
+title: O gatilho fetch
+description: Neste exemplo nós usamos o gatilho fetch para requisitar os dados a partir das páginas e e dos componentes
 category: dataFetching
 ---
 
-# fetch Hook
+# O gatilho fetch
 
-In this example we use the fetch hook to fetch data from components and from pages
+Neste exemplo nós usamos o gatilho `fetch` para requisitar os dados a partir das páginas e e dos componentes
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/index.vue` imports `components/Mountains.vue` which uses the `fetch` hook and the `$http` module to fetch our data at component level while `pages/mountains/_slug` fetches the data at page level and include:
+- O `pages/index.vue` importa o `components/Mountains.vue` o qual usa o gatilho `fetch` e o módulo `$http` para requisitar nossos dados no nível do componente enquanto `pages/mountains/_slug` requisita os dados no nível da página e inclui:
 
-- `$fetchState.pending` to show a loading text when the data is loading.
-- `$fetchState.error` to show an error message when we can't retrieve the data.
-- `$fetch` to fetch the data again when clicked.
+  - `$fetchState.pending` para mostrar um texto de carregamento quando os dados estiverem carregando.
+  - `$fetchState.error` para mostrar uma mensagem de erro quando nós não conseguimos recuperar os dados.
+  - `$fetch` para requisitar os dados novamente sempre que clicado.
 
 ::alert{type="next"}
-Learn more about the [http module](https://http.nuxtjs.org/).
+Saiba mais sobre o [módulo http](https://http.nuxtjs.org/).
 ::
 
 ::alert{type="next"}
-Learn more about the fetch hook in the Features book in the [Data Fetching](/docs/features/data-fetching) chapter.
+Saiba mais sobre o gatilho `fetch` no livro de Funcionalidades, no capítulo [Requisição de Dados](/docs/features/data-fetching).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/data-fetching/fetch-hook?fontsize=14&hidenavigation=1&module=%2Fcomponents%2FMountains.vue&theme=dark&view=editor"}

--- a/content/pt/examples/2.data-fetching/index.md
+++ b/content/pt/examples/2.data-fetching/index.md
@@ -1,4 +1,5 @@
 ---
+title: Requisição de Dados
 navigation:
   collapse: true
   redirect: /examples/data-fetching/async-data

--- a/content/pt/examples/3.assets-management/1.pre-processors.md
+++ b/content/pt/examples/3.assets-management/1.pre-processors.md
@@ -1,29 +1,29 @@
 ---
-title: Pre-processors
-description: Configuration your application to use pug and sass with style resources to easily add variables to all components.
+title: Pré-processadores
+description: Configura a sua aplicação para usar o pug e o sass com os recursos de estilo para adicionar facilmente variáveis em todos componentes.
 category: assetManagement
 ---
 
-# Pre-processors
+# Pré-processadores
 
-Configuration your application to use pug and sass with style resources to easily add variables to all components.
+Configura a sua aplicação para usar o `pug` e o `sass` com os recursos de estilo para adicionar facilmente variáveis em todos componentes.
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/index.vue` uses pug as a template language and sass for styling.
+- O `pages/index.vue` usa o pug como uma linguagem de modelo e o sass para estilização.
 
-`nuxt.config.js`:
+- O `nuxt.config.js`:
 
-- registers the style resources module.
-- contains a `styleResources` property to add `assets/variables.scss`.
-- contains a `css` property to add `assets/main.scss`.
+  - regista o módulo de recursos de estilo
+  - contém uma propriedade `styleResource` para adicionar `assets/variables.scss`.
+  - contém uma propriedade `css` para adicionar `assets/main.scss`.
 
-`package.json` shows the dependencies needed.
+- O `package.json` mostra as dependências necessárias.
 
 ::alert{type="next"}
-Learn more in the Features book in the [Configuration](/docs/features/configuration#pre-processors) chapter.
+Saiba mais no livro de Funcionalidades, no capítulo de [Configuração](/docs/features/configuration#pré-processadores). 
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/asset-management/pre-processors?fontsize=14&hidenavigation=1&theme=dark&view=editor"}

--- a/content/pt/examples/3.assets-management/2.webpack-assets.md
+++ b/content/pt/examples/3.assets-management/2.webpack-assets.md
@@ -1,29 +1,29 @@
 ---
-title: webpack Assets
-description: Use the assets folder to add css, images and fonts to your application
+title: Recursos do Webpack
+description: Use a pasta de recursos para adicionar o css, as imagens e as fontes à sua aplicação
 category: assetManagement
 ---
 
-# webpack Assets
+# Recursos do Webpack
 
-Use the assets folder to add css, images and fonts to your application
+Usar a pasta de recursos para adicionar o css, as imagens e as fontes à sua aplicação
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/index.vue` shows:
+- O `pages/index.vue` mostra:
 
-- how to add an image from the assets folder.
-- how to add a background image from the assets folder using CSS.
-- how to add dynamic images from the assets folder using the data property.
+  - como adicionar uma imagem da pasta de recursos.
+  - como adicionar como fundo uma imagem da pasta de recursos usando CSS.
+  - como adicionar de forma dinâmica imagens da pasta de recursos usando a propriedade `data`
 
-`nuxt.config.js` contains the `css` property for globally adding a css file.
+- O `nuxt.config.js` contém a propriedade `css` para adicionar globalmente um ficheiro css.
 
-`assets/main.css` shows how to reference the DMSans fonts from the assets folder using the `@font-face` rule.
+- O `assets/main.css` mostra como referenciar as fontes DM Sans da pasta de recursos usando a regra `@font-face`.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [Assets](/docs/directory-structure/assets) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [Recursos](/docs/directory-structure/assets).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/asset-management/webpack-assets?fontsize=14&hidenavigation=1&theme=dark&view=editor"}

--- a/content/pt/examples/3.assets-management/index.md
+++ b/content/pt/examples/3.assets-management/index.md
@@ -1,4 +1,5 @@
 ---
+title: Gestão de Recursos
 navigation:
   collapse: true
   redirect: /examples/assets-management/pre-processors

--- a/content/pt/examples/4.transitions/1.transitions.md
+++ b/content/pt/examples/4.transitions/1.transitions.md
@@ -1,24 +1,24 @@
 ---
-title: Nuxt transitions
-description: Adding default and custom transitions to your pages and layouts
+title: Transições do Nuxt
+description: Adicionando o padrão e as transições personalizadas às suas páginas e esquemas
 category: transitions
 ---
 
-# Nuxt transitions
+# Transições do Nuxt
 
-Adding default and custom transitions to your pages and layouts
+Adicionando o padrão e as transições personalizadas às suas páginas e esquemas
 
 ---
 
-In this example:
+Neste exemplo:
 
-- `pages/index.vue` and `pages/fade.vue` use the default page transiton.
-- `pages/bounce.vue` uses the `transition` property with a bounce transition
-- `pages/slide.vue` uses the `transition` property with a slide-bottom transition.
-- `layout/default.vue` contains the classes for all transitions.
+- O `pages/index.vue` e o `pages/fade.vue` usam a transição de página padrão.
+- O `pages/bounce.vue` usa a propriedade `transition` com um transição `bounce` (saltar)
+- O `pages/slide.vue` usa a propriedade `transition` com uma transição `slide-bottom` (deslizar para baixo)
+- O `layout/default.vue` contém as classes para todas as transições.
 
 ::alert{type="next"}
-Learn more in the Features book in the [Transitions](/docs/features/transitions) chapter.
+Saiba mais no livro Funcionalidades, no capítulo de [Transições](/docs/features/transitions).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/transitions/nuxt-transitions?fontsize=14&hidenavigation=1&module=%2Flayouts%2Fdefault.vue&theme=dark&view=editor"}

--- a/content/pt/examples/4.transitions/index.md
+++ b/content/pt/examples/4.transitions/index.md
@@ -1,4 +1,5 @@
 ---
+title: Transições
 navigation:
   collapse: true
   redirect: /examples/transitions/transitions

--- a/content/pt/examples/5.seo/1.html-head.md
+++ b/content/pt/examples/5.seo/1.html-head.md
@@ -1,29 +1,29 @@
 ---
-title: SEO HTML Head
-description: In this example we use the head property to show how to get good SEO.
+title: Otimização de Motor de Busca com o Cabeçalho do HTML
+description: Neste exemplo nós usamos a propriedade head para mostrar como conseguir uma boa otimização do motor de busca.
 category: seo
 ---
 
-# SEO HTML Head
+# Otimização de Motor de Busca com o Cabeçalho do HTML
 
-In this example we use the head property to show how to get good SEO.
+Neste exemplo nós usamos a propriedade `head` para mostrar como conseguir uma boa otimização de motor de busca.
 
 ---
 
-In this example:
+Neste exemplo:
 
-`nuxt.config.js` uses the `head` property to show a `title`, `titleTemplate`, and `meta` including `description`. It also shows how to add an external google font using the link property and some JS using the script property. The lang and amp attributes are set with the `htmlAttrs` property.
+- O ficheiro `nuxt.config.js` usa a propriedade `head` para mostrar um `title` (título), `titleTemplate` (modelo do título), e `meta` incluindo o `description` (descrição). Ele também mostra como adicionar uma fonte externa do Google usando a propriedade `link` e algum JavaScript usando a propriedade `script`. Os atributos `lang` e `amp` são definidos com a propriedade `htmlAttrs`.
 
-`pages/index.vue` uses the head property as a function with dynamic data and uses the google font.
+- O `pages/index.vue` usa a propriedade `head` como uma função com dados dinâmicos e usa o Google Font.
 
-`pages/about.vue` uses the head property as an object.
+- O `pages/about.vue` usa a propriedade `head` como um objeto.
 
 ::alert{type="next"}
-Learn more about the options available for `head`, in the [vue-meta documentation](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
+Saiba mais sobre as opções disponíveis para o `head`, dentro da [documentação do vue-meta](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
 ::
 
 ::alert{type="next"}
-Learn more about meta tags in the Features book in the [Meta Tags and SEO](/docs/features/meta-tags-seo) chapter.
+Saiba mais sobre as meta tags no livro de Funcionalidades, no capítulo [Meta Tags and SEO](/docs/features/meta-tags-seo).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/seo/seo-html-head?fontsize=14&hidenavigation=1&module=%2Fnuxt.config.js&theme=dark&view=editor"}

--- a/content/pt/examples/5.seo/2.twitter-og.md
+++ b/content/pt/examples/5.seo/2.twitter-og.md
@@ -1,29 +1,29 @@
 ---
-title: SEO Twitter and Open Graph
-description: In this example we create a component to add our Twitter and Open Graph tags for when sharing on social media.
+title: Otimização do Motor de Busca do Twitter e o Open Graph
+description: Neste exemplo nós criamos um componente para adicionar o nosso Twitter e marcadores de Open Graph para quando estivermos partilhando na mídia social.
 category: seo
 ---
 
-# SEO Twitter and Open Graph
+# Otimização de Motor de Busca do Twitter e o Open Graph
 
-In this example we create a component to add our Twitter and Open Graph tags for when sharing on social media.
+Neste exemplo nós criamos um componente para adicionar o nosso Twitter e marcadores de Open Graph para quando estivermos partilhando na mídia social.
 
 ---
 
-In this example:
+Neste exemplo:
 
-`components/SocialHead` uses the `head` property to show `meta` for both Twitter and Open Graph social sharing using props.
+- O `components/SocialHead` usa a propriedade `head` para mostrar o `meta` para ambos partilhamento Twitter e o Open Graph Social usando propriedades.
 
-`pages/mountains/slug.vue` uses the `SocialHead` component passing the mountain's title, description and image as the values for props. It also uses the head tag to set the canonical link.
+- O `pages/mountains/slug.vue` usa o componente `SocialHead` passando o título da montanha, a descrição e a imagem como valores para as propriedades. Ele também usa a tag `head` para definir a ligação canónica.
 
-`nuxtconfig.js` shows the head tag with default meta for social sharing for when the the `SocialHead` component is not used as well as the canonical link.
+- O ficheiro `nuxt.config.js` mostra a tag `head` com o `meta` padrão para partilhamento social para quando o componente `SocialHead` não for usado bem como a ligação canónica.
 
 ::alert{type="next"}
-Learn more about the options available for `head`, in the [vue-meta documentation](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
+Saiba mais sobre as opções disponíveis para o `head`, dentro da [documentação do vue-meta](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
 ::
 
 ::alert{type="next"}
-Learn more about meta tags in the Features book in the [Meta Tags and SEO](/docs/features/meta-tags-seo) chapter.
+Saiba mais sobre as meta tags no livro de Funcionalidades, no capítulo [Marcadores de Meta e SEO](/docs/features/meta-tags-seo).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/seo/seo-twitter-og?fontsize=14&hidenavigation=1&module=%2Fcomponents%2FSocialHead.vue&theme=dark&view=editor"}

--- a/content/pt/examples/5.seo/index.md
+++ b/content/pt/examples/5.seo/index.md
@@ -1,4 +1,5 @@
 ---
+title: SEO
 navigation:
   collapse: true
   redirect: /examples/seo/html-head

--- a/content/pt/examples/6.loading/1.customize-nuxt-loading.md
+++ b/content/pt/examples/6.loading/1.customize-nuxt-loading.md
@@ -1,23 +1,23 @@
 ---
-title: Customize Nuxt Loading
-description: Create a custom loading component to replace the default loader
+title: Personalize o Carregamento do Nuxt
+description: Crie um componente de carregamento personalizado para substituir o carregador padrão
 category: loading
 ---
 
-# Customize Nuxt Loading
+# Personalize o Carregamento do Nuxt
 
-Create a custom loading component to replace the default loader
+Crie um componente de carregamento personalizado para substituir o carregador padrão
 
 ---
 
-In this example:
+Neste exemplo:
 
-`nuxt.config.js` contains the `loading` property which modifies the default loader
+- O ficheiro `nuxt.config.js` contém a propriedade `loading` a qual modifica o carregador padrão
 
-`pages/loading.vue` programmatically starts the loader so we force the page to take 2 seconds to load
+- O `pages/loading.vue` inicia programaticamente o carregador assim nós forçamos a página a levar dois segundos para carregar
 
 ::alert{type="next"}
-Learn more in the Features book in the [Loading](/docs/features/loading) chapter.
+Saiba mais no livro de Funcionalidades, no capítulo [Carregamento](/docs/features/loading).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/loading/customize-nuxt-loading?fontsize=14&hidenavigation=1&module=%2Fnuxt.config.js&theme=dark&view=editor"}

--- a/content/pt/examples/6.loading/2.customize-loading-indicator.md
+++ b/content/pt/examples/6.loading/2.customize-loading-indicator.md
@@ -1,24 +1,24 @@
 ---
-title: Customize Nuxt Loading Indicator
-description: Customize the Nuxt Loading Indicator for when ssr is set to false
+title: Personalize o Indicador de Carregamento do Nuxt
+description: Personalize o Indicador de Carregamento do Nuxt para quando a renderização no lado do servidor estiver defina como false
 category: loading
 ---
 
-# Customize Nuxt Loading Indicator
+# Personalize o Indicador de Carregamento do Nuxt
 
-Customize the Nuxt Loading Indicator for when ssr is set to false
+Personalize o Indicador de Carregamento do Nuxt para quando a renderização no lado do servidor estiver definida como `false`
 
 ---
 
-In this example:
+Neste exemplo:
 
-`nuxt.config.js` contains:
+O ficheiro `nuxt.config.js` contém:
 
-- `ssr: false` so we only have client side rendering
-- `loadingIndicator` property to modify the default spinner
+- `ssr: false` assim nós apenas temos a renderização no lado do cliente
+- A propriedade `loadingIndicator` para modificar o rodopiador (spinner) padrão
 
 ::alert{type="next"}
-Learn more in the Features book in the [Loading](/docs/features/loading) chapter.
+Saiba mais no livro de Funcionalidades, no capítulo [Carregamento](/docs/features/loading).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/loading/customize-loading-indicator?fontsize=14&hidenavigation=1&module=%2Fnuxt.config.js&theme=dark&view=editor"}

--- a/content/pt/examples/6.loading/3.custom-loading-component.md
+++ b/content/pt/examples/6.loading/3.custom-loading-component.md
@@ -1,25 +1,25 @@
 ---
-title: Custom Loading Component
-description: Create a custom loading component, modify the default loader as well as the spinner for spas
+title: Personalize o Componente de Carregamento
+description: Crie um componente de carregamento personalizado, modifique o carregador padrão bem como o rodopiador para Aplicações de Página única
 category: loading
 ---
 
-# Custom Loading Component
+# Componente de Carregamento Personalizado
 
-Create a custom loading component, modify the default loader as well as the spinner for spas
+Crie um componente de carregamento personalizado, modifique o carregador padrão bem como o rodopiador para Aplicações de Página única
 
 ---
 
-In this example:
+Neste exemplo:
 
-`components/LoadingBar.vue` shows a custom loading spinner to use instead of the default loading bar.
+- O `components/LoadingBar.vue` mostra um rodopiador de carregamento personalizado para usar ao invés da barra de carregamento padrão.
 
-`nuxt.config.js` contains the `loading` property which imports the loading component
+- O ficheiro `nuxt.config.js` contém a propriedade `loading` a qual importa o componente de carregamento
 
-`pages/loading.vue` programmatically starts the loader so we force the page to take 2 seconds to load
+- O `pages/loading.vue` inicia programaticamente o carregador assim nós forçamos a página a levar dois segundos para carregar
 
 ::alert{type="next"}
-Learn more in the Features book in the [Loading](/docs/features/loading) chapter.
+Saiba mais no livro de Funcionalidades, no capítulo [Carregamento](/docs/features/loading).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/loading/custom-loading-component?fontsize=14&hidenavigation=1&module=%2Fcomponents%2FLoadingBar.vue&theme=dark&view=editor"}

--- a/content/pt/examples/6.loading/index.md
+++ b/content/pt/examples/6.loading/index.md
@@ -1,4 +1,5 @@
 ---
+title: Carregamento
 navigation:
   collapse: true
   redirect: /examples/loading/customize-nuxt-loading

--- a/content/pt/examples/7.miscellaneous/1.layouts.md
+++ b/content/pt/examples/7.miscellaneous/1.layouts.md
@@ -1,23 +1,23 @@
 ---
-title: Layouts
-description: Using layouts to show different ways to structure your page
+title: Esquemas
+description: Usando esquemas para mostrar diferentes maneiras de estruturar a sua página
 category: miscellaneous
 ---
 
-# Layouts
+# Esquemas
 
-Using layouts to show different ways to structure your page
+Usando esquemas para mostrar diferentes maneiras de estruturar a sua página
 
 ---
 
-In this example:
+Neste exemplo:
 
-- `layouts/default.vue` is used in the home page as no layout property is defined
-- `layouts/auth.vue` is used in the /login page with the `layout` property set to 'auth'
-- `layouts/profile.vue` is used in the /profile page the `layout` property set to 'profile'
+- O `layouts/default.vue` é usado dentro da página inicial uma vez que não há a propriedade `layout` sendo definida
+- O `layouts/auth.vue` é usado dentro da página `/login` com a propriedade `layout` definida para `'auth'`
+- O `layouts/profile.vue` é usado dentro da página `/profile` e a propriedade `layout` definida para `'profile'`
 
 ::alert{type="next"}
-Learn more in the Concepts book in the [Views](/docs/concepts/views) chapter or in the Directory Structure book in the [Layouts](/docs/directory-structure/layouts) chapter.
+Saiba mais no livro de Conceitos, no capítulo de [Apresentações](/docs/concepts/views) ou no livro Estrutura de Diretório, no capítulo [Esquemas](/docs/directory-structure/layouts).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/miscellaneous/layouts?fontsize=14&hidenavigation=1&module=%2Fpages%2Fprofile.vue&theme=dark&view=editor"}

--- a/content/pt/examples/7.miscellaneous/2.lazy-loading-components.md
+++ b/content/pt/examples/7.miscellaneous/2.lazy-loading-components.md
@@ -1,28 +1,28 @@
 ---
-title: Lazy Loading Components
-description: Use fetch in your components to fetch data from an API as well as auto importing and lazy loading components
+title: Carregar Preguiçosamente Os Componentes
+description: Use o fetch dentro dos seus componentes para requisitar dados de uma API bem como importar automaticamente e carregamento preguiçoso de componentes.
 category: miscellaneous
 ---
 
-# Lazy Loading Components
+# Carregar Preguiçosamente Os Componentes
 
-Use fetch in your components to fetch data from an API as well as auto importing and lazy loading components
+Use o `fetch` dentro dos seus componentes para requisitar dados de uma API bem como importar automaticamente e carregar preguiçosamente os componentes
 
 ---
 
-In this example:
+Neste exemplo:
 
-`components/MountainsList.vue` uses fetch to fetch data from an API and uses:
+O `components/MountainsList.vue` usa o `fetch` para requisitar dados de um API e usa:
 
-- `$fetchState.pending` to show a loading message when waiting for the data to load.
-- `$fetchState.error` to show an error message if the component does not load.
+- O `$fetchState.pending` para mostrar uma mensagem de carregamento quando estiver esperando os dados carregarem.
+- O `$fetchState.error` mostra uma mensagem de erro se o componente não carregar.
 
-`pages/index.vue` shows how to lazy load a component by prefixing it with the word "Lazy".
+O `pages/index.vue` mostra como carregar preguiçosamente um componente ao prefixar ele com a palavra `"Lazy"`.
 
-`nuxt.config.js` shows `components: true` for auto importing components.
+O ficheiro `nuxt.config.js` mostra `components: true` para importação automatica de componentes.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [Components](/docs/directory-structure/components) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo de [Componentes](/docs/directory-structure/components).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/miscellaneous/lazy-loading-components?fontsize=14&hidenavigation=1&theme=dark&view=editor"}

--- a/content/pt/examples/7.miscellaneous/3.vuex-store.md
+++ b/content/pt/examples/7.miscellaneous/3.vuex-store.md
@@ -1,23 +1,23 @@
 ---
-title: Vuex Store
-description: In the first example we show how the store works using a todo app
+title: A Memória do Vuex
+description: Dentro do primeiro exemplo nós mostramos como a memória do vuex funciona usando uma aplicação de ToDo
 category: miscellaneous
 ---
 
-# Vuex Store
+# A Memória do Vuex
 
-In the first example we show how the store works using a todo app
+Dentro do primeiro exemplo nós mostramos como a memória do vuex funciona usando uma aplicação de ToDo
 
 ---
 
-In this example:
+Neste exemplo:
 
-`store/todos.js` stores state and mutations for our todo list.
+- O `store/todos.js` armazena o estado e mutações para a nossa lista de ToDo.
 
-`pages/index.vue` imports the `mapMutations` from the store and uses `computed` properties and `methods` to add and remove todos from the store.
+- O `pages/index.vue` importa o `mapMutations (mapa de mutações)` da memória e usa propriedades `computed (computadas)` e `methods (métodos)` para adicionar e remover ToDos da memória.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [store](/docs/directory-structure/store) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [Memória (Store)](/docs/directory-structure/store).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/14_store?fontsize=14&hidenavigation=1&theme=dark&view=editor"}

--- a/content/pt/examples/7.miscellaneous/4.helpers.md
+++ b/content/pt/examples/7.miscellaneous/4.helpers.md
@@ -1,29 +1,29 @@
 ---
-title: Nuxt Helpers
-description: Using the $nuxt helpers with $nuxt.isOnline, renderedOn, refresh(), onNuxtReady
+title: Os Auxiliares do Nuxt
+description: Usando os ajudadores do $nuxt com o $nuxt.isOnline, renderedOn, refresh(), e o onNuxtReady
 category: miscellaneous
 ---
 
-# Nuxt Helpers
+# Os Auxiliares do Nuxt
 
-Using the $nuxt helpers with $nuxt.isOnline, renderedOn, refresh(), onNuxtReady
+Usando os auxiliares do `$nuxt` com o `$nuxt.isOnline`, `renderedOn`, `refresh()`, e o `onNuxtReady`
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/index.vue` shows:
+O `pages/index.vue` mostra:
 
-- `$nuxt.isOnline` and `$nuxt.isOffline` - tells the user if they are online or offline.
-- `renderedOn` - prints a message telling us if the page is rendered on the server or client.
-- `$nuxt.refresh()` - refreshes data without refreshing the page.
+- O `$nuxt.isOnline` e o `$nuxt.isOffline` - que dizem aos usuários se eles estão em linha (online) ou fora de linha (offline).
+- O `renderedOn` - que imprime uma mensagem dizendo a nós se a página está renderizada no servidor ou no cliente.
+- O `$nuxt.refresh()` - que atualiza dos dados sem recarregar a página.
 
-`plugins/nuxt-ready.client.js` shows:
+O `plugins/nuxt-ready.client.js` mostra:
 
-- `window.onNuxtReady` - logs a message to the console when Nuxt is ready.
+- O `window.onNuxtReady` - que regista uma mensagem na consola quando o Nuxt estiver pronto.
 
 ::alert{type="next"}
-Learn more in the Concepts book in the [Context and Helpers](/docs/concepts/context-helpers#helpers) chapter.
+Saiba mais no livro Conceitos, no capítulo [Contexto e Auxiliares](/docs/concepts/context-helpers#os-auxiliares).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/miscellaneous/nuxt-helpers?fontsize=14&hidenavigation=1&theme=dark&view=editor"}

--- a/content/pt/examples/7.miscellaneous/index.md
+++ b/content/pt/examples/7.miscellaneous/index.md
@@ -1,4 +1,5 @@
 ---
+title: Variados
 navigation:
   collapse: true
   redirect: /examples/miscellaneous/layouts

--- a/content/pt/examples/8.middlewares/1.router.md
+++ b/content/pt/examples/8.middlewares/1.router.md
@@ -1,27 +1,27 @@
 ---
-title: Router Middleware
-description: Using router middleware to set a class to the body so we can then style differently depending on the route
+title: O Intermédiario do Roteador
+description: Usando o intermédiario do roteador para definir uma classe ao body assim podemos depois estilizar de maneira diferente dependendo da rota
 category: middleware
 ---
 
-# Router Middleware
+# O Intermédiario do Roteador
 
-Using router middleware to set a class to the body so we can then style differently depending on the route
+Usando o intermédiario do roteador para definir uma classe ao `body` assim podemos depois estilizar de maneira diferente dependendo da rota
 
 ---
 
-In this example:
+Neste exemplo:
 
-`store/class.js` sets a class to the body.
+O `store/class.js` define uma classe ao `body`.
 
-`middleware/class.js` uses router middleware to set a class before we enter the route.
+O `middleware/class.js` usa o intermédiario do roteador para definir uma classe antes de nós acessarmos a rota.
 
-`components/Navigation.vue` changes the font size for the route with the name of `router-middleware`.
+O `components/Navigation.vue` muda o tamanho da fonte para a rota com o nome de `router-middleware`.
 
-`nuxt.config.js` contains the `router` property to activate the middleware.
+O `nuxt.config.js` contém a propriedade `router` para ativar o intermédiario.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [middleware](/docs/directory-structure/middleware#router-middleware) chapter.
+Saiba mais no livro Estrutura de Diretório, dentro do capítulo [intermédiario](/docs/directory-structure/middleware#intermédiario-do-roteador).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/middleware/router-middleware?fontsize=14&hidenavigation=1&module=%2Fnuxt.config.js&theme=dark&view=editor"}

--- a/content/pt/examples/8.middlewares/2.named.md
+++ b/content/pt/examples/8.middlewares/2.named.md
@@ -1,27 +1,27 @@
 ---
-title: Named Middleware
-description: Using named middleware to authenticate a user using the store and allow them to visit a page once authenticated
+title: O Intermediário Nomeado
+description: Usando intermediário nomeado para autenticar os usuários com uso da memória e permitir eles visitarem uma página uma vez autenticados 
 category: middleware
 ---
 
-# Named Middleware
+# O Intermediário Nomeado
 
-Using named middleware to authenticate a user using the store and allow them to visit a page once authenticated
+Usando intermediário nomeado para autenticar os usuários com uso da memória e permitir eles visitarem uma página uma vez autenticados 
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/named-middleware.vue` contains a `middleware` property with the value of `auth` which is called before a user enters the route.
+- O `pages/named-middleware.vue` contém uma propriedade `middleware` com o valor de `auth` o qual é chamada antes de um usuário acessar a rota.
 
-`middleware/auth.js` checks to see if the user is authenticated and if they aren't it redirects them to the auth page.
+- O `middleware/auth.js` verifica para saber se os usuários estão se eles não estiverem redireciona eles para a página de autenticação.
 
-`pages/auth.vue` uses the store to authenticate the user.
+- O `pages/auth.vue` usa a memória para autenticar o usuário.
 
-`store/auth.js` sets the the user and password values and redirects the user.
+- O `store/auth.js` define os valores do usuário e a palavra-chave e redireciona o usuário.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [middleware](/docs/directory-structure/middleware#named-middleware) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [intermediário](/docs/directory-structure/middleware#intermediário-nomeado).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/middleware/named-middleware?fontsize=14&hidenavigation=1&module=%2Fpages%2Fnamed-middleware.vue&theme=dark&view=editor"}

--- a/content/pt/examples/8.middlewares/3.anonymous.md
+++ b/content/pt/examples/8.middlewares/3.anonymous.md
@@ -1,23 +1,23 @@
 ---
-title: Anonymous Middleware
-description: Using anonymous middleware to show the analytics of how many times a user visits a page.
+title: O Intermediário Anónimo
+description: Usando intermediários anónimos para mostrar os analíticos de quantas vezes um usuário visitou uma página.
 category: middleware
 ---
 
-# Anonymous Middleware
+# O Intermediário Anónimo
 
-Using anonymous middleware to show the analytics of how many times a user visits a page.
+Usando intermediários anónimos para mostrar os analíticos de quantas vezes um usuário visitou uma página.
 
 ---
 
-In this example:
+Neste exemplo:
 
-`pages/anonymous-middleware.vue` contains a middleware function which uses the store to call the increment mutation with results from the store displayed on the page.
+- O `pages/anonymous-middleware.vue` contém uma função intermediária a qual usa a memória para chamar a mutação de incremento com resultados da memória exibidos na página.
 
-`store/analytics.js` sets the `pageVisits` to 0 and increments the visits every time the increment function is called.
+- O `store/analytics.js` define o `pageVisits` para 0 e incrementa as visitas todo vez que a função de incremento é chamada.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [middleware](/docs/directory-structure/middleware#anonymous-middleware) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [intermediário](/docs/directory-structure/middleware#intermediário-anónimo).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/middleware/anonymous-middleware?fontsize=14&hidenavigation=1&module=%2Fpages%2Fanonymous-middleware.vue&theme=dark&view=editor"}

--- a/content/pt/examples/8.middlewares/index.md
+++ b/content/pt/examples/8.middlewares/index.md
@@ -1,4 +1,5 @@
 ---
+title: Intermediários
 navigation:
   collapse: true
   redirect: /examples/middlewares/router

--- a/content/pt/examples/9.plugins/1.vue.md
+++ b/content/pt/examples/9.plugins/1.vue.md
@@ -1,27 +1,27 @@
 ---
-title: Vue Plugins
-description: In this example we show how to add a vue plugin to your application
+title: Plugins de Vue
+description: Neste exemplo mostramos como adicionar um plugin de vue à sua aplicação
 category: plugins
 ---
 
-# Vue Plugins
+# Plugins de Vue
 
-In this example we show how to add a vue plugin to your application
+Neste exemplo mostramos como adicionar um plugin de vue à sua aplicação
 
 ---
 
-In this example:
+Neste exemplo:
 
-`plugins/vue-tooltip.js` imports our tooltip and tells Vue to use it.
+- O `plugins/vue-tooltip.js` importa nossa dica de ferramenta e diz ao Vue para usar ela.
 
-`pages/index.vue` uses our plugin.
+- O `pages/index.vue` usa o nosso plugin.
 
-`nuxt.config.js` contains the `plugins` property to register our plugin and the `css` property to add our tooltip css.
+- O ficheiro `nuxt.config.js` contém a propriedade `plugins` para registar o nosso plugin e a propriedade `css` para adicionar o estilo da nossa dica de ferramenta.
 
-`package.json` shows our tooltip package has been installed.
+- O `package.json` mostra que o nosso pacote de dica de ferramenta tem sido instalada
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [plugins](/docs/directory-structure/plugins#vue-plugins) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [Plugins](/docs/directory-structure/plugins#plugins-de-vue).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/plugins/vue-plugins?fontsize=14&hidenavigation=1&module=%2Fplugins%2Fvue-tooltip.js&theme=dark&view=editor"}

--- a/content/pt/examples/9.plugins/2.client-only.md
+++ b/content/pt/examples/9.plugins/2.client-only.md
@@ -1,23 +1,23 @@
 ---
-title: Client Only Plugins
-description: In this example we show how to use a plugin so that it is only available on the client side
+title: Plugins Apenas para o Cliente
+description: Neste exemplo mostramos como usar um plugin assim que ele apenas estiver disponível no lado do cliente
 category: plugins
 ---
 
-# Client Only Plugins
+# Plugins Apenas para o Cliente
 
-In this example we show how to use a plugin so that it is only available on the client side
+Neste exemplo mostramos como usar um plugin assim que ele apenas estiver disponível no lado do cliente
 
 ---
 
-In this example:
+Neste exemplo:
 
-`plugins/client-only.client.js` uses the `window.alert()` function which is not available on server side.
+- O `plugins/client-only.client.js` usa a função `window.alert()` a qual não está disponível no lado do servidor.
 
-`nuxt.config.js` contains the `plugins` property which registers the plugin on the client side by adding the `.client` extension.
+- O ficheiro `nuxt.config.js` contém a propriedade `plugins` a qual regista o plugin no lado do cliente pela adição da extensão `.client`.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [plugins](/docs/directory-structure/plugins#client-or-server-side-only) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [Plugins](/docs/directory-structure/plugins#apenas-no-lado-do-cliente-ou-servidor).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/plugins/client-only-plugins?fontsize=14&hidenavigation=1&module=%2Fplugins%2Fclient-only.client.js&theme=dark&view=editor"}

--- a/content/pt/examples/9.plugins/3.external-packages.md
+++ b/content/pt/examples/9.plugins/3.external-packages.md
@@ -1,31 +1,31 @@
 ---
-title: External Packages Plugin
-description: In this example we show how to use a plugin with an external package - axios
+title: Pacotes Externos de Plugin
+description: Neste exemplo mostramos como usar um plugin com um pacote externo - axios
 category: plugins
 ---
 
-# External Packages Plugin
+# Pacotes Externos de Plugin
 
-In this example we show how to use a plugin with an external package - axios
+Neste exemplo mostramos como usar um plugin com um pacote externo - axios
 
 ---
 
-In this example:
+Neste exemplo:
 
-`plugins/axios.js` intercepts the `$axios` call using the `onError()` function.
+- O `plugins/axios.js` interceta a chamada do `$axios` com uso da função `onError()`.
 
-`pages/index.vue` uses `$axios` to fetch our data from an API.
+- O `pages/index.vue` usa o `$axios` para requisitar nossos dados de uma API.
 
-`pages/mountains/_slug.vue` uses `$axios` to fetch our data from an API with the id coming from route params.
+- O `pages/mountains/_slug.vue` usa o `$axios` para requisitar nossos dados de uma API com o id vindo do parâmetros da rota.
 
-`pages/404.vue` is the page that is called when there is an error.
+- O `pages/404.vue` é a página que é chamada quando houver um erro.
 
-`nuxt.config.js` contains the `module` property and `plugin` property to register our module and plugin.
+- O ficheiro `nuxt.config.js` contém a propriedade `module` e a propriedade `plugin` para registar o nosso módulo e o plugin.
 
-`package.json` shows our module `@nuxtjs/axios` has been installed.
+- O `package.json` mostra que nosso módulo `@nuxtjs/axios` tem sido instalado.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [plugins](/docs/directory-structure/plugins#external-packages) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [Plugins](/docs/directory-structure/plugins#pacotes-externos).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/plugins/external-packages-plugin?fontsize=14&hidenavigation=1&module=%2Fplugins%2Faxios.js&theme=dark&view=editor"}

--- a/content/pt/examples/9.plugins/4.custom.md
+++ b/content/pt/examples/9.plugins/4.custom.md
@@ -1,34 +1,34 @@
 ---
-title: Custom Plugins
-description: In this example we show how you how you can create your own plugin
+title: Plugins Personalizados
+description: Neste exemplo mostramos como você pode criar seu próprio plugin
 category: plugins
 ---
 
-# Custom Plugins
+# Plugins Personalizados
 
-In this example we show how you how you can create your own plugin
+Neste exemplo mostramos como você pode criar seu próprio plugin
 
 ---
 
-In this example:
+Neste exemplo:
 
-`plugins/hello.js` - logs a message to the console with a dynamic message.
+- O `plugins/hello.js` - regista uma mensagem na consola com uma mensagem dinâmica.
 
-`store/index.js` - stores our dynamic message from our input.
+- O `store/index.js` - guarda nossa mensagem dinâmica da nossa saída.
 
-`pages/index.vue` uses the hello plugin to:
+- O `pages/index.vue` usa o plugin `hello` para:
 
-- log a message to the console on mounted.
-- log a message to the console containing the value from our input.
+  - registar uma mensagem na consola no gatilho `mounted`.
+  - registar uma mensagem na consola contendo o valor da nossa saída.
 
-`plugins/nuxt-api.js` - fetches data from our API.
+- O `plugins/nuxt-api.js` - requisita dados da nossa API.
 
-`pages/api-plugin.vue` - uses our plugin to fetch and show the data from our API.
+- O `pages/api-plugin.vue` - usa o nosso plugin para requisitar e mostrar os dados da nossa API.
 
-`nuxt.config.js` - registers our plugins using the `plugins` property.
+- O ficheiro `nuxt.config.js` - regista nossos plugins com o uso da propriedade `plugins`.
 
 ::alert{type="next"}
-Learn more in the Directory Structure book in the [plugins](/docs/directory-structure/plugins#inject-in-root--context) chapter.
+Saiba mais no livro Estrutura de Diretório, no capítulo [plugins](/docs/directory-structure/plugins#injetar-dentro-do-root--contexto).
 ::
 
 :sandbox{src="https://codesandbox.io/embed/github/nuxtlabs/examples/tree/master/plugins/custom-plugins?fontsize=14&hidenavigation=1&module=%2Fplugins%2Fnuxt-api.js&theme=dark&view=editor"}

--- a/content/pt/examples/9.plugins/index.md
+++ b/content/pt/examples/9.plugins/index.md
@@ -1,4 +1,5 @@
 ---
+title: Plugins
 navigation:
   collapse: true
   redirect: /examples/plugins/vue

--- a/content/pt/examples/index.md
+++ b/content/pt/examples/index.md
@@ -2,7 +2,7 @@
 template:
   nested: guide
   self: guide
-title: Examples
+title: Exemplos
 navigation:
   exclusive: true
   collapse: true


### PR DESCRIPTION
In this pull request I am sending one more small part of the job I did, I did struggle
to find some ideal Portuguese equivalent for some Frontend technical words, 
so I want ask to you guys to review carefully the folders:

- `4.transitions/`
-  `6.loading/`
- `7.miscellaneous/`
- `8.middlewares/`
- `9.plugins/`

@smarroufin and @ChristopheCVB do you mind 😊?