### PR TITLE
Add the section features of the documentation translated

### DIFF
--- a/content/pt/docs/3.features/1.rendering-modes.md
+++ b/content/pt/docs/3.features/1.rendering-modes.md
@@ -1,30 +1,31 @@
 ---
-title: Rendering
+title: Renderização
 category: features
 ---
-# Rendering
 
-## Server Side Rendered Sites and Static Sites
+# Renderização
 
-**Server-side rendered sites** are rendered on the server each time the user requests a page, therefore a server is needed to be able to serve the page on each request.
+## Sites Renderizados no Lado do Servidor e Sites Estáticos
 
-**Static sites** are very similar to server-side rendered applications with the main difference being that static sites are rendered at build time, therefore no server is needed. Navigating from one page to another is then on the client-side.
+**Sites Renderizados no Lado do Servidor** são renderizados no servidor a cada momento que o usuário requisitar uma página, então é necessário um servidor para encarregar-se de servir a página a cada requisição.
 
-See [deployment targets](/docs/features/deployment-targets) for more info on static and server hosting.
+**Sites Estáticos** são muito similares as aplicações renderizadas no lado do servidor com a diferença principal sendo que sites estáticos são renderizados no momento de construção, então o servidor não é necessário. A navegação de uma página para outra está então no lado do cliente.
+
+Consulte [alvos do deployment](/docs/features/deployment-targets) para obter informações mais detalhas sobre hospedagem de sites estáticos e renderizados no servidor.
 
 ```js{}[nuxt.config.js]
 export default {
-  ssr: true // default value
+  ssr: true // valor padrão
 }
 ```
 
 ::alert{type="info"}
-You do not need to add `ssr: true` to your nuxt config in order to enable server-side-rendering as it is enabled by default.
+Você não precisa adicionar `ssr: true` a sua configuração do Nuxt com o fim de ativar a renderização no lado do servidor porque esta opção está ativada por padrão.
 ::
 
-## Client Side Rendering Only
+## Renderizando Apenas no Lado do Cliente
 
