### PR TITLE
docs: fix typo

### DIFF
--- a/content/en/docs/3.features/8.nuxt-components.md
+++ b/content/en/docs/3.features/8.nuxt-components.md
@@ -73,7 +73,7 @@ Example:
 This file tree will generate these routes:
 
 ```js
-;[
+[
   {
     path: '/parent',
     component: '~/pages/parent.vue',


### PR DESCRIPTION
I think the semicolon might be inserted mistakenly. Please check out line number 76 in the following.

https://github.com/nuxt/nuxtjs.org/blob/ba319a8fc34160542076ffff1213c814831cac36/content/en/docs/3.features/8.nuxt-components.md?plain=1#L73-L90