-With client side rendering only there is no server-side rendering. Client side rendering means rendering the content in the browser using JavaScript. Instead of getting all of the content from the HTML we just get a basic HTML document with a JavaScript file that will then render the rest of the site using the browser. For client side rendering set ssr to `false`.
+Com a renderização apenas no lado do cliente não há renderização no lado do servidor. Renderização no lado do cliente significa renderizar o conteúdo no navegador usando JavaScript. Ao invés de receber todo o conteúdo a partir do HTML nós apenas recebemos um documento HTML básico com um ficheiro JavaScript que depois renderizará o resto no navegador. Para renderizar no lado do cliente defina o ssr para `false`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -33,5 +34,5 @@ export default {
 ```
 
 ::alert{type="next"}
-[The ssr property](/docs/configuration-glossary/configuration-ssr)
+[A propriedade ssr](/docs/configuration-glossary/configuration-ssr)
 ::

--- a/content/pt/docs/3.features/10.transitions.md
+++ b/content/pt/docs/3.features/10.transitions.md
@@ -1,31 +1,31 @@
 ---
-title: Transitions
-description: Nuxt uses the transition component to let you create amazing transitions/animations between your routes.
+title: Transições
+description: O Nuxt usa o componente de transição para permitir que você criar animações e transições incríveis entre suas rotas.
 category: features
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/05_transitions?fontsize=14&hidenavigation=1&theme=dark
 ---
-# Transitions
+# Transições
 
-Nuxt uses the [transition component](http://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) to let you create amazing transitions/animations between your routes.
+O Nuxt usa o [componente de transição](http://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) para permitir que você criar animações e transições incríveis entre suas rotas.
 
 ---
 
-To define a custom transition for a specific route add the `transition` key to the page component.
+Para definir uma transição personalizada para uma rota específica, adiciona a chave `transition`  ao componente da página.
 
 ```js{}[pages/index.vue]
 export default {
-  // Can be a String
+  // Pode ser uma String
   transition: ''
-  // Or an Object
+  // Ou um Objeto
   transition: {}
-  // or a Function
+  // Ou uma Função
   transition (to, from) {}
 }
 ```
 
-## String
+## Sequência de Caracteres
 
-If the `transition` key is set as a string, it will be used as the `transition.name`.
+Se a chave `transition`  for definida como uma sequência de caracteres, ela será usada como o `transition.name`.
 
 ```js{}[pages/index.vue]
 export default {
@@ -33,17 +33,17 @@ export default {
 }
 ```
 
-Nuxt will use these settings to set the component as follows:
+O Nuxt usará essas configurações para definir o componente da seguinte forma:
 
 ```html{}[pages/index.vue]
 <transition name="home"></transition>
 ```
 
 ::alert{type="warning"}
-This is automatically done for you and you do not need to add the `<transition>` component to your pages or layouts.
+Isto é feito automaticamente e você não precisa adicionar o componente `<transition>` a sua página ou esquemas (layouts).
 ::
 
-Now all you have to do is create the new class for your transitions.
+Agora tudo o que você precisa fazer é criar a nova classe para suas transições.
 
 ```html{}[pages/index.vue]
 <style>
@@ -52,9 +52,9 @@ Now all you have to do is create the new class for your transitions.
 </style>
 ```
 
-## Object
+## Objeto
 
-If the `transition` key is set as an object:
+Se a chave `transition`  for definida como um objeto:
 
 ```js{}[pages/index.vue]
 export default {
@@ -65,15 +65,15 @@ export default {
 }
 ```
 
-Nuxt will use these settings to set the component as follows:
+O Nuxt usará essas configurações para definir o componente da seguinte forma:
 
 ```html{}[pages/index.vue]
 <transition name="home" mode="out-in"></transition>
 ```
 
-The `transition` object can have many properties such as name, mode, css, duration and many more. Please see the vue docs for more info.
+O objeto `transition`  pode ter várias propriedades tais como name, mode, css, duration e muitas mais. Consulte a documentação do vue para ter informações mais detalhadas.
 
-You can also define methods in the page `transition` property, for more information on the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) see the vue docs.
+Você também pode definir métodos dentro da propriedade `transition` , para saber mais sobre consulte os [Gatilhos do JavaScript](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) na documentação do vue.
 
 ```js
 export default {
@@ -85,10 +85,10 @@ export default {
 }
 ```
 
-### Transition Mode
+### Modo de Transição
 
 ::alert{type="warning"}
-The default transition mode for pages differs from the default mode in Vue.js. The `transition` mode is by default set to `out-in`. If you want to run leaving and entering transitions simultaneously, you have to set the mode to the empty string `mode: ''`.
+O modo de transição padrão para páginas diferem do modo padrão no Vue.js. O modo `transition` está por padrão definido como `out-in`. Se você quiser executar as transições de entrada e saída simultaneamente, voê tem de definir o mode para uma string vazia `mode: ''`.
 ::
 
 ```js{}[pages/index.vue]
@@ -100,9 +100,9 @@ export default {
 }
 ```
 
-## Function
+## Função
 
-If the `transition` key is set as a function:
+Se a chave `transition` for definida como uma função:
 
 ```js{}[pages/index.vue]
 export default {
@@ -115,15 +115,15 @@ export default {
 }
 ```
 
-Transitions applied on navigation:
+Transições aplicadas na navegação:
 
 `/` to `/posts` => `slide-left`,`/posts` to `/posts?page=3` => `slide-left`,`/posts?page=3` to `/posts?page=2` => `slide-right`.
 
-## Global Settings
+## Configuração Global
 
-The Nuxt default transition name is `"page"`. To add a fade transition to every page of your application, all you need is a CSS file that is shared across all your routes.
+O nome de transição padrão do Nuxt é `"page"`. Para adicionar uma transição fade para todas páginas da sua aplicação, tudo o que você precisa é um ficheiro CSS que é compartilhado por todas rotas.
 
-Our global css in `assets/main.css`:
+Nosso css global dentro de `assets/main.css`:
 
 ```css{}[assets/main.css]
 .page-enter-active,
@@ -136,7 +136,7 @@ Our global css in `assets/main.css`:
 }
 ```
 
-Then we add its path to the `css` array in our `nuxt.config.js` file:
+Depois adicionarmos seu caminho ao array `css` dentro do nosso ficheiro de configuração `nuxt.config.js` :
 
 ```js{}[nuxt.config.js]
 export default {
@@ -144,13 +144,13 @@ export default {
 }
 ```
 
-## Configuration Settings
+## Configuração das Configurações
 
-### The layoutTransition Property
+### A Propriedade layoutTransition
 
-The layout transition is used to set the default properties of the layout transitions.
+A transição do esquema (ou layout) é usada para definir as propriedades da transições de esquema (layout).
 
-The default settings for layout transitions are:
+A configuração padrão para transições de esquema são:
 
 ```js
 {
@@ -170,7 +170,7 @@ The default settings for layout transitions are:
 }
 ```
 
-If you want to change the default settings for your layout transitions you can do so in the nuxt.config.js file.
+Se você quiser mudar as configurações padrões para as transições do seu esquema você pode fazer isso dentro do ficheiro `nuxt.config.js`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -194,9 +194,9 @@ export default {
 }
 ```
 
-### The pageTransition Property
+### A Propriedade pageTransition
 
-The default settings for page transitions are:
+A configuração padrão para transições de página são:
 
 ```js
 {
@@ -205,7 +205,7 @@ The default settings for page transitions are:
 }
 ```
 
-Should you wish to modify the default settings you can do so in the nuxt.config.js
+Deseja você modificar a configuração padrão, você pode fazer isso dentro do `nuxt.config.js`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -221,7 +221,7 @@ export default {
 }
 ```
 
-If you do modify the page Transition name you will also have to rename the css class.
+Se você modificar o nome da transição da página você também terá de renomear a classe css.
 
 ```css{}[assets/main.css]
 .my-page-enter-active,

--- a/content/pt/docs/3.features/11.live-preview.md
+++ b/content/pt/docs/3.features/11.live-preview.md
@@ -1,22 +1,22 @@
 ---
-title: Preview Mode
-description: Live Preview for target static with the preview mode
+title: Modo de Pré-visualização
+description: Pré-visualização ao vivo para o um alvo estático com o modo de pré-visualização
 category: features
 ---
-# Preview mode
+# Modo de Pré-visualização
 
-Live Preview for target static with the preview mode
+Pré-visualização ao vivo para alvo estático com o modo de pré-visualização
 
 ---
-With Nuxt and full static you can now use live preview out of the box which will call your API or your CMS so you can see the changes live before deploying.
+Com o Nuxt e completamente estático você pode agora usar a pré-visualização ao vivo fora da caixa que chamará sua API ou CMS, assim você pode visualizar as mudanças ao vivo antes de desdobrar.
 
 ::alert{type="warning"}
-Only available when using [`target:static`](/docs/features/deployment-targets#static-hosting)
+Disponível apenas quando estiver usando [`target:static`](/docs/features/deployment-targets#static-hosting)
 ::
 
-The preview mode will automatically refresh the page data as it uses `$nuxt.refresh` under the hood and therefore calls nuxtServerInit, asyncData and fetch on the client side.
+O modo de pré-visualização irá atualizar os dados da página automaticamente visto que ele usa `$nuxt.refresh` nos bastidores e portanto chama `nuxtServerInit`, `asyncDate` e `fetch` no lado do cliente.
 
-In order to activate live preview you will need to add the following plugin:
+No sentido de ativar a pré-visualização ao vivo você precisará adicionar o seguinte plugin:
 
 ```js{}[plugins/preview.client.js]
 export default function ({ query, enablePreview }) {
@@ -27,8 +27,7 @@ export default function ({ query, enablePreview }) {
 ```
 
 ::alert{type="warning"}
-`enablePreview` is only available in the context object of plugins. Previews are handled client-side and
-thus the plugin should be run on the client: preview.client.js
+O `enablePreview` está disponível apenas dentro do objeto de contexto dos plugins. Pré-visualizações são manipuladas no lado do cliente e desta maneira o plugin deve ser executado no cliente: `preview.client.js`
 ::
 
 ```js{}[nuxt.config.js]
@@ -37,7 +36,7 @@ export default {
 }
 ```
 
-Once you have added the plugin you can now generate your site and serve it.
+Uma vez que você adicionou o plugin você pode agora gerar seu site e servir ele.
 
 ::code-group
 ```bash [Yarn]
@@ -50,22 +49,21 @@ npx nuxt start
 ```
 ::
 
-Then you can see your preview page by adding the query param to the end of the page you want to see once:
+Em seguida você pode visualizar sua página de pré-visualização ao adicionar o parâmetro de consulta no final da página que você queira visualizar imediatamente:
 
 ```js
 ?preview=true
 ```
 
 ::alert{type="warning"}
-enablePreview should be tested locally with yarn start and not yarn
-dev
+O `enablePreview` deve ser testado localmente com o yarn start e não yarn dev
 ::
 
-### Previewing pages that are not yet generated
+### Pré-visualizando Páginas Que Ainda Não Foram Geradas
 
-For pages that are not yet generated, SPA fallback will still call the API before showing the 404 page as these pages exist on the API but are not generated yet.
+Para páginas que ainda não foram geradas, mesmo na queda do SPA elas ainda continuarão a chamar a API antes de exibir a página 404 como se essas páginas existissem na API mas que ainda não foram geradas.
 
-If you have set a validate hook, you will probably need to modify it so that it doesn't redirect to the 404 page in preview mode.
+Se você tiver definido um gatilho validate, você provavelmente precisará modificar ele, assim para que ele não redirecione para a página 404 no modo de pré-visualização.
 
 ```js
 validate({ params, query }) {
@@ -74,12 +72,12 @@ validate({ params, query }) {
 }
 ```
 
-### Passing data to enablePreview
+### Passando Dados ao enablePreview
 
-You can pass data to the `enablePreview` function. That data will then be available on the `$preview` context helper and on `this.$preview`.
+Você pode passar dados para função `enablePreview`. Esses dados irão depois estar disponíveis no auxiliar de contexto `$preview` e no `this.$preview`.
 
-### What's next
+### O Que Se Segue
 
 ::alert{type="next"}
-Check out the [Directory Structure book](/docs/directory-structure/nuxt)
+Consulte o [livro da Estrutura do Diretório](/docs/directory-structure/nuxt)
 ::

--- a/content/pt/docs/3.features/2.deployment-targets.md
+++ b/content/pt/docs/3.features/2.deployment-targets.md
@@ -1,47 +1,48 @@
 ---
-title: Deployment Targets
+title: Alvos do Desdobramento
 category: features
 ---
-# Deployment Targets
 
-## Static Hosting
+# Alvos do Desdobramento
 
-Nuxt also works as a static site generator. Statically render your Nuxt application and get all of the benefits of a universal app without a server. The `nuxt generate` command will generate a static version of your website. It will generate HTML for every one of your routes and put it inside of its own file in the `dist/` directory. This improves performance as well as SEO and better offline support.
+## Hospedagem Estática
+
+O Nuxt também funciona como um gerador de sítio estático. Renderiza estaticamente a sua aplicação Nuxt e receba todos os benefícios de uma aplicação universal sem um servidor. O comando `nuxt generate` gerará um versão estática do seu website. Ele gerará um HTML para cada rota sua e a põe dentro do seu próprio ficheiro dentro do diretório `dist/`. Isto melhora o desempenho como também o SEO e refinar o suporte do offline.
 
 ::alert{type="info"}
-Dynamic routes are also generated thanks to the [Nuxt Crawler](/docs/configuration-glossary/configuration-generate#crawler)
+Rotas dinâmicas são também geradas graças ao [Nuxt Crawler](/docs/configuration-glossary/configuration-generate#crawler)
 ::
 
-For static sites the target of `static` needs to be added to your `nuxt.config` file.
+Para sítios estáticos o alvo `static` precisa ser adicionado ao seu ficheiro `nuxt.config`.
 
 ```js{}[nuxt.config.js]
 export default {
-  target: 'static' // default is 'server'
+  target: 'static' // o padrão é 'server'
 }
 ```
 
-**Running nuxt dev with the static target will improve the developer experience:**
+**Executar o nuxt dev com o alvo estático melhorara a experiência do desenvolvedor:**
 
-- Remove `req` & `res` from `context`
-- Fallback to client-side rendering on 404, errors and redirects [see SPA fallback](/docs/concepts/static-site-generation#spa-fallback)
-- `$route.query` will always be equal to `{}` on server-side rendering
-- `process.static` is true
-
-::alert{type="info"}
-We are also exposing `process.target` for module authors to add logic depending on the user target.
-::
-
-## Server Hosting
-
-Server hosting means running Nuxt on a Node.js server. When the user opens your page, their browser will request that page from the server. Nuxt will handle the request, render the page and send back the resulting page with all its content.
-
-You might need server hosting if you want to render HTML on each request rather than in advance at generate-time, or if you need [serverMiddleware](/docs/configuration-glossary/configuration-servermiddleware). 
+- Remove `req` e o `res` do `context`
+- Recua para renderização no lado cliente no 404, erros e redireciona [consulte o recuo da aplicação de página única](/docs/concepts/static-site-generation#o-recuo-da-aplicação-de-página-única)
+- `$route.query` será sempre igual ao `{}` na renderização no lado do servidor
+- `process.static` é true
 
 ::alert{type="info"}
-You can still run Nuxt with server hosting with `ssr: false` but Nuxt will not fully render the HTML for each page - leaving that task to the browser. You might choose this option if you need serverMiddleware but do not want fully server-side rendered HTML.
+Nós também estamos expondo `process.target` para os autores do módulo para adicionar a lógica dependendo do alvo do usuário.
 ::
 
-For server hosting, `target: 'server'` is used, which is the default value. You will use the `build` command to build your application.
+## Hospedagem de Servidor
+
+Hospedagem do servidor significa executar o Nuxt em um servidor Node.js. Sempre que os usuários abrirem a sua página, os navegadores deles irão pedir aquela página a partir servidor. Nuxt manipulará a requisição, renderizará a página e enviará de volta a página resultante com todo o seu conteúdo.
+
+Você pode precisar hospedar o servidor se você quiser renderizar o HTML a cada requisição de preferência ao momento de produção, ou se você precisar [serverMiddleware](/docs/configuration-glossary/configuration-servermiddleware).
+
+::alert{type="info"}
+Você pode continuar a executar o Nuxt com a hospedagem do servidor com `ssr: false` mas o Nuxt não renderizará de todo o HTML para cada página - deixando esse trabalho para o navegador. Você poderia escolher essa opção se você precisar do serverMiddleware mas não deseja que o HTML seja completamente renderizado no lado do servidor.
+::
+
+Para hospedagem do servidor, `target: 'server'` é usado, que é o valor padrão. Você usará o comando `build` para construir sua aplicação.
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/pt/docs/3.features/3.file-system-routing.md
+++ b/content/pt/docs/3.features/3.file-system-routing.md
@@ -1,23 +1,23 @@
 ---
-title: File System Routing
-description: Nuxt automatically generates the vue-router configuration based on your file tree of Vue files inside the pages directory. When you create a .vue file in your pages directory you will have basic routing working with no extra configuration needed.
+title: Sistema de Roteamento de Ficheiro
+description: O Nuxt gera automaticamente a configuração do vue-router baseado na sua árvore de ficheiro de ficheiros Vue dentro do diretório pages. Sempre que você criar um ficheiro .vue dentro do seu diretório pages você terá o roteamento básico funcionando sem a necessidade de configurações extras.
 category: features
 ---
-# File system routing
+# Sistema de Roteamento de Ficheiro
 
-Nuxt automatically generates the vue-router configuration based on your file tree of Vue files inside the pages directory. When you create a .vue file in your pages directory you will have basic routing working with no extra configuration needed.
+O Nuxt gera automaticamente a configuração do vue-router baseado na sua árvore de ficheiro de ficheiros Vue dentro do diretório pages. Sempre que você criar um ficheiro .vue dentro do seu diretório pages você terá o roteamento básico funcionando sem a necessidade de configurações extras.
 
 ---
 
 
-Sometimes you might need to create dynamic routes or nested routes or you might need to further configure the router property. This chapter will go through everything you need to know in order to get the best out of your router.
+Algumas vezes você pode precisar criar rotas dinâmicas ou rotas aninhadas ou você pode precisar avançar para configurar a propriedade router. Este capítulo irá através de tudo que você precisa saber no sentido de tirar o melhor proveito do seu roteador.
 
 ::alert{type="info"}
-Nuxt gives you automatic code splitting for your routes, no configuration is needed
+O Nuxt oferece a você separação automática de código para suas rotas, sem precisar de configuração
 ::
 
 ::alert{type="info"}
-Use the [NuxtLink component](/docs/features/nuxt-components#the-nuxtlink-component) to navigate between pages
+Use o [componente NuxtLink](/docs/features/nuxt-components#the-nuxtlink-component) para navegar entre páginas
 ::
 
 ```html
@@ -26,9 +26,9 @@ Use the [NuxtLink component](/docs/features/nuxt-components#the-nuxtlink-compon
 </template>
 ```
 
-## Basic Routes
+## Rotas Básicas
 
-This file tree:
+Esta árvore de ficheiro:
 
 ```
 pages/
@@ -38,7 +38,7 @@ pages/
 --| index.vue
 ```
 
-will automatically generate:
+automaticamente gerará:
 
 ```js
 router: {
@@ -62,11 +62,11 @@ router: {
 }
 ```
 
-## Dynamic Routes
+## Rotas Dinâmicas
 
-Sometimes it is not possible to know the name of the route such as when we make a call to an API to get a list of users or blog posts. We call these dynamic routes. To create a dynamic route you need to add an underscore (`_`) before the `.vue` file name or before the name of the directory. You can name the file or directory anything you want but you must prefix it with an underscore.
+Algumas vezes não é possível saber o nome da rota tal como quando fazemos uma chamada para uma API para receber uma lista de usuários ou publicações de um blogue. Nós chamamos esses de rotas dinâmicas. Para criar uma rota dinâmica você precisa adicionar um sublinhado (`_`) antes do nome do ficheiro `.vue` ou antes do nome do diretório. Você pode nomear o ficheiro ou diretório com o que você quiser mas você deve prefixar ele com sublinhado.
 
-This file tree:
+Esta árvore de ficheiro:
 
 ```
 pages/
@@ -78,7 +78,7 @@ pages/
 --| index.vue
 ```
 
-will automatically generate:
+automaticamente gerará:
 
 ```js
 router: {
@@ -108,30 +108,30 @@ router: {
 ```
 
 ::alert{type="info"}
-As you can see the route named `users-id` has the path `:id?` which makes it optional, if you want to make it required, create an `index.vue` file in the `users/_id` directory instead.
+Como você pode ver a rota nomeada `users-id` tem o caminho `:id?` o que a torna opcional, se você quiser torna ela obrigatória, crie um ficheiro `index.vue` dentro do diretório `users/_id`.
 ::
 
 ::alert{type="info"}
-As of Nuxt >= v2.13 there is a crawler installed that will now crawl your link tags and generate your dynamic routes based on those links. However if you have pages that are not linked to such as a secret page, then you will need to manually generate those dynamic routes.
+Visto que desde o Nuxt >= v2.13 há um rastejador instalado que agora irá rastejar em suas tags de ligação e gerar suas rotas dinâmicas baseadas naquelas ligações. No entanto se você tiver páginas que não estão ligadas tais como uma página secreta, então você precisará manualmente gerar aquelas rotas dinâmicas.
 ::
 
 ::alert{type="next"}
-[Generate dynamic routes](/docs/concepts/static-site-generation) for static sites
+[Gerar rotas dinâmicas](/docs/concepts/static-site-generation) para sites estáticos.
 ::
 
-### Locally Accessing Route Params
+### Acessando Localmente Parâmetros de Rota
 
-You can access the current route parameters within your local page or component by referencing `this.$route.params.{parameterName}`. For example, if you had a dynamic users page (`users/_id.vue`) and wanted to access the `id` parameter to load the user or process information, you could access the variable like this: `this.$route.params.id`.
+Você pode acessar os parâmetros da rota atual dentro da sua página local ou componente ao referenciar `this.$route.params.{parameterName}`. Por exemplo, se você tinha uma página de usuários dinâmica (`users/_id.vue`) e quis acessar o parâmetro `id` para carregar o usuário ou processar informações, você poderia acessar a variável como: `this.$route.params.id`.
 
-## Nested Routes
+## Rotas Aninhadas
 
-Nuxt lets you create nested routes by using the children routes of vue-router. To define the parent component of a nested route, you need to create a Vue file with the same name as the directory which contains your children views.
+O Nuxt permite você criar rotas aninhadas ao usar rotas filhas do vue-router. Para definir o componente pai de uma rota alinhada, você precisa criar um ficheiro Vue com o mesmo nome que o diretório o qual contém suas views filhas.
 
 ::alert{type="warning"}
-Don't forget to include the [NuxtChild component](/docs/features/nuxt-components#the-nuxtchild-component) inside the parent component (`.vue` file).
+Não esqueça de incluir o [componente NuxtChild](/docs/features/nuxt-components#o-componente-nuxtchild) dentro do componente pai (ficheiro `.vue`).
 ::
 
-This file tree:
+Esta árvore de ficheiro:
 
 ```
 pages/
@@ -141,7 +141,7 @@ pages/
 --| users.vue
 ```
 
-will automatically generate:
+automaticamente gerará:
 
 ```js
 router: {
@@ -166,11 +166,11 @@ router: {
 }
 ```
 
-## Dynamic Nested Routes
+## Rotas Dinâmicas Aninhadas
 
-This is not a common scenario, but it is possible with Nuxt to have dynamic children inside dynamic parents.
+Este não é um quadro comum, mas é possível com o Nuxt ter filhos dinâmicos dentro de pais dinâmicos.
 
-This file tree:
+Esta árvore de ficheiro:
 
 ```
 pages/
@@ -184,7 +184,7 @@ pages/
 --| index.vue
 ```
 
-will automatically generate:
+automaticamente gerará:
 
 ```js
 router: {
@@ -225,11 +225,11 @@ router: {
 }
 ```
 
-## Unknown Dynamic Nested Routes
+## Rotas Dinâmicas Aninhadas Desconhecidas
 
-If you do not know the depth of your URL structure, you can use `_.vue` to dynamically match nested paths. This will handle requests that do not match a *more specific* route.
+Se você não sabe a profundidade da sua estrutura de URL, você pode usar `_.vue` para casar dinamicamente caminhos aninhados. Isto irá manipular requisições que não casarem uma rota *mais específica*.
 
-This file tree:
+Esta árvore de ficheiro:
 
 ```
 pages/
@@ -240,7 +240,7 @@ pages/
 --| index.vue
 ```
 
-Will handle requests like this:
+automaticamente gerará:
 
 ```
 / -> index.vue
@@ -252,42 +252,42 @@ Will handle requests like this:
 ```
 
 ::alert{type="info"}
-Handling 404 pages is now up to the logic of the `_.vue` page.
+Manipulação de páginas 404 agora sobre a lógica da página `_.vue`.
 ::
 
-## Extending the router
+## Estendendo o Roteador
 
-There are multiple ways to extend the routing with Nuxt:
+Há várias maneiras de estender o roteamento com o Nuxt:
 
-- [router-extras-module](https://github.com/nuxt-community/router-extras-module) to customize the route parameters in the page
-- component[@nuxtjs/router](https://github.com/nuxt-community/router-module) to overwrite the Nuxt router and write your own `router.js` file
-- Use the [router.extendRoutes](/docs/configuration-glossary/configuration-router#extendroutes) property in your `nuxt.config.js`
+- [router-extras-module](https://github.com/nuxt-community/router-extras-module) para personalizar os parâmetros dentro da página
+- componente [@nuxtjs/router](https://github.com/nuxt-community/router-module) para sobrescrever o router do Nuxt e escrever seu próprio ficheiro `router.js`
+- Usar a propriedade [router.extendRoutes](/docs/configuration-glossary/configuration-router#a-propriedade-extendroutes) dentro do seu `nuxt.config.js`
 
-## The router Property
+## A Propriedade router
 
-The router property lets you customize the Nuxt router (vue-router).
+A propriedade router permite você personalizar o router do Nuxt (vue-router).
 
 ```js{}[nuxt.config.js]
 export default {
   router: {
-    // customize the Nuxt router
+    // personalize o router do Nuxt
   }
 }
 ```
 
 ### Base:
 
-The base URL of the app. For example, if the entire single page application is served under `/app/`, then base should use the value `'/app/'`.
+A URL base da aplicação. Por exemplo, se a aplicação de página única inteira estiver servida debaixo de `/app/`, então a base deve usar o valor `'/app/'`.
 
 ::alert{type="next"}
-[Router Base Property](/docs/configuration-glossary/configuration-router#base)
+[Propriedade base do roteador](/docs/configuration-glossary/configuration-router#a-propriedade-base)
 ::
 
 ### extendRoutes
 
-You may want to extend the routes created by Nuxt. You can do so via the `extendRoutes` option.
+Você pode querer estender as rotas criadas pelo Nuxt. Você pode fazer então via opção `extendRoutes`.
 
-Example of adding a custom route:
+Exemplo de adição de uma rota personalizada:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -303,16 +303,16 @@ export default {
 }
 ```
 
-If you want to sort your routes, you can use the  `sortRoutes(routes)`  function from `@nuxt/utils`:
+Se você quiser organizar suas rotas, você pode usar a função `sortRoutes(routes)` do `@nuxt/utils`:
 
 ```js{}[nuxt.config.js]
 import { sortRoutes } from '@nuxt/utils'
 export default {
   router: {
     extendRoutes(routes, resolve) {
-      // Add some routes here ...
+      // Adicione algumas rota aqui ...
 
-      // and then sort them
+      // e depois organize elas
       sortRoutes(routes)
     }
   }
@@ -320,11 +320,11 @@ export default {
 ```
 
 ::alert{type="warning"}
-The schema of the route should respect the [vue-router](https://router.vuejs.org/en/) schema.
+O estrutura de rotas deve respeitar a estrutura do [vue-router](https://router.vuejs.org/en/).
 ::
 
 ::alert{type="warning"}
-When adding routes that use [Named Views](/docs/features/file-system-routing#nested-routes), don't forget to add the corresponding `chunkNames` of named `components`.
+Quando estiver adicionando rotas que usam [Views Nomeadas](/docs/features/file-system-routing#nested-routes), não esqueça de adicionar `chunkNames` correspondente dos `components` nomeados.
 ::
 
 ```js{}[nuxt.config.js]
@@ -347,36 +347,36 @@ export default {
 ```
 
 ::alert{type="next"}
-[extendRoutes Property](/docs/configuration-glossary/configuration-router#extendroutes)
+[Propriedade extendRoutes](/docs/configuration-glossary/configuration-router#extendroutes)
 ::
 
 ### fallback
 
-Controls whether the router should fallback to hash mode when the browser does not support history.pushState but mode is set to history.
+Controla se a roteador deveria recuar para o modo hash quando o browser não suportar o `history.pushState` mas o modo está definido para history.
 
 ::alert{type="next"}
-[fallback Property](/docs/configuration-glossary/configuration-router#fallback)
+[Propriedade fallback](/docs/configuration-glossary/configuration-router#fallback)
 ::
 
 ### mode
 
-Configure the router mode, it is not recommended to change it due to server-side rendering.
+Configura o modo do roteador, não é recomendado mudar ele por causa da renderização do lado do servidor.
 
 ::alert{type="next"}
-[mode Property](/docs/configuration-glossary/configuration-router#mode)
+[Propriedade mode](/docs/configuration-glossary/configuration-router#mode)
 ::
 
 ### parseQuery / stringifyQuery
 
-Provide custom query string parse / stringify functions.
+Fornece as funções parse / stringify da string de consulta personalizada
 
 ::alert{type="next"}
-[parseQuery / stringifyQuery Property](/docs/configuration-glossary/configuration-router#parsequery--stringifyquery)
+[Propriedade parseQuery / stringifyQuery](/docs/configuration-glossary/configuration-router#parsequery--stringifyquery)
 ::
 
 ### routeNameSplitter
 
-You may want to change the separator between route names that Nuxt uses. You can do so via the `routeNameSplitter` option in your configuration file. Imagine we have the page file `pages/posts/_id.vue`. Nuxt will generate the route name programmatically, in this case `posts-id`. Changing the `routeNameSplitter` config to `/` the name will therefore change to `posts/id`.
+Você pode querer mudar o separador entre os nomes de rota que o Nuxt usa. Você pode fazer isso via a opção `routeNameSplitter` dentro do seu ficheiro de configuração. Imagine que nós temos ao ficheiro de página `pages/posts/_id.vue`. O Nuxt gerará a nome da rota programaticamente, neste caso `posts-id`. Mudando a configuração do `routerNameSplitter` para `/` o nome irá portanto mudar para `posts/id`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -388,19 +388,19 @@ export default {
 
 ### scrollBehavior
 
-The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered.
+A opção `scrollBehavior` permite você definir um comportamento personalizado para a posição da rolagem entre as rotas. Este método é chamado toda vez que a página é renderizada.
 
 ::alert{type="next"}
-To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+Para aprender mais sobre ele, veja a [documentação do vue-router para scrollBehavior](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
 ::
 
-Available since:v2.9.0:
+Disponível desde a versão 2.9.0:
 
-In Nuxt you can use a file to overwrite the router scrollBehavior. This file should be placed in a folder called app.
+No Nuxt você pode usar o ficheiro para sobrescrever o scrollBehavior do router. Este ficheiro deve ser posto dentro da uma pasta chamada app.
 
 `~/app/router.scrollBehavior.js`.
 
-Example of forcing the scroll position to the top for every route:
+Exemplo de como forçar a posição da rolagem para o topo de toda rota:
 
 ```js{}[app/router.scrollBehavior.js]
 export default function (to, from, savedPosition) {
@@ -409,18 +409,18 @@ export default function (to, from, savedPosition) {
 ```
 
 ::alert{type="next"}
-[Nuxt default `router.scrollBehavior.js` file.](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/router.scrollBehavior.js)
+[Ficheiro `router.scrollBehavior.js` padrão do Nuxt.](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/router.scrollBehavior.js)
 ::
 
 ::alert{type="next"}
-[scrollBehavior Property](/docs/configuration-glossary/configuration-router#scrollbehavior)
+[Propriedade scrollBehavior](/docs/configuration-glossary/configuration-router#scrollbehavior)
 ::
 
 ### trailingSlash
 
-Available since: v2.10
+Disponível desde a versão: 2.10
 
-If this option is set to true, trailing slashes will be appended to every route. If set to false, they'll be removed.
+Se este opção estiver definida para true, rastros de barras serão somados a toda rota. Se definida para false, eles serão removidos,
 
 ```js{}[nuxt.config.js]
 export default {
@@ -431,9 +431,9 @@ export default {
 ```
 
 ::alert{type="warning"}
-This option should not be set without preparation and has to be tested thoroughly. When setting `router.trailingSlash` to something else other than `undefined`(which is the default value), the opposite route will stop working. Thus 301 redirects should be in place and your *internal linking* has to be adapted correctly. If you set `trailingSlash` to `true`, then only `example.com/abc/` will work but not `example.com/abc`. On false, it's vice-versa.
+Esta opção não deve ser definida sem preparação e ter sido testado cuidadosamente. Quando estiver definindo `router.trailingSlash` para alguma coisa diferente de `undefined` (o qual é o valor padrão), a rota oposta irá parar de funcionar. Assim redireções 301 devem estar no lugar e sua *ligação interna* tem de ser adaptada corretamente. Se você definir `trailingSlash` para `true`, só assim o `example.com/abc/` irá funcionar mas não `example.com/abc`. No false, é vice-versa.
 ::
 
 ::alert{type="next"}
-[trailingSlash Property](/docs/configuration-glossary/configuration-router#trailingslash)
+[Propriedade trailingSlash](/docs/configuration-glossary/configuration-router#trailingslash)
 ::

--- a/content/pt/docs/3.features/4.data-fetching.md
+++ b/content/pt/docs/3.features/4.data-fetching.md
@@ -1,63 +1,64 @@
 ---
-title: Data Fetching
-description: In Nuxt we have 2 ways of getting data from an API. We can use the fetch method or the asyncData method.
+title: Requisição de Dados
+description: Dentro do Nuxt, nós temos duas maneiras de receber dados de uma API. Podemos usar o método fetch ou o método asyncData.
 category: features
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/04_data_fetching?fontsize=14&hidenavigation=1&theme=dark
 ---
-# Data Fetching
+# Requisição de Dados
 
-In Nuxt we have 2 ways of getting data from an API. We can use the fetch method or the asyncData method.
+Dentro do Nuxt, nós temos duas maneiras de receber dados de uma API. Podemos usar o método fetch ou o método asyncData.
 
 ---
 
-Nuxt supports traditional Vue patterns for loading data in your client-side app, such as fetching data in a component's `mounted()` hook. Universal apps, however, need to use Nuxt-specific hooks to be able to render data during server-side rendering. This allows your page to render with all of its required data present.
+O Nuxt suporta os padrões tradicionais do Vue para o carregamento de dados em sua aplicação no lado do cliente, tais como requisição de dados dentro de um gatilho `mounted()` do componente. As aplicações universais, por outro lado, precisam usar gatilhos específicos do Nuxt para serem capazes de renderizar dados durante a renderização no lado do servidor. Isto permite a sua página renderizar com todos os seus dados obrigatórios presente.
 
-Nuxt has two hooks for asynchronous data loading:
+O Nuxt tem dois gatilhos para carregamento assíncrono de dados:
 
-- **`asyncData`**. This hook can only be placed on _page_ components. Unlike `fetch`, this hook does not display a loading placeholder during client-side rendering: instead, this hook blocks route navigation until it is resolved, displaying a page error if it fails.
-- **`fetch`** (Nuxt 2.12+). This hook can be placed on any component, and provides shortcuts for rendering loading states (during client-side rendering) and errors.
+- **`asyncData`**. Este gatilho só pode ser colocado nos componentes _page_. Ao contrário do `fetch`, este gatilho não exibindo um placeholder de carregamento durante a renderização no lado do cliente: ao invés disso, este gatilho bloqueia a navegação da rota até estiver resolvida, exibindo uma página de erro se ele falhar.
+- **`fetch`** (Nuxt 2.12+). Este gatilho pode ser colocado em qualquer componente, e fornece atalhos para renderização para estados do carregamentos (durante a renderização no lado do cliente) e erros.
 
-These hooks can be used with _any data fetching library_ you choose. We recommend using [@nuxt/http](https://http.nuxtjs.org/) or [@nuxt/axios](https://axios.nuxtjs.org/) for making requests to HTTP APIs. More information about these libraries, such as guides for configuring authentication headers, can be found in their respective documentation.
-
-::alert{type="info"}
-If you define `fetch` or `asyncData` inside a mixin and also have it defined in a component/page, the mixin function will be overwritten instead of called.
-::
-
-## The fetch hook
+Estes gatilhos podem ser usados com _qualquer biblioteca de requisição de dados_ que você escolher. Nós recomendamos usar [@nuxt/http](https://http.nuxtjs.org/) ou [@nuxt/axios](https://axios.nuxtjs.org/) para fazer requisições para APIs em HTTP. Mais informações sobre estas bibliotecas, tais como guias para configuração de cabeçalhos de autenticação, podem ser achadas em suas respetivas documentações.
 
 ::alert{type="info"}
-**Before Nuxt 2.12, there was a different `fetch` hook that only worked for _page_  components and didn't have access to the component instance.**
-
-If your `fetch()` accepts a `context` argument, it will be treated like a legacy fetch hook. This functionality is deprecated, and should be replaced with either `asyncData` or an [anonymous middleware](/docs/directory-structure/middleware#anonymous-middleware).
+Se você definer `fetch` ou `asyncData` dentro de um mixin e também tem ele definido dentro de uma página/componente, a função mixin será sobrescrita ao invés de ser chamada.
 ::
 
-`fetch` is a hook called during server-side rendering after the component instance is created, and on the client when navigating. The fetch hook should return a promise (whether explicitly, or implicitly using `async/await`) that will be resolved:
-
-- On the server, before the initial page is rendered
-- On the client, some time after the component is mounted
+## O Gatilho Fetch
 
 ::alert{type="info"}
-For [static hosting](/docs/features/deployment-targets#static-hosting), the fetch hook is only called during page generation, and the result is then cached for use on the client. To avoid cache conflicts, it may be necessary to specify a name for your component, or alternatively provide a unique fetchKey implementation.
+**Antes do Nuxt 2.12, havia um gatilho `fetch` diferente que só funcionava para componentes _page_ e não tinha acesso a instância do componente.**
+
+Se o seu `fetch()` aceitar um argumento `context`, ele será tratado como um gatilho fetch legado. Esta funcionalidade está depreciada, e deve ser substituídos tanto com o `asyncData` ou um [intermediário anónimo](/docs/directory-structure/middleware#anonymous-middleware).
 ::
 
-### Usage
+`fetch` é um gatilho chamado durante a renderização no lado do cliente depois da instância do componente ser criada, e no cliente quando estiver navegando. O gatilho fetch deve retornar uma promessa (seja explicitamente, ou implicitamente usando `async/await`) que será resolvida:
 
-#### Fetching data
-Within the fetch hook, you will have access to the component instance via `this`.
+- No servidor, antes da página inicial ser renderizada
+- No cliente, algum tempo depois que o componente ser montado
 
 ::alert{type="info"}
-Make sure any properties you want to modify have already been declared in `data()`. Then the data that comes from the fetch can be assigned to these properties.
+Para [hospedagem estática](/docs/features/deployment-targets#static-hosting), o gatilho fetch é somente chamado durante a geração da página, e o resultado é depois cacheado para ser usado no cliente. Para evitar conflitos, pode ser necessário especificar um nome para o seu componente, ou alternativamente fornecer uma implementação única fetchKey. 
 ::
 
-#### Changing fetch behavior
+### Uso
 
-`fetchOnServer`: `Boolean` or `Function` (default: `true`), call `fetch()` when server-rendering the page
+#### Requisitando Dados
 
-`fetchKey`: `String` or `Function` (defaults to the component scope ID or component name), a key (or a function that produces a unique key) that identifies the result of this component's fetch (available on Nuxt 2.15+). When hydrating a server-rendered page, this key is used to map the result of the server-side `fetch()` to the client-side component data. [More information available in original PR](https://github.com/nuxt/nuxt.js/pull/8466).
+Dentro do gatilho fetch, você terá acesso a instância do componente via `this`.
 
-`fetchDelay`: `Integer` (default: `200`), set the minimum executing time in milliseconds (to avoid quick flashes)
+::alert{type="info"}
+Certifique-se de que quaisquer propriedades que você queira modificar tenha já sido declarada dentro do `data()`. Então os dados que vierem da requisição possam ser atribuídas a essas propriedades.
+::
 
-When `fetchOnServer` is falsy (`false` or returns `false`), `fetch` will be called only on client-side and `$fetchState.pending` will return `true` when server-rendering the component.
+#### Mudando o Comportamento do Fetch
+
+`fetchOnServer`: `Boolean` ou `Function` (padrão: `true`), chama `fetch()` sempre que estiver renderizando a página no lado do servidor
+
+`fetchKey`: `String` ou `Function` (padrões para o escopo ID do componente ou nome do componente), uma chave (ou uma função que produz uma chave única) que identifica o resultado deste fetch do componente (disponível no Nuxt 2.15+). Sempre que estiver hidratando uma página renderizada no lado do servidor, esta chave é será para mapear o resultado do `fetch()` no lado do servidor para os dados do componente no lado do cliente. [Mais informações estão disponíveis dentro do PR original](https://github.com/nuxt/nuxt.js/pull/8466)
+
+`fetchDelay`: `Integer` (padrão: `200`), define o tempo mínimo de execução em milissegundos (para evitar piscadas)
+
+Sempre que o `fetchOnServer` for falsy (`false` ou retorna `false`), `fetch` será chamado somente no lado do cliente e `$fetchState.pending` retornará `true` quando estiver renderizando o componente no lado do servidor.
 
 ```js
 export default {
@@ -68,27 +69,27 @@ export default {
     this.posts = await this.$http.$get('https://api.nuxtjs.dev/posts')
   },
   fetchOnServer: false,
-  // multiple components can return the same `fetchKey` and Nuxt will track them both separately
+  // dois ou vários componentes podem retornar a mesma `fetchKey` e o Nuxt irá rastrear elas ambas separadamente
   fetchKey: 'site-sidebar',
-  // alternatively, for more control, a function can be passed with access to the component instance
-  // It will be called in `created` and must not depend on fetched data
+  // alternativamente, para mais controle, uma função pode ser passado com acesso a instância do componente
+  // Ele será chamado dentro do `created` e não deve depender dos dados requisitados
   fetchKey(getCounter) {
-    // getCounter is a method that can be called to get the next number in a sequence
-    // as part of generating a unique fetchKey.
+    // getCounter é um método que pode ser chamado para receber o próximo número dentro de uma sequência
+    // como parte da geração de uma fetchKey única.
     return this.someOtherData + getCounter('sidebar')
   }
 }
 ```
 
-#### Accessing the fetch state
+#### Acessando o Estado do Fetch
 
-The `fetch` hook exposes `this.$fetchState` at the component level with the following properties:
+O gatilho `fetch` expõem `this.$fetchState` no nível do componente com as seguintes propriedades:
 
-- `pending` is a `Boolean` that allows you to display a placeholder when `fetch` is being called *on client-side*.
-- `error` is either `null` or an `Error` thrown by the fetch hook
-- `timestamp` is a timestamp of the last fetch, useful for [caching with `keep-alive`](#caching)
+- `pending` é um `Boolean` que permite você exibir um placeholder quando `fetch` estiver sendo chamado *no lado do cliente*.
+- `error` é um `null` ou um `Error` lançando pelo gatilho fetch
+- `timestamp` é uma referência a data e hora do ultimo fetch, útil para [cacheamento com `keep-alive`](#cacheamento)
 
-In addition to fetch being called by Nuxt, you can manually call fetch in your component (to e.g. reload its async data) by calling `this.$fetch()`.
+Adicionalmente ao fetch ser chamado pelo Nuxt, você pode manualmente chamar o fetch dentro do seu componente (para por exemplo recarregar seus dados assincronamente) ao chamar `this.$fetch()`.
 
 ```html{}[components/NuxtMountains.vue]
 <template>
@@ -122,12 +123,12 @@ In addition to fetch being called by Nuxt, you can manually call fetch in your c
 ```
 
 ::alert{type="info"}
-You can access the Nuxt [context](/docs/concepts/context-helpers) within the fetch hook using `this.$nuxt.context`.
+Você pode acessar o [contexto](/docs/concepts/context-helpers) do Nuxt dentro do gatilho fetch ao usar `this.$nuxt.context`.
 ::
 
-### Listening to query string changes
+### Ouvindo as Mudanças na String de Consulta
 
-The `fetch` hook is not called on query string changes by default. To watch for query changes you can add a watcher on `$route.query` and call `$fetch`:
+O gatilho fetch não é chamado sobre as mudanças da string de consulta por padrão. Para vigiar as mudanças na consulta você pode adicionar um vigia sobre `$route.query` e depois chamar `$fetch`:
 
 ```js
 export default {
@@ -135,14 +136,14 @@ export default {
     '$route.query': '$fetch'
   },
   async fetch() {
-    // Called also on query changes
+    // Chamado também sobre as mudanças da consulta
   }
 }
 ```
 
-### Caching
+### Cacheamento
 
-You can use `keep-alive` directive in `<nuxt/>` and `<nuxt-child/>` component to save `fetch` calls on pages you already visited:
+Você pode usar a diretiva `keep-alive` dentro do componente `<nuxt/>` e `<nuxt-child/>` para guardar as chamados do `fetch` na páginas que você já visitou:
 
 ```html{}[layouts/default.vue]
 <template>
@@ -150,21 +151,21 @@ You can use `keep-alive` directive in `<nuxt/>` and `<nuxt-child/>` compon
 </template>
 ```
 
-You can also specify the [props](https://vuejs.org/v2/api/#keep-alive) passed to `<keep-alive>` by passing a prop `keep-alive-props` to the `<nuxt>`  component.
+Você pode também especificar as [props](https://vuejs.org/v2/api/#keep-alive) passadas para o `<keep-alive>` ao passar uma propriedade `keep-alive-props` para o componente `<nuxt>` :
 
 ```html{}[layouts/default.vue]
 <nuxt keep-alive :keep-alive-props="{ max: 10 }" />
 ```
 
-Keeps only 10 page components in memory.
+Mantenha apenas 10 componentes de página dentro da memória.
 
-### Error handling
+### Manipulação de Erro
 
 ::alert{type="warning"}
-If there is an error when fetching data, the normal Nuxt error page won't be loaded - and you should not use the Nuxt `redirect` or `error` methods within `fetch()`. Instead, you will need to handle it within your component using `$fetchState.error`.
+Se houver um erro durante a requisição dos dados, a página erro normal do Nuxt não será carregado - e você não deve usar o `redirect` do Nuxt ou o método `error` dentro do `fetch()`. Ao invés disso, você precisará manipular ele dentro do seu componente usando `$fetchState.error`.
 ::
 
-We can  check `$fetchState.error` and show an error message if there is an error fetching the data.
+Podemos verificar o `$fetchState.error` e exibir uma mensagem de erro se houver um erro na requisição dos dados.
 
 ```html{}[components/MountainsList.vue]
 <template>
@@ -194,9 +195,9 @@ We can  check `$fetchState.error` and show an error message if there is an error
 </script>
 ```
 
-### Using `activated` hook
+### Usando o gatilho `activated`
 
-Nuxt will directly fill  `this.$fetchState.timestamp`  (timestamp) of the last `fetch` call (ssr included). You can use this property combined with `activated` hook to add a 30 seconds cache to `fetch`:
+O Nuxt irá diretamente preencher o `this.$fetchState.timestamp` (data e hora) do última chamada do `fetch` (inclusive no SSR). Você pode usar esta propriedade combinada com o gatilho `activated` para adicionar um cache de 30 segundos para `fetch`:
 
 ```html{}[pages/posts/_id.vue]
 <template> ... </template>
@@ -209,7 +210,7 @@ Nuxt will directly fill  `this.$fetchState.timestamp`  (timestamp) of the last
       }
     },
     activated() {
-      // Call fetch again if last fetch more than 30 sec ago
+      // Chama o fetch novamente se o último fetch foi a mais de 30 segundos atrás.
       if (this.$fetchState.timestamp <= Date.now() - 30000) {
         this.$fetch()
       }
@@ -223,15 +224,15 @@ Nuxt will directly fill  `this.$fetchState.timestamp`  (timestamp) of the last
 </script>
 ```
 
-The navigation to the same page will not call `fetch` if last `fetch` call was before 30 sec ago.
+A navegação para a mesma página não chamará o `fetch` se a última chamada do `fetch` antes de 30 segundos atrás.
 
-## Async Data
+## Dados Assíncronos
 
 ::alert{type="warning"}
-`asyncData` is only available for [pages](/docs/directory-structure/pages) and you don't have access to `this` inside the hook.
+`asyncData` está apenas disponível para [páginas](/docs/directory-structure/pages) e você não tem acesso ao `this` dentro do gatilho.
 ::
 
-`asyncData` is another hook for universal data fetching. Unlike `fetch`, which requires you to set properties on the component instance (or dispatch Vuex actions) to save your async state, `asyncData` simply merges its return value into your component's local state. Here's an example using the [@nuxt/http](https://http.nuxtjs.org/) library:
+`asyncData` é outro gatilho para requisição de dados universal. Ao contrário do `fetch`, que requer que você defina propriedades na instância do componente (ou despachar ações do Vuex) para guardar seu estado assíncrono, `asyncData` simplesmente funde seu valor de retorno dentro do seu estado local do componente. Aqui está um exemplo usando a biblioteca [@nuxt/http](https://http.nuxtjs.org/):
 
 ```html{}[pages/posts/_id.vue]
 <template>
@@ -251,24 +252,24 @@ The navigation to the same page will not call `fetch` if last `fetch` call w
 </script>
 ```
 
-Unlike `fetch`, the promise returned by the `asyncData` hook is resolved _during route transition_. This means that no "loading placeholder" is visible during client-side transitions (although the [loading bar](https://nuxtjs.org/guides/features/loading/) can be used to indicate a loading state to the user). Nuxt will instead wait for the `asyncData` hook to be finished before navigating to the next page or display the [error page](/docs/directory-structure/layouts#error-page)).
+Ao contrário do `fetch`, a promessa retornada pelo gatilho `asyncData` é resolvida _durante a transição da rota_. Isto significa que nenhum "placeholder de carregamento" está visível durante as transições do lado do cliente (se bem que a [barra de carregamento](https://nuxtjs.org/guides/features/loading/) pode ser usada para indicar um estado de carregamento ao usuário). O Nuxt irá ao invés disso esperar que o `asyncData` seja terminado antes de navegar para a próxima página ou exibir a [página de erro](/docs/directory-structure/layouts#error-page).
 
-This hook can only be used for page-level components. Unlike `fetch`, `asyncData` cannot access the component instance (`this`). Instead, it receives [the context](/docs/concepts/context-helpers) as its argument. You can use it to fetch some data and Nuxt will automatically shallow merge the returned object with the component data.
+Este gatilho pode somente ser usado para componentes do nível de página. Ao contrário do `fetch`, `asyncData` não consegue acessar a instância do componente (`this`). Ao invés disso, ele recebe [o contexto](/docs/concepts/context-helpers) como seu argumento. Você pode usar ele para pedir alguns dados e o Nuxt irá automaticamente fazer uma fusão superficial do objeto retornado com os dados do componente.
 
-In the upcoming examples, we are using [@nuxt/http](https://http.nuxtjs.org/) which we recommend for fetching data from an API.
+Dentro dos exemplos que estão por vir, estamos usando o [@nuxt/http](https://http.nuxtjs.org/) o qual recomendamos para requisição de dados de uma API.
 
-### Async data in components?
+### Dados Assíncrono em Componentes?
 
-Because components do not have an `asyncData` method, you cannot directly fetch async data server side within a component. In order to get around this limitation you have three basic options:
+Visto que os componentes não têm um método `asyncData`, você não consegue diretamente pedir dados assíncronos do lado do servidor dentro de um componente. No sentido de dar a volta a está limitação você tem três opções básicas:
 
-1. Use [the new `fetch` hook](#the-fetch-hook) that is available in Nuxt 2.12 and later versions.
-2. Make the API call in the `mounted` hook and set data properties when loaded. _Downside: Won't work for server side rendering._
-3. Make the API call in the `asyncData` method of the page component and pass the data as props to the sub components. Server rendering will work fine. _Downside: the `asyncData` of the page might be less readable because it's loading the data for other components_.
+1. Usar [o novo gatilho `fetch`](#o-gatilho-fetch) que está disponível no Nuxt 2.12 e posteriores versões.
+2. Fazer a API chamar dentro do gatilho `mounted` e definir propriedades de dados sempre que for carregado. _Desvantagem: Não funcionará para a renderização no lado do servidor_
+3. Fazer a API chamar dentro do método `asyncData` do componente da página e passar os dados como propriedades para os subcomponentes. Funcionará bem no lado do servidor. _Desvantagem: o `asyncData` da página pode ser menos legível porque está carregando os dados para outros componentes_.
 
-### Listening to query changes
+### Ouvindo Mudanças na Consulta
 
-The `asyncData` method is not called on query string changes by default. If you want to change this behavior, for example when building a pagination component, you can set up parameters that should be listened to with the `watchQuery` property of your page component.
+O método `asyncData` não é chamado sobre as mudanças da string de consulta por padrão. Se você quiser mudar este comportamento, por exemplo quando estiver construindo um componente de paginação, você pode configurar parâmetros que devem ser ouvidos com a propriedade `watchQuery` do seu componente de página.
 
 ::alert{type="next"}
-Learn more about the [watchQuery property](/docs/components-glossary/watchquery) and see the list of available [keys in context](/docs/concepts/context-helpers).
+Aprenda mais sobre a [propriedade watchQuery](/docs/components-glossary/watchquery) e veja a lista de [chaves disponíveis dentro do contexto](/docs/concepts/context-helpers).
 ::

--- a/content/pt/docs/3.features/5.meta-tags-seo.md
+++ b/content/pt/docs/3.features/5.meta-tags-seo.md
@@ -1,27 +1,27 @@
 ---
-title: Meta Tags and SEO
-description: Nuxt lets you define all default meta tags for your application inside the nuxt.config.js file using the head property. This is very useful for adding a default title and description tag for SEO purposes or for setting the viewport or adding the favicon.
+title: Marcadores de Meta e SEO
+description: O Nuxt permite você definir todos marcadores de metas padrão para a sua aplicação dentro do ficheiro nuxt.config.js com o uso da propriedade head. Isto é muito útil para a adição dos marcadores de título e descrição com o fim de SEO ou configuração da janela de visualização ou adição do favicon.
 category: features
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/06_meta_tags_seo?fontsize=14&hidenavigation=1&theme=dark
 ---
 
-# Meta Tags and SEO
+# Marcadores de Meta e SEO
 
-Nuxt gives you 3 different ways to add meta data to your application:
+O Nuxt dá para você 3 maneiras diferentes de adicionar meta dados a sua aplicação:
 
 ::div{.d-heading-description .leading-6}
 
-- Globally using the nuxt.config.js
-- Locally using the head as an object
-- Locally using the head as a function so that you have access to data and computed properties.
+- Usando o `nuxt.config.js` globalmente
+- Usando o head como um objeto localmente
+- Localmente usando o `head` como uma função assim você tem acesso ao dados ou propriedades computadas.
 
 ::
 
 ---
 
-### Global Settings
+### Configuração Global
 
-Nuxt lets you define all default `<meta>` tags for your application inside the nuxt.config.js file using the head property. This is very useful for adding a default title and description tag for SEO purposes or for setting the viewport or adding the favicon.
+O Nuxt permite você definir todos marcadores de metas padrão para a sua aplicação dentro do ficheiro `nuxt.config.js` com o uso da propriedade `head`. Isto é muito útil para a adição dos marcadores de título e descrição com o fim de SEO ou configuração da janela de visualização ou adição do favicon.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -42,12 +42,12 @@ export default {
 ```
 
 ::alert{type="info"}
-This will give you the same title and description on every page
+Isto lhe dará o mesmo title e description em todas as páginas
 ::
 
-### Local Settings
+### Configuração Local
 
-You can also add titles and meta for each page by setting the `head` property inside your script tag on every page:
+Você pode também adicionar títulos e meta para cada página pela configuração da propriedade `head` dentro da sua marcação de script em cada página:
 
 ```js{}[pages/index.vue]
 <script>
@@ -67,7 +67,7 @@ export default {
 ```
 
 ::alert{type="info"}
-Use `head` as an object to set a title and description only for the home page
+Use o `head` como um objeto para definir o `title` e a `description` somente para a página inicial (home)
 ::
 
 ```html{}[pages/index.vue]
@@ -98,28 +98,28 @@ Use `head` as an object to set a title and description only for the home page
 ```
 
 ::alert{type="info"}
-Use `head` as a function to set a title and description only for the home page. By using a function you have access to data and computed properties
+Use o `head` como uma função para definir um `title` e uma description somente para a página inicial (home). Ao usar uma função você tem acesso aos dados e propriedades computadas.
 ::
 
-Nuxt uses [vue-meta](https://vue-meta.nuxtjs.org/) to update the document head and meta attributes of your application.
+O Nuxt usa [vue-meta](https://vue-meta.nuxtjs.org/) para atualizar o `head` e atributos meta do documento da sua aplicação.
 
 ::alert{type="warning"}
-To avoid any duplication when used in child components, please give a unique identifier with the `hid` key to the meta description. This way `vue-meta` will know that it has to overwrite the default tag.
+Para evitar qualquer duplicação sempre que usado em componentes filhos, dê um identificador único com a chave  `hid`  para a descrição de meta. Desta maneira `vue-meta` saberá que ele tem de sobrescrever o marcador padrão.
 ::
 
 ::alert{type="next"}
-Learn more about the options available for `head`, in the [vue-meta documentation](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
+Aprenda mais sobre as opções disponíveis para  `head`, na [documentação do vue-meta](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
 ::
 
-## External Resources
+## Recursos Externos
 
-You can include external resources such as scripts and fonts by adding them globally to the `nuxt.config.js` or locally in the `head` object or function.
+Você pode incluir recursos externos tais como scripts e fontes ao adicionar eles globalmente ao `nuxt.config.js` ou localmente dentro do objeto ou função `head`.
 
 ::alert{type="info"}
-You can also pass each resource an optional `body: true` to include the resource before the closing `</body>` tag.
+Você também pode passar para cada recurso um `body: true`  opcional para incluir os recursos antes do fechamento da tag `</body>` .
 ::
 
-### Global Settings
+### Configuração Global
 
 ```js{}[nuxt.config.js]
 export default {
@@ -139,7 +139,7 @@ export default {
 }
 ```
 
-### Local Settings
+### Configuração Local
 
 ```html{}[pages/index.vue]
 <template>

--- a/content/pt/docs/3.features/6.configuration.md
+++ b/content/pt/docs/3.features/6.configuration.md
@@ -1,47 +1,47 @@
 ---
-title: Configuration
-description: By default, Nuxt is configured to cover most use cases. This default configuration can be overwritten with the nuxt.config.js file.
+title: Configuração
+description: Por padrão, o Nuxt está configurado para cobrir a maioria dos casos de uso. Esta configuração padrão pode ser sobrescrita com o ficheiro nuxt.config.js.
 category: features
 csb_link_host_port: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/07_configuration_host_port?fontsize=14&hidenavigation=1&theme=dark
 csb_link_pre-processors: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/07_configuration_pre-processors?fontsize=14&hidenavigation=1&theme=dark
 ---
 
-# Configuration
+# Configuração
 
-By default, Nuxt is configured to cover most use cases. This default configuration can be overwritten with the nuxt.config.js file.
+Por padrão, o Nuxt está configurado para cobrir a maioria dos casos de uso. Esta configuração padrão pode ser sobrescrita com o ficheiro `nuxt.config.js`.
 
 ---
 
-## The css Property
+## A Propriedade CSS
 
-Nuxt lets you define the CSS files/modules/libraries you want to set globally (included in every page).
+O Nuxt permite você definir os ficheiros/módulos/bibliotecas CSS que você quiser definer globalmente (incluído dentro de cada página).
 
 ::alert{type="warning"}
-In case you want to use `sass` make sure that you have installed the `sass` and `sass-loader` packages.
+Neste caso você quiser usar `sass` certifique-se de que você tem instalado os pacotes `sass` e `sass-loader` .
 ::
 
-In `nuxt.config.js`, add the CSS resources:
+Dentro do `nuxt.config.js`, adicione os recursos do CSS:
 
 ```js [nuxt.config.js]
 export default {
   css: [
-    // Load a Node.js module directly (here it's a Sass file)
+    // Carrega um módulo Node.js diretamente (aqui está um ficheiro Sass)
     'bulma',
-    // CSS file in the project
+    // ficheiro CSS dentro do projeto
     '~/assets/css/main.css',
-    // SCSS file in the project
+    // ficheiro SCSS dentro do projeto
     '~/assets/css/main.scss'
   ]
 }
 ```
 
 ::alert{type="warning"}
-Nuxt will automatically guess the file type by its extension and use the appropriate pre-processor loader for webpack. You will still need to install the required loader if you need to use them.
+O Nuxt irá automaticamente deduzir o tipo do ficheiro pela sua extensão e usar o carregador de pré-processador apropriado para o webpack. Você continuará a precisar instalar o carregador solicitado se você precisar usar eles.
 ::
 
-### Style Extensions
+### Extensões do Estilo
 
-You can omit the file extension for CSS/SCSS/Postcss/Less/Stylus/... files listed in the css array in your nuxt config file.
+Você pode omitir a extensão do ficheiro para os ficheiros CSS/SCSS/PostCSS/Less/Stylus... listados dentro do array css dentro do seu ficheiro de configuração.
 
 ```js [nuxt.config.js]
 export default {
@@ -50,16 +50,16 @@ export default {
 ```
 
 ::alert{type="warning"}
-If you have two files with the same name, e.g. `main.scss` and `main.css`, and don't specify an extension in the css array entry, e.g. `css: ['~/assets/css/main']`, then only one file will be loaded depending on the order of `styleExtensions`. In this case only the `css` file will be loaded and the `scss` file will be ignored because `css` comes first in the default `styleExtension` array.
+Se você tem dois ficheiros com o mesmo nome, por exemplo `main.scss` e `main.css`, e não especifica uma extensão dentro o array de entrada css, por exemplo `css: ['~/assets/css/main']`, então somente um ficheiro será carregado dependendo da ordem do `styleExtensions`. Neste caso apenas o ficheiro `css` será carregado e o ficheiro `scss` será ignorado porque o `css` vem em primeiro dentro do array `styleExtensions` padrão.
 ::
 
-Default order: `['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']`
+Ordem padrão: `['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']`
 
-## Pre-processors
+## Pré-processadores
 
-Thanks to [Vue Loader](http://vue-loader.vuejs.org/en/configurations/pre-processors.html), you can use any kind of pre-processor for your  `<template>` or `<style>`: use the `lang` attribute.
+Graças ao [Vue Loader](http://vue-loader.vuejs.org/en/configurations/pre-processors.html), você pode usar qualquer tipo de pré-processador para o seu  `<template>` ou `<style>`: use o atributo `lang` .
 
-Example of our `pages/index.vue` using [Pug](https://github.com/pugjs/pug) and [Sass](http://sass-lang.com/):
+Exemplo do nosso `pages/index.vue` usando [Pug](https://github.com/pugjs/pug) e [Sass](http://sass-lang.com/):
 
 ```html [pages/index.vue]
 <template lang="pug">
@@ -73,7 +73,7 @@ Example of our `pages/index.vue` using [Pug](https://github.com/pugjs/pug) an
 </style>
 ```
 
-To use these pre-processors, we need to install their webpack loaders:
+Para usar estes pré-processadores, precisamos instalar seus carregadores para o webpack:
 
 ::code-group
 ```bash [Yarn]
@@ -86,13 +86,13 @@ npm install --save-dev sass sass-loader@10
 ```
 ::
 
-## External Resources
+## Recursos Externos
 
-### Global Settings
+### Configuração Global
 
-You can include your external resources in the head object or function. As described in the [head API docs](https://nuxtjs.org/api/pages-head/), the following examples shows the use of `head` as an object and as a function. If you want to use values from your Vue component like computed properties or data, you can use the `head()` function, returning the final head object. You can also pass each resource an optional `body: true` to include the resource before the closing `</body>` tag.
+Você pode incluir seus recursos externos dentro da função ou objeto head. Assim como é descrito dentro da [documentação da API head](https://nuxtjs.org/api/pages-head/), os exemplos seguintes mostram o uso do `head` como um objeto e como uma função. Se você quiser usar valores do seu componente Vue como propriedades computadas ou dados, você pode usar a função `head`, retornado o objeto head final. Você pode também passar cada recurso um `body: true` opcional para incluir o recurso antes do fechamento da tag `</body>`.
 
-Include your resources in `nuxt.config.js` (here in the head object):
+Inclua os seus recursos dentro do `nuxt.config.js` (aqui dentro do objeto head).
 
 ```js
 export default {
@@ -112,9 +112,9 @@ export default {
 }
 ```
 
-### Local Settings
+### Configuração Local
 
-Include your resources in your `.vue` file inside the `pages/` directory (here in the head function):
+Inclua os seus recursos dentro do seu ficheiro `.vue` dentro do diretório `pages/` (aqui dentro da função head):
 
 ```html
 <template>
@@ -148,25 +148,25 @@ Include your resources in your `.vue` file inside the `pages/` directory (here i
 </style>
 ```
 
-## PostCSS plugins
+## Plugins do PostCSS
 
-If present, rename or delete the `postcss.config.js` in your project directory. Then, in your `nuxt.config.js` file add the following:
+Se apresentar, renomear ou eliminar o `postcss.config.js` dentro do diretório do projeto. Então, dentro do seu ficheiro `nuxt.config.js` para adicione o seguinte:
 
 ```js [nuxt.config.js]
 export default {
   build: {
     postcss: {
-      // Add plugin names as key and arguments as value
-      // Install them before as dependencies with npm or yarn
+      // Adicione os nomes do plugins como chaves e argumentos como valores
+      // Instale eles antes como dependências com o npm ou yarn
       plugins: {
-        // Disable a plugin by passing false as value
+        // Desative um plugin ao passar false como valor
         'postcss-url': false,
         'postcss-nested': {},
         'postcss-responsive-type': {},
         'postcss-hexrgba': {}
       },
       preset: {
-        // Change the postcss-preset-env settings
+        // Mude as configurações do postcss-preset-env
         autoprefixer: {
           grid: true
         }
@@ -178,9 +178,9 @@ export default {
 
 ## JSX
 
-Nuxt uses [@nuxt/babel-preset-app](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app), which is based on the official [@vue/babel-preset-app](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app) for babel default configuration, so you can use JSX in your components.
+O Nuxt usa [@nuxt/babel-preset-app](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app), que é baseado [@vue/babel-preset-app](https://github.com/vuejs/vue-cli/tree/dev/packages/%40vue/babel-preset-app) oficial para a configuração padrão do babel, assim você pode usar JSX dentro dos seus componentes.
 
-You can also use JSX in the `render` method of your components:
+Você pode também usar JSX dentro do método `render` dos seus componentes:
 
 ```js
 export default {
@@ -193,55 +193,55 @@ export default {
 }
 ```
 
-Aliasing `createElement` to `h` is a common convention you’ll see in the Vue ecosystem but is actually optional for JSX since it [automatically injects](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` in any method and getter (not functions or arrow functions) declared in ES2015 syntax that has JSX so you can drop the (h) parameter.
+Apelidar de `createElement` para `h` é uma convenção comum que você verá dentro do ecossistema porém é atualmente opcional para o JSX desde qye ele [injete automaticamente](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElemet` dentro de qualquer método e recebedor (getter) (não em funções ou funções em seta) declarado dentro da sintaxe ES2015 que tem o JSX assim você pode eliminar o parâmetro (h).
 
-You can learn more about how to use it in the [JSX section](https://vuejs.org/v2/guide/render-function.html#JSX) of the Vue.js documentation.
+Você pode aprender mais sobre como usar ele dentro da [secção JSX](https://vuejs.org/v2/guide/render-function.html#JSX) da documentação do Vue.js.
 
-## Ignoring files
+## Ignorando Ficheiros
 
 ### .nuxtignore
 
-You can use a `.nuxtignore` file to let Nuxt ignore  `layout`, `page`, `store` and `middleware`  files in your project’s root directory (`rootDir`) during the build phase. The `.nuxtignore` file is subject to the same specification as  `.gitignore`  and  `.eslintignore` files, in which each line is a glob pattern indicating which files should be ignored.
+Você pode usar um ficheiro `.nuxtignore` para deixar o Nuxt ignorar `layout`, `page`, `store` e ficheiros `middleware`  dentro do diretório raiz do seu projeto (`rootDir`) durante a fase de construção. O ficheiro `.nuxtignore` está sujeito a mesma especificação que os ficheiros  `.gitignore`  e  `.eslintignore` , no qual cada linha é um padrão global indicando quais ficheiros devem ser ignorados.
 
 ```markdown{}[.nuxtignore]
-# ignore layout foo.vue
+# ignore o esquema foo.vue
 
 layouts/foo.vue
 
-# ignore layout files whose name ends with -ignore.vue
+# ignore os ficheiros de esquemas os quais o nome termina com -ignore.vue
 
 layouts/*-ignore.vue
 
-# ignore page bar.vue
+# ignore a página bar.vue
 
 pages/bar.vue
 
-# ignore page inside ignore folder
+# ignore a página dentro da pasta ignore
 
 pages/ignore/*.vue
 
-# ignore store baz.js
+# ignore a memória baz.js
 
 store/baz.js
 
-# ignore store files match _.test._
+# ignore os ficheiros de memória correspondente _.test._
 
 store/ignore/_.test._
 
-# ignore middleware files under foo folder except foo/bar.js
+# ignore ficheiros intermediários dentro da pasta foo exceto foo/bar.js
 
 middleware/foo/*.js !middleware/foo/bar.js
 ```
 
-### The ignorePrefix Property
+### A Propriedade ignorePrefix
 
-Any file in pages/, layout/, middleware/ or store/ will be ignored during the build if its filename starts with the prefix specified by ignorePrefix.
+Qualquer ficheiro dentro pages/, layout/, middleware/ ou store/ será ignorado durante a construção se seu nome de ficheiro com o prefixo especificado pelo ignorePrefix.
 
-By default all files which start with `-` will be ignored, such as `store/-foo.js` and `pages/-bar.vue`. This allows for co-locating tests, utilities, and components with their callers without themselves being converted into routes, stores, etc.
+Por padrão todos ficheiros que começam com `-` serão ignorados, tais como `store/-foo.js` e `pages/-bar.vue`. Isto permite colocar-se testes, utilidades, e componentes com seus chamadores sem eles mesmos serem convertidos em rotas, memórias etc.
 
-### The ignore Property
+### A Propriedade ignore
 
-More customizable than ignorePrefix: all files matching glob patterns specified inside ignore will be ignored in building.
+Mais personalizável do que o ignorePrefix: todos ficheiros correspondentes aos padrões globais dentro de ignore serão ignorados durante a construção.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -249,9 +249,9 @@ export default {
 }
 ```
 
-### ignoreOptions
+### A propriedade ignoreOptions
 
-`nuxtignore` is using `node-ignore` under the hood, `ignoreOptions` can be configured as `options` of `node-ignore`.
+O `nuxtignore` está usando `node-ignore` nos bastidores, `ignoreOptions` pode ser configurado como `options` de `node-ignore`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -261,9 +261,9 @@ export default {
 }
 ```
 
-## Extend webpack config
+## Estender a Configuração do Webpack
 
-You can extend nuxt's webpack configuration via the `extend` option in your `nuxt.config.js`. The `extend` option of the `build` property is a method that accepts two arguments. The first argument is the webpack `config` object exported from nuxt's webpack config. The second parameter is a context object with the following boolean properties: `{ isDev, isClient, isServer, loaders }`.
+Você pode estender a configuração do webpack do Nuxt via opção `extend` dentro do seu `nuxt.config.js`. A opção `extend` da propriedade `build`  é um método que aceita dois argumentos. O primeiro argumento é o objeto `config` do webpack exportado a partir da configuração do webpack do Nuxt. O segundo parâmetro é um objeto de contexto com as seguintes propriedades booleanas: `{ isDev, isClient, isServer, loaders }`.
 
 ```js [nuxt.config.js]
 export default {
@@ -274,7 +274,7 @@ export default {
         test: /\.(ttf|eot|svg|woff(2)?)(\?[a-z0-9=&.]+)?$/,
         loader: 'file-loader'
       })
-      // Sets webpack's mode to development if `isDev` is true.
+      // Defina o modo do webpack para desenvolvimento se a variável `isDev` for true.
       if (isDev) {
         config.mode = 'development'
       }
@@ -283,11 +283,11 @@ export default {
 }
 ```
 
-The `extend` method gets called twice - Once for the client bundle and the other for the server bundle.
+O método `extend` é chamada duas vezes - uma vez para o pacote do cliente e outra para o pacote do servidor.
 
-### Customize chunks configuration
+### Personalize Pedaços de Configuração
 
-You may want to tweak the [optimization configuration](/docs/configuration-glossary/configuration-build#optimization) a bit, avoiding a rewrite of the default object.
+Você pode querer ajustar levemente a [configuração de otimização](/docs/configuration-glossary/configuration-build#optimization), evitando uma rescrita do objeto padrão.
 
 ```js [nuxt.config.js]
 export default {
@@ -301,15 +301,15 @@ export default {
 }
 ```
 
-### Inspect webpack configuration
+### Inspecionar A Configuração do Webpack
 
-For complex projects and debugging it's sometimes useful to check what the final webpack configuration will look like. Luckily you can run `nuxt webpack` command from withing your project to output the configuration. Checkout this PR [#7029](https://github.com/nuxt/nuxt.js/pull/7029) for more details.
+Para projetos complexos e depurações fâz-se útil verificar algumas vezes como será a configuração final do webpack. Felizmente você pode executar o comando `nuxt webpack` a partir de dentro do seu projeto para a saída da configuração. Para obter mais detalhes consulte esta PR [#7029](https://github.com/nuxt/nuxt.js/pull/7029).
 
-### Add webpack plugins
+### Adicionar Plugins Ao Webpack
 
-In your `nuxt.config.js` file, under the `build` option, you can pass webpack `plugins`, the same way you would do it in [a `webpack.config.js` file](https://webpack.js.org/configuration/plugins/).
+Dentro do seu ficheiro `nuxt.config.js`, por baixo da opção `build`, você pode passar `plugins` ao webpack, da mesma maneira que você faria dentro de [um ficheiro `webpack.config.js`](https://webpack.js.org/configuration/plugins/).
 
-In this example we add the webpack built-in [ProvidePlugin](https://webpack.js.org/plugins/provide-plugin/) for automatically loading JavaScript modules (_lodash_ and _jQuery_) instead of having to `import` or `require` them everywhere.
+Neste exemplo adicionamos o método [ProvidePlugin](https://webpack.js.org/plugins/provide-plugin/) embutido ao webpack para automaticamente carregar módulos do JavaScript (_lodash_ and _jQuery_) ao invés de ter de os `import` ou os `require` por todos os lugares.
 
 ```js [nuxt.config.js]
 import webpack from 'webpack'
@@ -318,7 +318,7 @@ export default {
   build: {
     plugins: [
       new webpack.ProvidePlugin({
-        // global modules
+        // módulos globais
         $: 'jquery',
         _: 'lodash'
       })
@@ -327,13 +327,13 @@ export default {
 }
 ```
 
-> Note: You might not need jQuery in a Vue-based app.
+> Note que: você pode não precisar do JQuery dentro de uma aplicação baseada no Vue. 
 
-With Nuxt, you can also control plugins execution context: if they are meant to be run on the `client` or in the `server` builds (or differentiating `dev` and `prod` builds) within [`build.extend`](/docs/configuration-glossary/configuration-build#extend), where you can manually pass webpack plugins too.
+Com o Nuxt, você pode também controlar o contexto de execução dos plugins: se eles serão executados nas construções no `client` ou dentro do `server` (ou diferenciando construções do `dev` e `prod`) dentro do [`build.extend`](/docs/configuration-glossary/configuration-build#extend), onde você pode também manualmente passar plugins ao webpack.
 
-### Extend Webpack to load audio files
+### Estender o Webpack para Carregar Ficheiros de Audio
 
-Audio files should be processed by `file-loader`. This loader is already included in the default Webpack configuration, but it is not set up to handle audio files. You need to extend its default configuration in `nuxt.config.js`:
+Ficheiros de audio devem ser processados pelo `file-loader`. Este carregador já está incluído dentro da configuração padrão do Webpack, mas não está configurado para lidar com ficheiros de audio. Você precisa estender sua configuração padrão dentro do `nuxt.config.js`:
 
 ```js [nuxt.config.js]
 export default {
@@ -351,9 +351,9 @@ export default {
 }
 ```
 
-You can now import audio files like this `<audio :src="require('@/assets/water.mp3')" controls></audio>`.
+Você pode agora importar ficheiros de audio como isto `<audio :src="require('@/assets/water.mp3')" controls></audio>`.
 
-If you only want to write: `<audio src="@/assets/water.mp3" controls></audio>`, you need to tell `vue-loader` to automatically require your audio files when you reference them with the `src` attribute:
+Se você apenas quiser escrever: `<audio src="@/assets/water.mp3" controls></audio>`, você precisar dizer ao `vue-loader` para automaticamente requerer ficheiros de audio sempre que você fizer referência a eles com o atributo `src`:
 
 ```js [nuxt.config.js]
 export default {
@@ -379,41 +379,41 @@ export default {
 }
 ```
 
-## Edit host and port
+## Editar o Hospedeiro e a Porta
 
-By default, the Nuxt development server host is `localhost`  which is only accessible from within the host machine. In order to view your app on another device you need to modify the host. You can modify the host in your nuxt.config.js file.
+Por padrão, o servidor hospedeiro de desenvolvimento do Nuxt é `localhost` o qual somente é acessível a partir de dentro da máquina hospedeira. No sentido de ver sua aplicação em outro dispositivo você precisa modificar o hospedeiro. Você pode modificar o hospedeiro dentro do seu ficheiro nuxt.config.js.
 
-Host `'0.0.0.0'`  is designated to tell Nuxt to resolve a host address, which is accessible to connections *outside* of the host machine (e.g. LAN). If the host is assigned the string value of `'0'` (not 0, which is falsy), or `'0.0.0.0'` your local IP address will be assigned to your Nuxt application.
+O hospedeiro `'0.0.0.0'`  está designado para dizer ao Nuxt para resolver o endereço do hospedeiro, o qual está acessível para conexões *fora* da máquina hospedeira (exemplo, LAN). Se  ao hospedeiro é atribuído o valor string `'0'` (não 0, o qual é falsy), ou `0.0.0.0` o seu endereço de IP local será atribuído a sua aplicação Nuxt.
 
 ```js [nuxt.config.js]
 export default {
   server: {
-    host: '0' // default: localhost
+    host: '0' // padrão: localhost
   }
 }
 ```
 
-You can also change the port number from the default port of 3000.
+Você pode também mudar a número da porta da porta padrão de 3000. 
 
 ```js [nuxt.config.js]
 export default {
   server: {
-    port: 8000 // default: 3000
+    port: 8000 // padrão: 3000
   }
 }
 ```
 
 ::alert{type="info"}
-If the port is assigned the string value of `'0'` (not 0, which is falsy) a random port number will be assigned to your Nuxt application.
+Se a porta é atribuída o valor string de `'0'` (não 0, o qual é falsy) um número de porta aleatório será atribuído a sua aplicação Nuxt.
 ::
 
-Although you can modify this in the nuxt.config.js file it is not advised to as it might cause you issues when hosting your site. It is much better to modify the host and port direct in the dev command.
+Se bem que você pode modificar isto dentro do ficheiro nuxt.config.js, não é aconselhado visto que isto pode causar a você problemas quando estiveres hospedando o seu site. É muito melhor modificar o hospedeiro e a porta direto dentro do comando dev.
 
 ```bash
 HOST=0 PORT=8000 npm run dev
 ```
 
-or create a script in your package.json
+ou criar um script dentro do package.json
 
 ```json
 "scripts": {
@@ -421,9 +421,9 @@ or create a script in your package.json
 }
 ```
 
-## Asynchronous Configuration
+## Configuração Assíncrona
 
-Although it is better to use the normal configuration `export default {}` you can have an async configuration by exporting an async function that return the config object.
+Embora seja melhor usar a configuração normal `export default {}` você pode ter uma configuração assíncrona ao exportar uma função assíncrona que retorna um objeto de configuração.
 
 ```js [nuxt.config.js]
 import axios from 'axios'
@@ -433,18 +433,18 @@ export default async () => {
   return {
     head: {
       title: data.title
-      //... rest of config
+      //... resto da configuração
     }
   }
 }
 ```
 
 ::alert{type="warning"}
-The axios-module cannot be used in `nuxt.config.js`. You will need to import axios and configure it again.
+O módulo axios não pode ser usado dentro do `nuxt.config.js`. Você precisará importar o axios e configurar ele novamente.
 ::
 
-## Further configuration
+## Configurações Avançadas
 
 ::alert{type="next"}
-The `nuxt.config.js` has way more customization and configuration options! Check out all its keys in the [configuration glossary](/docs/configuration-glossary/configuration-build).
+O `nuxt.config.js` tem mais opções de personalização e configurações! Consulte todas suas chaves dentro do [glossário de configuração](/docs/configuration-glossary/configuration-build).
 ::

--- a/content/pt/docs/3.features/7.loading.md
+++ b/content/pt/docs/3.features/7.loading.md
@@ -1,20 +1,20 @@
 ---
-title: Loading
-description: Out of the box, Nuxt gives you its own loading progress bar component that's shown between routes. You can customize it, disable it or even create your own loading component.
+title: Carregamento
+description: Fora da caixa, o Nuxt dá para você o seu próprio componente de barra de progresso de carregamento que é exibido entre as rotas. Você pode personalizar ele, desativar ele ou até criar seu próprio componente de carregamento.
 category: features
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/08_loading?fontsize=14&hidenavigation=1&theme=dark
 ---
-# Loading
+# Carregamento
 
-Out of the box, Nuxt gives you its own loading progress bar component that's shown between routes. You can customize it, disable it or even create your own loading component.
+Fora da caixa, o Nuxt dá para você o seu próprio componente de barra de progresso de carregamento que é exibido entre as rotas. Você pode personalizar ele, desativar ele ou até criar seu próprio componente de carregamento.
 
 ---
 
-## Customizing the Progress Bar
+## Personalizando a Barra de Progresso
 
-Among other properties, the color, size, duration and direction of the progress bar can be customized to suit your application's needs. This is done by updating the `loading` property of the `nuxt.config.js` with the corresponding properties.
+Entre outras propriedades, a color, o tamanho, a duração e a direção da barra de progresso podem ser personalizados para enquadrarem-se as necessidades da sua aplicação. Isto é feito pela atualização da propriedade `loading` do `nuxt.config.js` com as propriedades correspondentes.
 
-For example, to set a blue progress bar with a height of 5px, we update the `nuxt.config.js` to the following:
+Por exemplo, para definir uma barra de progresso azul com a altura de 5px, atualizamos o `nuxt.config.js` para o seguinte:
 
 ```js
 export default {
@@ -25,22 +25,22 @@ export default {
 }
 ```
 
-List of properties to customize the progress bar.
+Lista de propriedades para personalizar a barra de progresso.
 
-| Key         | Type    | Default | Description                                                                                                                       |     |
-| ----------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- | --- |
-| color       | String  | 'black' | CSS color of the progress bar                                                                                                     |     |
-| failedColor | String  | 'red'   | CSS color of the progress bar when an error appended while rendering the route (if data or fetch sent back an error for example). |     |
-| height      | String  | '2px'   | Height of the progress bar (used in the style property of the progress bar)                                                       |     |
-| throttle    | Number  | 200     | In ms, wait for the specified time before displaying the progress bar. Useful for preventing the bar from flashing.               |     |
-| duration    | Number  | 5000    | In ms, the maximum duration of the progress bar, Nuxt assumes that the route will be rendered before 5 seconds.                |     |
-| continuous  | Boolean | false   | Keep animating progress bar when loading takes longer than duration.                                                              |     |
-| css         | Boolean | true    | Set to false to remove default progress bar styles (and add your own).                                                            |     |
-| rtl         | Boolean | false   | Set the direction of the progress bar from right to left.                                                                         |     |
+| Chave       | Tipo    | Padrão  |  Descrição                                                                                                          |     |
+| ----------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------- | --- |
+| color       | String  | 'black' | Cor CSS da barra de progresso                                                                                       |     |
+| failedColor | String  | 'red'   | Cor CSS da barra de progresso quando um erro é anexado durante a renderização da rota (se os dados ou requisição enviada voltar com um erro por exemplo).                                                                                                                                                       |     |
+| height      | String  | '2px'   | Altura da barra de progresso (usada dentro da propriedade de estilo da barra de progresso)                          |     |
+| throttle    | Number  | 200     | Em ms, espera pelo tempo especificado antes de exibir a barra de progresso. Útil para impedir a barra de piscar.    |     |
+| duration    | Number  | 5000    | Em ms, a duração máxima da barra de progresso, o Nuxt assume que a rota será renderizada antes de 5 segundos.       |     |
+| continuous  | Boolean | false   | Mantêm a barra de progresso animando sempre que o carregamento levar mais tempo que a duração.                      |     |
+| css         | Boolean | true    | Define para false para remover os estilos padrão da barra de progresso (e adicione você mesmo).                     |     |
+| rtl         | Boolean | false   | Define a direção da barra de progresso da direita para a esquerda.                                                  |     |
 
-## Disable the Progress Bar
+## Desativar a Barra de Progresso
 
-If you don't want to display the progress bar between the routes add `loading: false` in your `nuxt.config.js` file:
+Se você não quiser exibir a barra de progresso entre as rotas adicione `loading: false` dentro do seu ficheiro `nuxt.config.js` :
 
 ```js{}[nuxt.config.js]
 export default {
@@ -48,7 +48,7 @@ export default {
 }
 ```
 
-The loading property gives you the option to disable the default loading progress bar on a specific page.
+A propriedade loading dá para você a opção de desativar a barra de progresso padrão em uma página específica.
 
 ```html{}[pages/index.vue]
 <template>
@@ -62,11 +62,11 @@ The loading property gives you the option to disable the default loading progres
 </script>
 ```
 
-## Programmatically starting the loading bar
+## Começar Programaticamente a Barra de Carregamento
 
-The loading bar can also be programmatically started in your components by calling `this.$nuxt.$loading.start()` to start the loading bar and `this.$nuxt.$loading.finish()` to finish it.
+A barra de carregamento também pode ser programaticamente iniciada dentro dos seus componentes ao chamar `this.$nuxt.$loading.start()` para iniciar a barra de carregamento e `this.$nuxt.$loading.finish()` para terminar ele.
 
-During your page component's mounting process, the `$loading` property may not be immediately available to access. To work around this, if you want to start the loader in the `mounted` method, make sure to wrap your `$loading` method calls inside `this.$nextTick` as shown below.
+Durante o processo de montagem dos componentes da sua página, a propriedade `$loading` pode não estar imediatamente disponível para acessar. Para dar a volta a isso, se você quiser iniciar o carregador dentro do método `mounted` , certifique-se de envolver a sua chamada para o método `$loading` dentro de `this.$nextTick` como é mostrado abaixo.
 
 ```js
 export default {
@@ -79,13 +79,13 @@ export default {
 }
 ```
 
-## Internals of the Progress Bar
+## Os Interiores da Barra de Progresso
 
-Unfortunately, it is not possible for the Loading component to know in advance how long loading a new page will take. Therefore, it is not possible to accurately animate the progress bar to 100% of the loading time.
+Infelizmente, não é possível para o componente de carregamento saber de antemão quanto tempo uma nova página levará para carregar. Portanto, não é possível de maneira precisa animar a barra de progresso até 100% do tempo de carregamento.
 
-Nuxt's loading component partially solves this by letting you set the `duration`, this should be set to an estimate of how long the loading process will take. Unless you use a custom loading component, the progress bar will always move from 0% to 100% in `duration` time (regardless of actual progression). When the loading takes longer than `duration` time, the progress bar will stay at 100% until the loading finishes.
+O componente de carregamento do Nuxt resolve parcialmente isso ao deixar você definir a `duration`, isso deve ser definido para uma estimativa de quanto tempo o processo de carregamento levará. A menos que você use um componente de carregamento personalizado, a barra de progresso irá sempre mover de 0% para 100% em tempo de `duration`  (independentemente da progressão atual). Sempre que o carregamento levar mais tempo do que o tempo em `duration` , a barra de progresso continuará em 100% até o carregamento terminar.
 
-You can change the default behavior by setting `continuous` to true, then after reaching 100% the progress bar will start shrinking back to 0% again in `duration` time. When the loading is still not finished after reaching 0% it will start growing from 0% to 100% again, this repeats until the loading finishes.
+Você pode mudar o comportamento padrão ao configurar `continuous` para true, então depois de alcançar o 100% a barra de progresso começará reduzindo novamente de volta para 0% em tempo de `duration` . Sempre que o carregamento não estiver terminado depois de alcançar 0% ele começará crescendo novamente de 0% até 100%, isto é repetido até o carregamento terminar.
 
 ```js
 export default {
@@ -95,24 +95,24 @@ export default {
 }
 ```
 
-_Example of a continuous progress bar:_
+_Exemplo de uma barra de progresso contínua:_
 
 ![/img/docs/api-continuous-loading.gif](/img/docs/api-continuous-loading.gif)
 
-## Using a Custom Loading Component
+## Usando um Componente de Carregamento Personalizado
 
-You can also create your own component that Nuxt will call instead of the default loading progress bar component. To do so, you need to give a path to your component in the `loading` option. Then, your component will be called directly by Nuxt.
+Você pode também criar seu próprio componente que o Nuxt chamará no lugar do componente padrão para a barra de progresso. Para fazer isso no entanto, você precisa dar um caminho para o seu componente dentro da opção `loading` . Depois, o seu componente será chamado diretamente pelo Nuxt.
 
-Your component has to expose some of these methods:
+O seu componente tem que expor alguns desses métodos:
 
-| Method        | Required | Description                                                                              |
-| ------------- | -------- | ---------------------------------------------------------------------------------------- |
-| start()       | Required | Called when a route changes, this is where you display your component.                   |
-| finish()      | Required | Called when a route is loaded (and data fetched), this is where you hide your component. |
-| fail(error)   | Optional | Called when a route couldn't be loaded (failed to fetch data for example).               |
-| increase(num) | Optional | Called during loading the route component, num is an Integer < 100.                      |
+| Método        | Obrigatório | Descrição                                                                                                 |
+| ------------- | ----------- | --------------------------------------------------------------------------------------------------------- |
+| start()       | Obrigatório | Chamado sempre que uma rota muda, é aqui onde você exibe o seu componente.                                |
+| finish()      | Obrigatório | Chamado sempre que uma rota é carregada (e dados são pedidos), é aqui onde você esconde o seu componente. |
+| fail(error)   |  Opcional   | Chamado sempre que uma rota não puder ser carregada (falhou ao pedir os dados por exemplo).               |
+| increase(num) |  Opcional   | Chamado durante o carregamento do componente de rota, num é um Inteiro menor que 100 (Integer < 100).     |
 
-You can create your custom component in `components/LoadingBar.vue`:
+Você pode criar o seu componente personalizado dentro de `components/LoadingBar.vue`:
 
 ```html{}[components/LoadingBar.vue]
 <template>
@@ -153,7 +153,7 @@ You can create your custom component in `components/LoadingBar.vue`:
 </style>
 ```
 
-Then, you update your `nuxt.config.js` to tell Nuxt to use your component:
+Depois, você atualiza seu `nuxt.config.js` para dizer ao Nuxt para usar o seu componente:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -161,9 +161,9 @@ export default {
 }
 ```
 
-## The loading indicator Property
+## A Propriedade loadingIndicator
 
-When running Nuxt in SPA mode, there is no content from the server side on the first page load. So, instead of showing a blank page while the page loads, Nuxt gives you a spinner which you can customize to add your own colors or background and even change the the indicator.
+Não há conteúdo vindo do lado do servidor no primeiro carregamento da página, quando o Nuxt estiver executando no modo SPA. Então, ao invés de mostrar uma página em branco enquanto a página carrega, o Nuxt dá para você um rodopiador (spinner) o qual você pode personalizar para adicionar suas próprias cores, fundo e até mudar o indicador.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -175,9 +175,9 @@ export default {
 }
 ```
 
-## Built-in indicators
+## Indicadores Embutidos
 
-These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com/spinkit) project. You can check out its demo page to preview the spinners. In order to use one of these spinners all you have to do is add its name to the name property. No need to import or install anything. Here is a list of built in indicators you can use.
+Esses indicadores são importados do incrível projeto [SpinKit](http://tobiasahlin.com/spinkit) . Você pode consultar a sua página de demonstração para pré-visualizar os rodopiadores (spinners). No propósito de usar um desses rodopiadores tudo o que você tem de fazer é adicionar seu nome a propriedade name. Não precisa importar ou instalar nada. Aqui está uma lista dos indicadores embutidos para você usar.
 
 - circle
 - cube-grid
@@ -191,10 +191,10 @@ These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com
 - three-bounce
 - wandering-cubes
 
-Built-in indicators support `color` and `background` options.
+Os indicadores embutidos suportam as opções `color` e `background` .
 
-## Custom indicators
+## Indicadores Personalizados
 
-If you need your own special indicator, a String value or Name key can also be a path to an HTML template of indicator source code! All of the options are passed to the template, too.
+Se você precisar seu próprio indicador especial, um valor do tipo String ou chave Name pode ser um caminho para o modelo (template) HTML do código-fonte do indicador! Todas as opções são passadas para o modelo também.
 
-Nuxt's built-in [source code](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) is also available if you need a base!
+[Código-fonte](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) do componente Loading embutido do Nuxt!

--- a/content/pt/docs/3.features/8.nuxt-components.md
+++ b/content/pt/docs/3.features/8.nuxt-components.md
@@ -1,23 +1,23 @@
 ---
-title: Built-in Components
-description: Nuxt comes with a few important components included out of the box, which will be helpful when building your application.
+title: Componentes Embutidos
+description: O Nuxt vem com alguns componentes importantes incluídos fora da caixa, os quais serão úteis quando estiver construindo sua aplicação.
 category: features
 csb_link_nuxt_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/09_components_nuxt-link?fontsize=14&hidenavigation=1&theme=dark
 csb_link_nuxt: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/03_features/09_components_nuxt?fontsize=14&hidenavigation=1&theme=dark
 ---
-# Nuxt Components
+# Componentes do Nuxt
 
-Nuxt comes with a few important components included out of the box, which will be helpful when building your application. The components are globally available, which means that you don't need to import them in order to use them.
+O Nuxt vem com alguns componentes importantes incluídos fora da caixa, os quais serão úteis quando estiver construindo sua aplicação. Os componentes estão disponíveis globalmente, o que significa que você não precisa importar eles no sentido de usar eles.
 
-In the following paragraphs, each of the included components is explained.
+Dentro dos parágrafos seguintes, cada componente incluído é explicado.
 
 ---
 
 
 
-## The Nuxt Component
+## O Componente Nuxt
 
-The `<Nuxt>` component is the component you use to display your page components. Basically, this component gets replaced by what is inside your page components depending on the page that is being shown. Therefore it is important that you add the `<Nuxt>` component to your layouts.
+O componente `<Nuxt>` é o componente que você usa para exibir seus componentes de página. Basicamente, este componente é substituído pelo que está dentro dos componentes de página dependendo da página que está sendo exibida. Daí, é importante que você adicione o componente `<Nuxt>` aos seus esquemas.
 
 ```html{}[layouts/default.vue]
 <template>
@@ -30,14 +30,14 @@ The `<Nuxt>` component is the component you use to display your page components.
 ```
 
 ::alert{type="warning"}
-The `<Nuxt>` component can only be used inside [layouts](/docs/concepts/views#layouts).
+O componente `<Nuxt>` apenas pode ser usando dentro dos [esquemas](/docs/concepts/views#layouts).
 ::
 
-The `<Nuxt>` component can take the prop of `nuxt-child-key`. This prop will be passed to `<RouterView>` so that your transitions will work correctly inside dynamic pages.
+O componente `<Nuxt>` pode carregar a propriedade `nuxt-child-key`. Esta propriedade será passada para `<RouterView>`, assim suas transições funcionarão corretamente dentro das páginas dinâmicas.
 
-There are 2 ways to handle the internal `key` prop of `<RouterView>`.
+Há 2 maneiras de manipular a propriedade interna `key` de `<RouterView>`.
 
-1. Use a `nuxtChildKey` prop on your `<Nuxt>` component
+1. Use uma propriedade `nuxtChildKey` no seu componente `<Nuxt>`
 
 ```html{}[layouts/default.vue]
 <template>
@@ -47,7 +47,7 @@ There are 2 ways to handle the internal `key` prop of `<RouterView>`.
 </template>
 ```
 
-2. Add the `key` option in _page_ components as `string` or `function`
+2. Adicione a opção `key` como `string` ou `função` dentro dos componentes de _página_ 
 
 ```js
 export default {
@@ -57,9 +57,9 @@ export default {
 }
 ```
 
-## The NuxtChild Component
+## O Componente NuxtChild
 
-This component is used for displaying the children components in a nested route.
+Este componente é usado para exibição dos componentes filhos dentro de uma rota aninhada.
 
 Example:
 
@@ -70,7 +70,7 @@ Example:
 ---| parent.vue
 ```
 
-This file tree will generate these routes:
+Esta árvore de ficheiro gerará estas rotas:
 
 ```js
 ;[
@@ -89,7 +89,7 @@ This file tree will generate these routes:
 ]
 ```
 
-To display the `child.vue` component, you have to insert the `<NuxtChild>` component inside `pages/parent.vue`:
+Para exibir o componente `child.vue` , você tem de inserir o componente `<NuxtChild>`  dentro de `pages/parent.vue`:
 
 ```html{}[pages/parent.vue]
 <template>
@@ -102,10 +102,10 @@ To display the `child.vue` component, you have to insert the `<NuxtChild>` co
 
 ## keep-alive
 
-Both, the `<Nuxt>` component and the `<NuxtChild/>` component, accept `keep-alive` and `keep-alive-props.`
+Ambos, o componente `<Nuxt>` e o componente `<NuxtChild/>` , aceitam `keep-alive` e `keep-alive-props`.
 
 ::alert{type="info"}
-To learn more about keep-alive and keep-alive-props see the [vue docs](https://vuejs.org/v2/api/#keep-alive)
+Para aprender mais sobre o keep-alive e keep-alive-props consulte a [documentação do vue](https://vuejs.org/v2/api/#keep-alive)
 ::
 
 ```html{}[layouts/default.vue]
@@ -115,7 +115,7 @@ To learn more about keep-alive and keep-alive-props see the [vue docs](https://v
   </div>
 </template>
 
-<!-- will be converted into something like this -->
+<!-- será convertido em alguma coisa parecida com isto -->
 <div>
   <KeepAlive :exclude="['modal']">
     <RouterView />
@@ -130,7 +130,7 @@ To learn more about keep-alive and keep-alive-props see the [vue docs](https://v
   </div>
 </template>
 
-<!-- will be converted into something like this -->
+<!-- será convertido em alguma coisa parecida com isto -->
 <div>
   <KeepAlive :exclude="['modal']">
     <RouterView />
@@ -138,7 +138,7 @@ To learn more about keep-alive and keep-alive-props see the [vue docs](https://v
 </div>
 ```
 
-`<NuxtChild>` components can also receive properties like a regular Vue component.
+Os componentes `<NuxtChild>` pode também receber propriedades como um componente normal do Vue.
 
 ```html
 <template>
@@ -148,15 +148,15 @@ To learn more about keep-alive and keep-alive-props see the [vue docs](https://v
 </template>
 ```
 
-To see an example, take a look at the [nested-routes example](https://nuxtjs.org/examples/nested-routes).
+Pare ver um exemplo, dê uma vista de olhos ao [exemplo de rotas-aninhadas](https://nuxtjs.org/examples/nested-routes).
 
 :code-sandbox{src="csb_link_nuxt"}
 
-## The NuxtLink Component
+## O Componente NuxtLink
 
-To navigate between pages of your app, you should use the  `<NuxtLink>` component. This component is included with Nuxt and therefore you don't have to import it like you do with other components. It is similar to the HTML `<a>` tag except that instead of using a `href="/about"` you use `to="/about"`. If you've used `vue-router` before, you can think of `<NuxtLink>` as a replacement of `<RouterLink>`
+Para navegar entre as páginas da sua aplicação, você deve usar o componente `<NuxtLink>` . Este componente está incluído com Nuxt e assim você não tem de importar ele como você faz com outros componentes. É similar a tag `<a>` do HTML exceto que ao invés de usar o `href="/about"` você usa `to="/about"`. Se você já usou o `vue-router` antes, você pode pensar do `<NuxtLink>` como uma substituição do  `<RouterLink>`.
 
-A simple link to the `index.vue` page in your `pages` folder:
+Uma simples ligação para a página `index.vue` dentro da sua pasta `pages`:
 
 ```html
 <template>
@@ -164,7 +164,7 @@ A simple link to the `index.vue` page in your `pages` folder:
 </template>
 ```
 
-The `<NuxtLink>` component should be used for all internal links. That means for all links to the pages within your site you should use `<NuxtLink>`. The `<a>` tag should be used for all external links. That means if you have links to other websites you should use the `<a>` tag for those.
+O componente `<NuxtLink>` deve ser usado para todas ligações internas. Isso significa que todas as ligações para as páginas dentro do seu site você deve usar o `<NuxtLink>`. A tag `<a>` deve ser usada para todas ligações externas. Isso significa que se você tiver ligações para outros websites você deve usar a tag `<a>` para esses.
 
 ```html
 <template>
@@ -179,31 +179,31 @@ The `<NuxtLink>` component should be used for all internal links. That means for
 ```
 
 ::alert{type="info"}
-If you want to know more about `<RouterLink>`, feel free to read the [Vue Router documentation](https://router.vuejs.org/api/#router-link) for more information.
+Se você quiser saber mais sobre `<RouterLink>`, sinta-se livre para ler a [documentação do Vue Router](https://router.vuejs.org/api/#router-link) para obter mais informações.
 ::
 
 ::alert{type="info"}
 
-`<NuxtLink>` also comes with [smart prefetching](/docs/features/nuxt-components#the-nuxtlink-component) out of the box.
+O `<NuxtLink>` também vem com a [pré-requisição inteligente](/docs/features/nuxt-components#the-nuxtlink-component) fora da caixa.
 
 ::
 
-## prefetchLinks
+## Pré-requisitar Ligações
 
-Nuxt automatically includes smart prefetching. That means it detects when a link is visible, either in the viewport or when scrolling and prefetches the JavaScript for those pages so that they are ready when the user clicks the link. Nuxt only loads the resources when the browser isn't busy and skips prefetching if your connection is offline or if you only have 2g connection.
+O Nuxt automaticamente incluí pré-requisição inteligente. Isso significa que ele deteta quando uma ligação está visível, seja dentro da viewport ou quando estiver rolando na tela e pré-requisita o JavaScript para aquelas páginas assim que eles estiverem prontas quando o usuário clicar na ligação. O Nuxt apenas carrega os recursos quando o browser não estiver ocupado e pula a pré-requisição se a sua conexão estiver offline ou se você apenas tiver uma conexão 2G.
 
-### Disable prefetching for specific links
+### Desativa a Pré-requisição para Ligações Específicas
 
-However sometimes you may want to disable prefetching on some links if your page has a lot of JavaScript or you have a lot of different pages that would be prefetched or you have a lot of third party scripts that need to be loaded. To disable the prefetching on a specific link, you can use the `no-prefetch` prop. Since Nuxt v2.10.0, you can also use the `prefetch` prop set to `false`
+No entanto algumas vezes você pode querer desativar a pré-requisição em algumas ligações se sua página tiver muito JavaScript ou você tiver muitas páginas diferentes que seriam pré-requisitadas ou você tiver muitos scripts de terceiros que precisam ser carregados. Para desativar a pré-requisição em uma ligação específica, você pode usar a propriedade `no-prefetch` . Desde o Nuxt v2.10.0, você também pode usar a propriedade `prefetch` definida para `false`.
 
 ```html
 <NuxtLink to="/about" no-prefetch>About page not pre-fetched</NuxtLink>
 <NuxtLink to="/about" :prefetch="false">About page not pre-fetched</NuxtLink>
 ```
 
-### Disable prefetching globally
+### Desativar a Pré-requisição Globalmente
 
-To disable the prefetching on all links, set the `prefetchLinks` to `false`:
+Para desativar a pré-requisição em todas ligações, defina o `prefetchLinks` para `false`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -213,15 +213,15 @@ export default {
 }
 ```
 
-Since Nuxt v2.10.0, if you have set `prefetchLinks` to `false` but you want to prefetch a specific link, you can use the `prefetch` prop:
+Desde o Nuxt v2.10.0, se você tiver definido `prefetchLinks` para `false` mas você quiser pré-requisitar uma ligação específica, você pode usar a propriedade `prefetch` :
 
 ```html
 <NuxtLink to="/about" prefetch>About page pre-fetched</NuxtLink>
 ```
 
-## linkActiveClass
+## linkActiveClass (classe da ligação ativa)
 
-The `linkActiveClass` works the same as the `vue-router` class for active links. If we want to show which links are active all you have to do is create some css for the class `nuxt-link-active` .
+A `linkActiveClass` funciona da mesma forma que a classe do `vue-router` para ligações ativas. Se quisermos mostrar quais ligações são ativada, tudo que você tem de fazer é criar algum CSS para a classe `nuxt-link-active`.
 
 ```css
 .nuxt-link-active {
@@ -230,10 +230,10 @@ The `linkActiveClass` works the same as the `vue-router` class for active links.
 ```
 
 ::alert
-This css can be added to the navigation component or for a specific page or layout or in your main.css file.
+O CSS pode ser adicionado ao componente de navegação ou para uma página específica ou esquema ou dentro de seu ficheiro main.css.
 ::
 
-If you want to you can also configure the class name to be something else. You can do this by modifying the `linkActiveClass` in the router property in your `nuxt.config.js` file.
+Se você quiser, você pode também configurar o nome da classe para alguma coisa que você queira. Você pode fazer isso ao modificar a propriedade `linkActiveClass` dentro da propriedade router dentro do seu ficheiro `nuxt.config.js`.
 
 ```js
 export default {
@@ -244,12 +244,12 @@ export default {
 ```
 
 ::alert{type="info"}
-This option is given directly to the `vue-router` linkActiveClass. See the [vue-router docs](https://router.vuejs.org/api/#active-class) for more info.
+Esta opção é dada diretamente ao linkActiveClass do `vue-router`. Veja a [documentação do vue-router](https://router.vuejs.org/api/#active-class) para obter mais informações.
 ::
 
-## linkExactActiveClass
+## linkExactActiveClass (classe da ligação exata ativa)
 
-The `linkExactActiveClass` works the same as the `vue-router` class for exact active links. If we want to show which links are active with an exact match all you have to do is create some css for the class `nuxt-link-exact-active` .
+O `linkExactActiveClass` funciona da mesma forma que a classe do `vue-router` para ligações exatas ativas. Se quisermos mostrar quais ligações são ativas com um correspondente exato, todo que você tem de fazer é criar algum CSS para a classe `nuxt-link-exact-active`.
 
 ```css
 .nuxt-link-exact-active {
@@ -258,10 +258,10 @@ The `linkExactActiveClass` works the same as the `vue-router` class for exact ac
 ```
 
 ::alert{type="info"}
-This css can be added to the navigation component or for a specific page or layout or in your main.css file.
+O CSS pode ser adicionado ao componente de navegação ou para uma página específica ou esquema ou dentro de seu ficheiro main.css.
 ::
 
-If you want to you can also configure the class name to be something else. You con do this by modifying the `linkExactActiveClass` in the router property in your `nuxt.config.js` file.
+Se você quiser, você pode também configurar o nome da classe para alguma coisa que você queira. Você pode fazer isso ao modificar a propriedade `linkExactActiveClass` dentro da propriedade router dentro do seu ficheiro `nuxt.config.js`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -272,12 +272,12 @@ export default {
 ```
 
 ::alert{type="info"}
-This option is given directly to the `vue-router` linkExactActiveClass. See the [vue-router](https://router.vuejs.org/api/#active-class) [docs](https://router.vuejs.org/api/#exact-active-class) for more info
+Esta opção é dada diretamente ao linkExactActiveClass do `vue-router`. Veja a [documentação do vue-router](https://router.vuejs.org/api/#active-class) para obter mais informações.
 ::
 
-## linkPrefetchedClass
+## linkPrefetchedClass (classe da ligação pré-requisitada)
 
-The linkPrefetchedClass will allow you to add styles for all links that have been prefetched. This is great for testing which links are being prefetched after modifying the default behavior. The linkPrefetchedClass is disabled by default. If you want to enable it you need to add it to the router property in your `nuxt-config.js` file.
+O linkPrefetchedClass permitirá você adicionar estilos para todas ligações que têm de ser pré-requisitados. Isto é genial para testar quais ligações estão sendo pré-requisitadas depois de modificar o comportamento padrão. O linkPrefetchedClass está desativado por padrão. Se você quiser ativar ele você precisa adicionar ele à propriedade router dentro do seu ficheiro `nuxt.config.js`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -287,7 +287,7 @@ export default {
 }
 ```
 
-Then you can add the styles for that class.
+Depois você pode adicionar estilos para aquela classe.
 
 ```css
 .nuxt-link-prefetched {
@@ -296,38 +296,38 @@ Then you can add the styles for that class.
 ```
 
 ::alert{type="info"}
-In this example we have used the class `nuxt-link-prefetched` but you can name it anything you like
+Neste exemplo temos usado a classe `nuxt-link-prefetched` mas você pode nomear ele para o você achar melhor.
 ::
 
 :code-sandbox{src="csb_link_nuxt_link"}
 
-## The client-only Component
+## O Componente client-only
 
-This component is used to purposely render a component only on client-side. To import a component only on the client, register the component in a client-side only plugin.
+Este componente é usado para propositadamente renderizar um componente somente no lado do cliente. Para importar um componente somente no cliente, registe o componente dentro de um plugin somente no lado do cliente.
 
 ```html{}[pages/example.vue]
 <template>
   <div>
     <sidebar />
     <client-only placeholder="Loading...">
-      <!-- this component will only be rendered on client-side -->
+      <!-- este componente somente será renderizado no lado do cliente -->
       <comments />
     </client-only>
   </div>
 </template>
 ```
 
-Use a slot as placeholder until `<client-only />` is mounted on client-side.
+Use um slot como um placeholder até `<client-only />` ser montado no lado do cliente.
 
 ```html{}[pages/example.vue]
 <template>
   <div>
     <sidebar />
     <client-only>
-      <!-- this component will only be rendered on client-side -->
+      <!-- este componente somente será renderizado no lado do cliente -->
       <comments />
 
-      <!-- loading indicator, rendered on server-side -->
+      <!-- indicador de carregamento, renderizado no lado do servidor -->
       <template #placeholder>
         <comments-placeholder />        
       </template>
@@ -337,7 +337,7 @@ Use a slot as placeholder until `<client-only />` is mounted on client-side.
 ```
 
 ::alert{type="info"}
-Sometimes in server rendered pages `$refs` inside `<client-only>` might not be ready even with `$nextTick`, the trick might be to call `$nextTick` a couple of times:
+Algumas vezes dentro das páginas renderizadas no servidor `$refs` dentro `<client-only>` pode não estar pronto mesmo com `$nextTick`, o truque pode ser chamar o `$nextTick` umas poucas vezes:
 
 ```js{}[page.vue]
 mounted(){
@@ -359,5 +359,5 @@ methods: {
 ::
 
 ::alert
-If you are using a version of Nuxt < v2.9.0, use `<no-ssr>` instead of `<client-only>`
+Se você estiver usando a versão do Nuxt inferior a v2.9.0, use o `<no-ssr>` ao invés de `<client-only>` 
 ::

--- a/content/pt/docs/3.features/9.component-discovery.md
+++ b/content/pt/docs/3.features/9.component-discovery.md
@@ -1,14 +1,14 @@
 ---
-title: Component Discovery
-description: By default, Nuxt is configured to cover most use cases. This default configuration can be overwritten with the nuxt.config.js file.
+title: Descoberta de Componente
+description: Por padrão, O Nuxt está configurado para cobrir a maior parte dos casos de uso. Esta configuração padrão pode ser sobrescrita com o ficheiro nuxt.config.js.
 category: features
 img: /docs/components.png
 imgAlt: nuxt components module
 ---
 
-## Enabling Auto-Discovery
+## Ativando a Descoberta Automática
 
-Starting from `v2.13`, Nuxt can auto import your components when used in your templates. To activate this feature, set `components: true` in your configuration:
+Desde a versão `v2.13`, o Nuxt pode importar automaticamente seus componentes sempre que usados nos seus modelos (templates):
 
 ```js{}[nuxt.config.js]
 export default {
@@ -17,12 +17,12 @@ export default {
 ```
 
 ::alert{type="info"}
-Check out [how to configure component auto-discovery](/docs/configuration-glossary/configuration-components#advanced).
+Saiba [como configurar a auto-descoberta de componente](/docs/configuration-glossary/configuration-components#advanced).
 ::
 
-## Using Components
+## Usando Componentes
 
-Once you create your components in the components directory they will then be available throughout your app without the need to import them.
+Depois de você criar os seus componentes dentro do diretório de componentes, eles estarão disponíveis em toda a sua aplicação sem a necessidade de importar eles.
 
 ```bash
 | components/
@@ -41,12 +41,12 @@ Once you create your components in the components directory they will then be av
 ```
 
 ::alert{type="info"}
-See [live demo](https://codesandbox.io/s/nuxt-components-cou9k) or [video example](https://www.youtube.com/watch?v=lQ8OBrgVVr8).
+Consulte a [demonstração ao vivo](https://codesandbox.io/s/nuxt-components-cou9k) ou [vídeo de exemplo](https://www.youtube.com/watch?v=lQ8OBrgVVr8).
 ::
 
-## Component Names
+## Nomes do Componente
 
-If you have components in nested directories such as:
+Se você tem componentes dentro de diretórios aninhados tais como:
 
 ```bash
 | components/
@@ -55,17 +55,17 @@ If you have components in nested directories such as:
 ------| Button.vue
 ```
 
-The component name will be based on its own path directory and filename. Therefore, the component will be:
+O nome do componente será baseado no seu próprio diretório e nome de ficheiro. Então, o componente será:
 
 ```html
 <BaseFooButton />
 ```
 
 ::alert
-For clarity, it is recommend that the component file name matches its name. (So, in the example above, you could rename `Button.vue` to be `BaseFooButton.vue`.)
+Por questão de clareza, é recomendado que o nome do ficheiro do componente corresponde ao seu nome. (Assim, no exemplo acima, você poderia renomear `Button.vue` para ser `BaseFooButton.vue`.)
 ::
 
-If you want to use a custom directory structure that should not be part of the component name, you can explicitly specify these directories:
+Se você quiser usar uma estrutura de diretório personalizada que não deve fazer parte do nome do componente, você pode explicitamente especificar esses diretórios:
 
 ```bash
 | components/
@@ -83,19 +83,19 @@ components: {
 }
 ```
 
-And now in your template you can use `FooButton` instead of `BaseFooButton`.
+E agora dentro do seu modelo você pode usar `FooButton` ao invés de `BaseFooButton`.
 
 ```html{}[pages/index.vue]
 <FooButton />
 ```
 
 ::alert{type="info"}
-Consider naming your components and directories following the [Vue Style Guide](https://vuejs.org/v2/style-guide/).
+Considere nomear o seu componentes e diretórios seguindo o [Guia de Estilo do Vue](https://vuejs.org/v2/style-guide/).
 ::
 
-## Dynamic Imports
+## Importação Dinâmica
 
-To dynamically import a component (also known as lazy-loading a component) all you need to do is add the `Lazy` prefix to the component name.
+Para importar dinamicamente um componente (também conhecido como carregar preguiçosamente (lazy-loading) um componente) tudo que você precisa fazer é adicionar o prefixo `Lazy` para o componente do nome.
 
 ```html{}[layouts/default.vue]
 <template>
@@ -107,7 +107,7 @@ To dynamically import a component (also known as lazy-loading a component) all y
 </template>
 ```
 
-This is particularly useful if the component is not always needed. By using the `Lazy` prefix you can delay loading the component code until the right moment, which can be helpful for optimizing your JavaScript bundle size.
+Isto é particularmente útil se o componente não é sempre necessário. Ao usar o prefixo `Lazy` você pode adiar o carregamento do código do componente até o momento correto, o que pode ser útil para otimizar o tamanho do seu pacote JavaScript.
 
 ```html{}[pages/index.vue]
 <template>

--- a/content/pt/docs/3.features/index.md
+++ b/content/pt/docs/3.features/index.md
@@ -1,4 +1,5 @@
 ---
+title: Funcionalidades
 navigation:
   collapse: true
   redirect: /docs/features/rendering-modes


### PR DESCRIPTION
In this pull request I am pushing the translated files,
that belong to section features of the documentation.

the specific folder is: `content/pt/docs/3.features`

With exceptions of `case-studies`, `articles`, `announcements`,
I already translated the whole website.

It possible that @ChristopheCVB may have other occupations,
but I would like to ask him if is it possible for him to visit this section of pull requests twice per week?
I believe we can go more quick with the updates.

@smarroufin and @ChristopheCVB it is your turn now 🙂.