### PR TITLE
docs(pt): add configuration-glossary section translated

### DIFF
--- a/content/en/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/en/docs/5.configuration-glossary/2.configuration-build.md
@@ -1,30 +1,30 @@
 ---
-title: The build Property
+title: A propriedade build
 navigation.title: build
-description: Nuxt lets you customize the webpack configuration for building your web application as you want.
+description: O Nuxt permite você personalizar a configuração do webpack para construir a sua aplicação web como você quiser.
 menu: build
 category: configuration-glossary
 ---
-# The build property
+# A propriedade build
 
-Nuxt lets you customize the webpack configuration for building your web application as you want.
+O Nuxt permite você personalizar a configuração do webpack para construir a sua aplicação web como você quiser.
 
 ---
 
-## analyze
+## A propriedade analyze
 
-> Nuxt use [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) to let you visualize your bundles and how to optimize them.
+> O Nuxt usa o [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) para permitir você visualizar seus pacotes e como otimizar eles.
 
-- Type: `Boolean` or `Object`
-- Default: `false`
+- Tipo: `Boolean` ou `Object`
+- Padrão: `false`
 
-If an object, see available properties [here](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin).
+Se for um objeto, veja as propriedades disponíveis [aqui](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin).
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     analyze: true,
-    // or
+    // ou
     analyze: {
       analyzerMode: 'static'
     }
@@ -33,23 +33,23 @@ export default {
 ```
 
 ::alert{type="info"}
-**Info:** you can use the command `yarn nuxt build --analyze` or `yarn nuxt build -a` to build your application and launch the bundle analyzer on [http://localhost:8888](http://localhost:8888). If you are not using `yarn` you can run the command with `npx`.
+**Informação:** você pode usar o comando `yarn nuxt build --analyze` ou `yarn nuxt build -a` para construir a sua aplicação e lançar o analisador de pacote sobre o [http://localhost:8888](http://localhost:8888). Se você não estiver usando `yarn` você pode executar o comando com `npx`.
 ::
 
-## corejs
+## A propriedade corejs
 
-> As of [Nuxt@2.14](https://github.com/nuxt/nuxt.js/releases/tag/v2.14.0) Nuxt automatically detects the current version of `core-js` in your project, also you can specify which version you want to use.
+> Desde o [Nuxt@2.14](https://github.com/nuxt/nuxt.js/releases/tag/v2.14.0) o Nuxt automaticamente deteta a versão atual do `core-js` dentro do seu projeto, você também pode especificar qual versão você deseja usar.
 
-- Type: `number` | `string` (Valid values are `'auto'`, `2` and `3`)
-- Default: `'auto'`
+- Tipo: `number` | `string` (os valores válidos são `'auto'`, `2` e `3`)
+- Padrão: `'auto'`
 
-## babel
+## A propriedade babel
 
-> Customize Babel configuration for JavaScript and Vue files. `.babelrc` is ignored by default.
+> Personalize a configuração do Babel para os ficheiros JavaScript e Vue. `.babelrc` é ignorado por padrão.
 
-- Type: `Object`
-- See `babel-loader` [options](https://github.com/babel/babel-loader#options) and `babel` [options](https://babeljs.io/docs/en/options)
-- Default:
+- Tipo: `Object`
+- Consulte as [opções](https://github.com/babel/babel-loader#options) do `babel-loader` e as [opções](https://babeljs.io/docs/en/options) do `babel`
+- Padrão:
 
   ```js
   {
@@ -59,37 +59,37 @@ export default {
   }
   ```
 
-The default targets of [@nuxt/babel-preset-app](https://github.com/nuxt/nuxt.js/blob/dev/packages/babel-preset-app/src/index.js) are `ie: '9'` in the `client` build, and `node: 'current'` in the `server` build.
+A alvos padrão do [@nuxt/babel-preset-app](https://github.com/nuxt/nuxt.js/blob/dev/packages/babel-preset-app/src/index.js) são: `ie: '9'` na construição do `client`, e `node: 'current'` na construção do `server`.
 
-### presets
+### O método presets
 
-- Type: `Function`
-- Argument:
+- Tipo: `Function`
+- Argumento:
   1. `Object`: { isServer: true | false }
   2. `Array`:
-     - preset name `@nuxt/babel-preset-app`
-     - [`options`](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app#options) of `@nuxt/babel-preset-app`
+     - nome prédefinido `@nuxt/babel-preset-app`
+     - [`opções`](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app#options) do `@nuxt/babel-preset-app`
 
-**Note**: The presets configured in `build.babel.presets` will be applied to both, the client and the server build. The target will be set by Nuxt accordingly (client/server). If you want configure the preset differently for the client or the server build, please use `presets` as a function:
+**Nota:**: O `presets` configurado dentro do `build.babel.presets` será aplicado a ambas, construção cliente e a do servidor. O alvo será definido pelo Nuxt de acordo com o (cliente/servidor). Se você quiser configurar o `preset` diferentemente para a construção do cliente ou do servidor, use o `presets` como uma função:
 
-> We **highly recommend** to use the default preset instead of below customization
+> Nós **recomendamos fortemente** a usar o `preset` padrão ao invés da personalização abaixo
 
 ```js
 export default {
   build: {
     babel: {
       presets({ isServer }, [ preset, options ]) {
-        // change options directly
+        // muda as opções diretamente
         options.targets = isServer ? ... :  ...
         options.corejs = ...
-        // return nothing
+        // não retorna nada
       }
     }
   }
 }
 ```
 
-Or override default value by returning whole presets list:
+Ou sobrescreva o valor padrão ao retornar a lista de `presets` inteira:
 
 ```js
 export default {
@@ -105,7 +105,7 @@ export default {
             }
           ],
           [
-            // Other presets
+            // Outras predefinições
           ]
         ]
       }
@@ -114,49 +114,49 @@ export default {
 }
 ```
 
-## cache
+## A propriedade cache
 
-- Type: `Boolean`
-- Default: `false`
+- Tipo: `Boolean`
+- Padrão: `false`
 - ⚠️ Experimental
 
-> Enable cache of [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin#options) and [cache-loader](https://github.com/webpack-contrib/cache-loader#cache-loader)
+> Ativa o cache do [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin#options) e do [cache-loader](https://github.com/webpack-contrib/cache-loader#cache-loader)
 
-## cssSourceMap
+## A propriedade cssSourceMap
 
-- Type: `boolean`
-- Default: `true` for dev and `false` for production.
+- Tipo: `boolean`
+- Padrão: `true` para o desenvolvimento e `false` para a produção.
 
-> Enables CSS Source Map support
+> Ativa o suporte ao CSS Source Map (Mapa da Fonte do CSS)
 
-## devMiddleware
+## A propriedade devMiddleware
 
-- Type: `Object`
+- Tipo: `Object`
 
-See [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) for available options.
+Consulte o [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) para conhecer as opções disponíveis.
 
-## devtools
+## A propriedade devtools
 
-- Type: `boolean`
-- Default: `false`
+- Tipo: `boolean`
+- Padrão: `false`
 
-Configure whether to allow [vue-devtools](https://github.com/vuejs/vue-devtools) inspection.
+Configura-se para permitir inspeção do [vue-devtools](https://github.com/vuejs/vue-devtools).
 
-If you already activated through nuxt.config.js or otherwise, devtools enable regardless of the flag.
+Se você já a ativou através do ficheiro `nuxt.config.js` ou de outra maneira, a ferramenta de desenvolvimento ativa apesar da bandeira.
 
-## extend
+## O método extend
 
-> Extend the webpack configuration manually for the client & server bundles.
+> Estende a configuração do webpack manualmente para os pacotes do cliente e do servidor.
 
-- Type: `Function`
+- Tipo: `Function`
 
-The extend is called twice, one time for the server bundle, and one time for the client bundle. The arguments of the method are:
+O `extend` é chamado duas vezes, uma vez para o pacote do servidor, e uma vez para o pacote do cliente. Os argumentos do método são:
 
-1. The Webpack config object,
-2. An object with the following keys (all boolean except `loaders`): `isDev`, `isClient`, `isServer`, `loaders`.
+1. O objeto de configuração do Webpack,
+2. Um objeto com as seguintes chaves (todas booleanas exceto `loaders`): `isDev`, `isClient`, `isServer`, `loaders`.
 
 ::alert{type="warning"}
-**Warning:** The `isClient` and `isServer` keys provided in are separate from the keys available in [`context`](/docs/internals-glossary/context). They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.
+**Aviso:** As chaves `isClient` e `isServer` fornecidas são separadas das chaves disponíveis dentro do [`contexto`](/docs/internals-glossary/context). Elas **não** estão depreciadas. Não use `process.client` e `process.server` aqui neste ponto quando eles forem `undefined`.
 ::
 
 ```js{}[nuxt.config.js]
@@ -172,17 +172,17 @@ export default {
 }
 ```
 
-If you want to see more about our default webpack configuration, take a look at our [webpack directory](https://github.com/nuxt/nuxt.js/tree/dev/packages/webpack/src/config).
+Se você quiser ver mais sobre nossa configuração padrão do webpack, dê uma vista de olhos no nosso [diretório do webpack](https://github.com/nuxt/nuxt.js/tree/dev/packages/webpack/src/config).
 
-### loaders in extend
+### O objeto loaders dentro do extend
 
-`loaders` has the same object structure as [build.loaders](#loaders), so you can change the options of loaders inside `extend`.
+O `loaders` tem a mesma estrutura de objeto que o [build.loaders](#a-propriedade-loaders), assim você pode mudar as opções de `loaders` dentro do `extend`.
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     extend(config, { isClient, loaders: { vue } }) {
-      // Extend only webpack config for client-bundle
+      // Estende a configuração do webpack somente para o pacote do cliente
       if (isClient) {
         vue.transformAssetUrls.video = ['src', 'poster']
       }
@@ -191,22 +191,22 @@ export default {
 }
 ```
 
-## extractCSS
+## A propriedade extractCSS
 
-> Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://ssr.vuejs.org/en/css.html).
+> Ativa a Common CSS Extraction (Extração Comum do CSS) usando as [orientações](https://ssr.vuejs.org/en/css.html) do Vue Server Renderer (Servidor Renderizador do Vue).
 
-- Type: `Boolean` or `Object`
-- Default: `false`
+- Tipo: `Boolean` ou `Object`
+- Padrão: `false`
 
-Using [`extract-css-chunks-webpack-plugin`](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/) under the hood, all your CSS will be extracted into separate files, usually one per component. This allows caching your CSS and JavaScript separately and is worth a try in case you have a lot of global or shared CSS.
+Ao usar o [`extract-css-chunks-webpack-plugin`](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/) nos bastidores, todo o seu CSS será extraido em ficheiros separados, normalmente um por componente. Isto permite o cacheamento do seu CSS e JavaScript separadamente e vale a pena tentar no caso de você ter um grande volume ou CSS partilhado.
 
-Example (`nuxt.config.js`):
+Exemplo (`nuxt.config.js`):
 
 ```js
 export default {
   build: {
     extractCSS: true,
-    // or
+    // ou
     extractCSS: {
       ignoreOrder: true
     }
@@ -215,13 +215,13 @@ export default {
 ```
 
 ::alert{type="info"}
-**Note:** There was a bug prior to Vue 2.5.18 that removed critical CSS imports when using this options.
+**Nota:** Havia um bug antes do Vue 2.5.18 que removia a importação de CSS crítico quando usada esta opção.
 ::
 
-You may want to extract all your CSS to a single file. There is a workaround for this:
+Você talvez queira extrair todo o seu CSS em ficheiro único. Existe uma maneira de dar a volta a isto:
 
 ::alert{type="warning"}
-It is not recommended to extract everything into a single file. Extracting into multiple CSS files is better for caching and preload isolation. It can also improve page performance by downloading and resolving only those resources that are needed.
+Não é recomendado extrair tudo em um ficheiro único. A extração em vários ficheiros CSS é melhor para o cacheamento e para isolação do pré-carregamento. Isto pode também melhorar o desempenho da página ao descarregar e resolver somente aqueles recursos que são necessários.
 ::
 
 ```js
@@ -244,12 +244,12 @@ export default {
 }
 ```
 
-## filenames
+## A propriedade filenames
 
-> Customize bundle filenames.
+> Personaliza os nomes de ficheiro de pacote.
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
   ```js
   {
@@ -262,7 +262,8 @@ export default {
   }
   ```
 
-This example changes fancy chunk names to numerical ids:
+Este exemplo muda pedaços agradáveis de nomes para identificadores numéricos:
+
 
 ```js{}[nuxt.config.js]
 export default {
@@ -274,37 +275,37 @@ export default {
 }
 ```
 
-To understand a bit more about the use of manifests, take a look at this [webpack documentation](https://webpack.js.org/guides/code-splitting/).
+Para entender um pouco mais sobre o uso de manifestos, dê uma vista de olhos na [documentação do webpack](https://webpack.js.org/guides/code-splitting/).
 
 ::alert{type="warning"}
-Be careful when using non-hashed based filenames in production as most browsers will cache the asset and not detect the changes on first load.
+Seja cuidadoso quando estiver usando nomes de ficheiros que não são baseados em hash em produção assim a maioria dos navegadores cachearão o recurso e não detetarão as mudanças no primeiro carregamento.
 ::
 
-## friendlyErrors
+## A propriedade friendlyErrors
 
-- Type: `Boolean`
-- Default: `true` (Overlay enabled)
+- Tipo: `Boolean`
+- Padrão: `true` (cobertura ativada)
 
-Enables or disables the overlay provided by [FriendlyErrorsWebpackPlugin](https://github.com/nuxt/friendly-errors-webpack-plugin)
+Ativa ou desativa a cobertura fornecida pelo [FriendlyErrorsWebpackPlugin](https://github.com/nuxt/friendly-errors-webpack-plugin)
 
-## hardSource
+##  A propriedade hardSource
 
-- Type: `Boolean`
-- Default: `false`
+- Tipo: `Boolean`
+- Padrão: `false`
 - ⚠️ Experimental
 
-Enables the [HardSourceWebpackPlugin](https://github.com/mzgoddard/hard-source-webpack-plugin) for improved caching
+Ativa o [HardSourceWebpackPlugin](https://github.com/mzgoddard/hard-source-webpack-plugin) para melhoramento do cache
 
-## hotMiddleware
+## A propriedade hotMiddleware
 
-- Type: `Object`
+- Tipo: `Object`
 
-See [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware) for available options.
+Consulte o [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware) para saber as opções disponíveis
 
-## html.minify
+## A propriedade html.minify
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
 ```js
 {
@@ -320,25 +321,25 @@ See [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware
 }
 ```
 
-**Attention:** If you make changes to `html.minify`, they won't be merged with the defaults!
+**Atenção:** Se você fizer mudanças ao `html.minify`, elas não serão combinadas com os padrões!
 
-Configuration for the [html-minifier](https://github.com/kangax/html-minifier) plugin used to minify HTML files created during the build process (will be applied for _all modes_).
+Configuração para o plugin [html-minifier](https://github.com/kangax/html-minifier) usada para minificar os ficheiros HTML criados durante o processo de construção (serão aplicados a _todos os modos_).
 
-## indicator
+## A propriedade indicator
 
-> Display build indicator for hot module replacement in development (available in `v2.8.0+`)
+> Mostra o indicador de construção para o substituição forte de módulo em desenvolvimento (disponível nas versões `v2.8.0+`)
 
-- Type: `Boolean`
-- Default: `true`
+- Tipo: `Boolean`
+- Padrão: `true`
 
 ![nuxt-build-indicator](https://user-images.githubusercontent.com/5158436/58500509-93ba0f80-8197-11e9-8524-e115c6d32571.gif)
 
-## loaders
+## A propriedade loaders
 
-> Customize options of Nuxt integrated webpack loaders.
+> Personaliza as opções do Nuxt integradas aos loaders (carregadores) do webpack.
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
 ```js
 {
@@ -368,44 +369,45 @@ Configuration for the [html-minifier](https://github.com/kangax/html-minifier) p
 }
 ```
 
-> Note: In addition to specifying the configurations in `nuxt.config.js`, it can also be modified by [build.extend](#extend)
+> Nota: Além de especificar a configuração dentro do ficheiro `nuxt.config.js`, ele pode também ser modificado pelo [build.extend](#extend)
 
-### loaders.file
+### A propriedade loaders.file
 
-> More details are in [file-loader options](https://github.com/webpack-contrib/file-loader#options).
+> Mais detalhes estão dentro das [opções do file-loader](https://github.com/webpack-contrib/file-loader#options).
 
-### loaders.fontUrl and loaders.imgUrl
+### As propriedades loaders.fontUrl e loaders.imgUrl
 
 > More details are in [url-loader options](https://github.com/webpack-contrib/url-loader#options).
+> Mais detalhes estão dentro das [opções do url-loader](https://github.com/webpack-contrib/url-loader#options).
 
-### loaders.pugPlain
+### A propriedade loaders.pugPlain
 
-> More details are in [pug-plain-loader](https://github.com/yyx990803/pug-plain-loader) or [Pug compiler options](https://pugjs.org/api/reference.html#options).
+> Mais detalhes estão dentro do [pug-plain-loader](https://github.com/yyx990803/pug-plain-loader) e das [opções do compilador do Pug](https://pugjs.org/api/reference.html#options).
 
-### loaders.vue
+### A propriedade loaders.vue
 
-> More details are in [vue-loader options](https://vue-loader.vuejs.org/options.html).
+> Mais detalhes estão dentro das [opões do vue-loader](https://vue-loader.vuejs.org/options.html).
 
-### loaders.css and loaders.cssModules
+### As propriedades loaders.css e loaders.cssModules
 
-> More details are in [css-loader options](https://github.com/webpack-contrib/css-loader#options). Note: cssModules is loader options for usage of [CSS Modules](https://vue-loader.vuejs.org/guide/css-modules.html#css-modules)
+> Mais detalhes estão dentro das [opções do css-loader](https://github.com/webpack-contrib/css-loader#options). O cssModules é a opção do carregador para o uso de [Módulos do CSS](https://vue-loader.vuejs.org/guide/css-modules.html#css-modules)
 
-### loaders.less
+### A propriedade loaders.less
 
-> You can pass any Less specific options to the `less-loader` via `loaders.less`. See the [Less documentation](http://lesscss.org/usage/#command-line-usage-options) for all available options in dash-case.
+> Você pode passar quaisquer opções específicas do Less para o `less-loader` via `loaders.less`. Consulte a [documentação do Less](http://lesscss.org/usage/#command-line-usage-options) para saber todas opções disponíveis dentro do dash-case
 
-### loaders.sass and loaders.scss
+### As propriedades loaders.sass e loaders.scss
 
-> See the [Sass documentation](https://github.com/sass/dart-sass#javascript-api) for all available Sass options. Note: `loaders.sass` is for [Sass Indented Syntax](http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html)
+> Consulte a [documentação do Sass](https://github.com/sass/dart-sass#javascript-api) para saber todas opções disponíveis para o Sass. Nota: O `loaders.sass` é para [Sintaxe Indentada do Sass](http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html)
 
-### loaders.vueStyle
+### A propriedade loaders.vueStyle
 
-> More details are in [vue-style-loader options](https://github.com/vuejs/vue-style-loader#options).
+> Mais detalhes estão dentro das [opções do vue-style-loader](https://github.com/vuejs/vue-style-loader#options).
 
-## optimization
+## A propriedade optimization
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
   ```js
   {
@@ -423,37 +425,37 @@ Configuration for the [html-minifier](https://github.com/kangax/html-minifier) p
   }
   ```
 
-The default value of `splitChunks.name` is `true` in `dev` or `analyze` mode.
+O valor padrão do `splitChunks.name` é `true` no modo `dev (desenvolvimento)` ou no modo `analyze (analise)`.
 
-You can set `minimizer` to a customized Array of plugins or set `minimize` to `false` to disable all minimizers. (`minimize` is being disabled for development by default)
+Você pode definir `minimizer` para um `Array` personalizado de plugins ou definir `minimize` para `false` para desativar todos minimizadores. (`minimize` está desativado para desativado para desenvolvimento por padrão)
 
-See [Webpack Optimization](https://webpack.js.org/configuration/optimization).
+Consulte a secção de [Otimização do Webpack](https://webpack.js.org/configuration/optimization).
 
-## optimizeCSS
+## A propriedade optimizeCSS
 
-- Type: `Object` or `Boolean`
-- Default:
+- Tipo: `Object` ou `Boolean`
+- Padrão:
   - `false`
-  - `{}` when extractCSS is enabled
+  - `{}` quando o extractCSS estiver ativado
 
-OptimizeCSSAssets plugin options.
+Opções do plugin OptimizeCSSAssets.
 
-See [NMFR/optimize-css-assets-webpack-plugin](https://github.com/NMFR/optimize-css-assets-webpack-plugin).
+Consulte o [NMFR/optimize-css-assets-webpack-plugin](https://github.com/NMFR/optimize-css-assets-webpack-plugin).
 
-## parallel
+## A propriedade parallel
 
-- Type: `Boolean`
-- Default: `false`
+- Tipo: `Boolean`
+- Padrão: `false`
 - ⚠️ Experimental
 
-> Enable [thread-loader](https://github.com/webpack-contrib/thread-loader#thread-loader) in webpack building
+> Ativa o [thread-loader](https://github.com/webpack-contrib/thread-loader#thread-loader) dentro da construção do webpack
 
-## plugins
+## A propriedade plugins
 
-> Add webpack plugins
+> Adiciona plugins do webpack
 
-- Type: `Array`
-- Default: `[]`
+- Tipo: `Array`
+- Padrão: `[]`
 
 ```js{}[nuxt.config.js]
 import webpack from 'webpack'
@@ -469,15 +471,15 @@ export default {
 }
 ```
 
-## postcss
+## A propriedade postcss
 
-> Customize [PostCSS Loader](https://github.com/postcss/postcss-loader#usage) plugins.
+> Personaliza os plugins do [Carregador do PostCSS](https://github.com/postcss/postcss-loader#usage) plugins.
 
-- Type: `Array` (legacy, will override defaults), `Object` (recommended), `Function` or `Boolean`
+- Tipo: `Array` (legado, sobrescreverá os padrões), `Object` (recomendado), `Function` ou `Boolean`
 
-  **Note:** Nuxt has applied [PostCSS Preset Env](https://github.com/csstools/postcss-preset-env). By default it enables [Stage 2 features](https://cssdb.org/) and [Autoprefixer](https://github.com/postcss/autoprefixer), you can use `build.postcss.preset` to configure it.
+  **Nota:** O Nuxt tem aplicado a [pré-definição de ambiente do PostCSS](https://github.com/csstools/postcss-preset-env). Por padrão ele ativa o [estágio de 2 funcionalidades](https://cssdb.org/) e o [Autoprefixer](https://github.com/postcss/autoprefixer), você pode usar o `build.postcss.preset` para configurar ele.
 
-- Default:
+- Padrão:
 
   ```js{}[nuxt.config.js]
   {
@@ -485,7 +487,7 @@ export default {
       'postcss-import': {},
       'postcss-url': {},
       'postcss-preset-env': this.preset,
-      'cssnano': { preset: 'default' } // disabled in dev mode
+      'cssnano': { preset: 'default' } // desativado no modo de desenvolvimento
     },
     order: 'presetEnvAndCssnanoLast',
     preset: {
@@ -494,16 +496,16 @@ export default {
   }
   ```
 
-Your custom plugin settings will be merged with the default plugins (unless you are using an `Array` instead of an `Object`).
+As suas definições personalizadas de plugin serão combinadas com os plugins padrão (a menos que você esteja usando um `Array` ao invés de um `Object`).
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     postcss: {
       plugins: {
-        // Disable `postcss-url`
+        // Desativa `postcss-url`
         'postcss-url': false,
-        // Add some plugins
+        // Adiciona alguns plugins
         'postcss-nested': {},
         'postcss-responsive-type': {},
         'postcss-hexrgba': {}
@@ -518,31 +520,31 @@ export default {
 }
 ```
 
-If the postcss configuration is an `Object`, `order` can be used for defining the plugin order:
+Se a configuração do PostCSS é um `Object`, o `order` pode ser usado para definição da ordem do plugin:
 
-- Type: `Array` (ordered plugin names), `String` (order preset name), `Function`
-- Default: `cssnanoLast` (put `cssnano` in last)
+- Tipo: `Array` (ordenado por nomes de plugin), `String` (ordena a pré-definição de nome), `Function`
+- Padrão: `cssnanoLast` (coloca `cssnano` em último)
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     postcss: {
-      // preset name
+      // pré-definição do nome
       order: 'cssnanoLast',
-      // ordered plugin names
+      // ordenado por nomes de plugin
       order: ['postcss-import', 'postcss-preset-env', 'cssnano']
-      // Function to calculate plugin order
+      // função para calcular a ordem do plugin
       order: (names, presets) => presets.cssnanoLast(names)
     }
   }
 }
 ```
 
-### postcss plugins & @nuxtjs/tailwindcss
+### A propriedade plugins do postcss e o módulo @nuxtjs/tailwindcss
 
-If you want to apply a postcss plugin (e.g. postcss-pxtorem) on the [@nuxtjs/tailwindcss](https://github.com/nuxt-community/tailwindcss-module) configuration, you have to change order and load tailwindcss first.
+Se você quiser aplicar um plugin de PostCSS (por exemplo, postcss-pxtorem) na configuração do módulo `@nuxtjs/tailwindcss`, você tem de mudar a ordem e carregar o `tailwindcss` primeiro.
 
-**This setup has no impact on nuxt-purgecss.**
+**Esta configuração não tem impacto sobre o `nuxt-purgecss`.**
 
 ```js{}[nuxt.config.js]
 import { join } from 'path'
@@ -562,19 +564,19 @@ export default {
 }
 ```
 
-## profile
+## A propriedade profile
 
-- Type: `Boolean`
-- Default: enabled by command line argument `--profile`
+- Tipo: `Boolean`
+- Padrão: ativado pelo argumento de linha de comando `--profile`
 
-> Enable the profiler in [WebpackBar](https://github.com/nuxt/webpackbar#profile)
+> Ativa o perfilador dentro do [WebpackBar](https://github.com/nuxt/webpackbar#profile)
 
-## publicPath
+## A propriedade publicPath
 
-> Nuxt lets you upload your dist files to your CDN for maximum performances, simply set the `publicPath` to your CDN.
+> O Nuxt deixa você carregar os seus ficheiros de distribuição para o seu CDN para o máximo desempenho, simplesmente defina o `PublicPath` para o seu CDN.
 
-- Type: `String`
-- Default: `'/_nuxt/'`
+- Tipo: `String`
+- Padrão: `'/_nuxt/'`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -584,21 +586,21 @@ export default {
 }
 ```
 
-Then, when launching `nuxt build`, upload the content of `.nuxt/dist/client` directory to your CDN and voilà!
+Depois, quando estiver executando o `nuxt build`, carrega o conteúdo do diretório `.nuxt/dist/client` para a sua CDN e voilà!.
 
-In Nuxt 2.15+, changing the value of this property at runtime will override the configuration of an app that has already been built.
+No Nuxt 2.15+, mudando o valor desta propriedade em tempo de execução sobrescreverá a configuração de uma aplicação que já tem sido construida.
 
-## quiet
+## A propriedade quiet
 
-> Suppresses most of the build output log
+> Suprime a maioria do registo de saída da construção 
 
-- Type: `Boolean`
-- Default: Enabled when a `CI` or `test` environment is detected by [std-env](https://github.com/blindmedia/std-env)
+- Tipo: `Boolean`
+- Padrão: Ativado quando uma `CI` ou ambiente de `test` é detetado pelo [std-env](https://github.com/blindmedia/std-env)
 
-## splitChunks
+## A propriedade splitChunks
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
   ```js{}[nuxt.config.js]
   export default {
@@ -612,50 +614,50 @@ In Nuxt 2.15+, changing the value of this property at runtime will override the 
   }
   ```
 
-Whether or not to create separate chunks for `layout`, `pages` and `commons` (common libs: vue|vue-loader|vue-router|vuex...). For more information, see [webpack docs](https://v4.webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks).
+Se criar ou não pedaços separados para o `layouts`, `pages` e `commons` (bibliotecas comuns: vue|vue-loader|vue-router|vuex...) Para mais informações, consulte a [documentação do webpack](https://v4.webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks).
 
-## ssr
+## A propriedade ssr
 
-> Creates special webpack bundle for SSR renderer.
+> Cria um pacote especial do webpack para o renderizador de SSR.
 
-- Type: `Boolean`
-- Default: `true` for universal mode and `false` for spa mode
+- Tipo: `Boolean`
+- Padrão: `true` para o modo universal e `false` para o modo de aplicação de página única
 
-This option is automatically set based on `mode` value if not provided.
+Esta opção é automaticamente definida com base no valor de `mode` se não for fornecida.
 
-## standalone
+## A propriedade standalone
 
-> Inline server bundle dependencies (advanced)
+> Dependências em linha do pacote do servidor (avançado)
 
-- Type: `Boolean`
-- Default: `false`
+- Tipo: `Boolean`
+- Padrão: `false`
 
-This mode bundles `node_modules` that are normally preserved as externals in the server build ([more information](https://github.com/nuxt/nuxt.js/pull/4661)).
+Este mode empacota o `node_modules` que é normalmente preservado como externo dentro da construção de servidor ([mais informações](https://github.com/nuxt/nuxt.js/pull/4661)).
 
 ::alert{type="warning"}
-Runtime dependencies (modules, `nuxt.config`, server middleware and static directory) are not bundled. This feature only disables use of [webpack-externals](https://webpack.js.org/configuration/externals/) for server-bundle.
+Dependências do tempo de execução (módulos, `nuxt.config`, intermediário do servidor e diretório estático (static)) não são empacotados. Esta funcionalidade desativa o uso do [webpack-externals](https://webpack.js.org/configuration/externals/) para o pacote de servidor (server-bundle).
 ::
 
 ::alert{type="info"}
-you can use the command `yarn nuxt build --standalone` to enable this mode on the command line. (If you are not using `yarn` you can run the command with `npx`.)
+Você pode usar o comando `yarn nuxt build --standalone` para desativar este modo na linha de comando. (Se você não está usando o `yarn` você pode executar o comando com o `npx`.)
 ::
 
-## styleResources
+## A propriedade styleResources
 
-- Type: `Object`
-- Default: `{}`
+- Tipo: `Object`
+- Padrão: `{}`
 
 ::alert{type="warning"}
-This property is deprecated. Please use the [style-resources-module](https://github.com/nuxt-community/style-resources-module/) instead for improved performance and better DX!
+Esta propriedade está depreciada. Ao invés desta use o [style-resources-module](https://github.com/nuxt-community/style-resources-module/) para melhorado desempenho e melhor experiência do desenvolvedor!
 ::
 
-This is useful when you need to inject some variables and mixins in your pages without having to import them every time.
+Isto é útil quando você precisa injetar algumas variáveis e mixins dentro das suas páginas sem ter que importar elas a todo momento.
 
-Nuxt uses https://github.com/yenshih/style-resources-loader to achieve this behavior.
+O Nuxt usa o [style-resources-loader](https://github.com/yenshih/style-resources-loader) para alcançar este comportamento.
 
-You need to specify the patterns/path you want to include for the given pre-processors: `less`, `sass`, `scss` or `stylus`
+Você precisa especificar os padrões/caminhos que você quer incluir para os dados pré-processadores: `less`, `sass`, `scss` ou `stylus`
 
-You cannot use path aliases here (`~` and `@`), you need to use relative or absolute paths.
+Você não pode usar os apelidos de caminho aqui (`~` e `@`), você precisa usar caminhos relativos e caminhos absolutos.
 
 ```js{}[nuxt.config.js]
 {
@@ -666,29 +668,29 @@ You cannot use path aliases here (`~` and `@`), you need to use relative or abso
       // sass: ...,
       // scss: ...
       options: {
-        // See https://github.com/yenshih/style-resources-loader#options
-        // Except `patterns` property
+        // Consulte o https://github.com/yenshih/style-resources-loader#options
+        // Exceto a propriedade `patterns`
       }
     }
   }
 }
 ```
 
-## templates
+## A propriedade templates
 
-> Nuxt allows you provide your own templates which will be rendered based on Nuxt configuration. This feature is specially useful for using with [modules](/docs/directory-structure/modules).
+> O Nuxt permite você fornecer os seus próprios modelos os quais serão renderizados com base na configuração do Nuxt. Esta funcionalidade é especialmente útil para uso com [módulos](/docs/directory-structure/modules).
 
-- Type: `Array`
+- Tipo: `Array`
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     templates: [
       {
-        src: '~/modules/support/plugin.js', // `src` can be absolute or relative
-        dst: 'support.js', // `dst` is relative to project `.nuxt` dir
+        src: '~/modules/support/plugin.js', // `src` pode ser absoluto ou relativo
+        dst: 'support.js', // `dst` é relativo ao diretório `.nuxt` do projeto
         options: {
-          // Options are provided to template as `options` key
+          // Opções são fornecidas ao modelo como chave `options`
           live_chat: false
         }
       }
@@ -697,12 +699,12 @@ export default {
 }
 ```
 
-Templates are rendered using [`lodash.template`](https://lodash.com/docs/#template) you can learn more about using them [here](https://github.com/learn-co-students/javascript-lodash-templates-lab-v-000).
+Os modelos são renderizados usando o [`lodash.template`](https://lodash.com/docs/#template) que você pode aprender sobre como usar eles [aqui](https://github.com/learn-co-students/javascript-lodash-templates-lab-v-000).
 
-## terser
+## A propriedade terser
 
-- Type: `Object` or `Boolean`
-- Default:
+- Tipo: `Object` or `Boolean`
+- Padrão:
 
 ```js{}[nuxt.config.js]
 {
@@ -720,20 +722,20 @@ Templates are rendered using [`lodash.template`](https://lodash.com/docs/#templa
 }
 ```
 
-Terser plugin options. Set to `false` to disable this plugin.
+Opções do plugin Terser. Defina para `false` para desativar este plugin.
 
-Enabling `sourceMap` will leave `//# sourceMappingURL` linking comment at the end of each output file if webpack `config.devtool` is set to `source-map`.
+A ativação do `sourceMap` deixará o comentário de ligação `//# sourceMappingURL` no final de cada ficheiro de saída se o webpack `config.devtool` estiver definido para `source-map`.
 
-See [webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin).
+Consulte o [webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin).
 
-## transpile
+## A propriedade transpile
 
-- Type: `Array<String | RegExp | Function>`
-- Default: `[]`
+- Tipo: `Array<String | RegExp | Function>`
+- Padrão: `[]`
 
-If you want to transpile specific dependencies with Babel, you can add them in `build.transpile`. Each item in transpile can be a package name, a string or regex object matching the dependency's file name.
+Se você quiser transpilar dependências específicas com Babel, você pode adicionar elas dentro do `build.transpile`. Cada item dentro da propriedade `transpile` pode ser um nome de pacote, uma sequência de caracteres e objeto de expressões regulares correspondem ao nome do ficheiro da dependência.
 
-Starting with `v2.9.0`, you can also use a function to conditionally transpile. The function will receive an object (`{ isDev, isServer, isClient, isModern, isLegacy }`):
+A partir da versão `2.9.0`, você pode também usar uma função para transpilar condicionalmente, a função receberá um objeto (`{ isDev, isServer, isClient, isModern, isLegacy }`):
 
 ```js{}[nuxt.config.js]
 {
@@ -743,14 +745,14 @@ Starting with `v2.9.0`, you can also use a function to conditionally transpile. 
 }
 ```
 
-In this example, `ky` will be transpiled by Babel if Nuxt is not in [modern mode](/docs/configuration-glossary/configuration-modern).
+Neste exemplo, o `ky` será transpilado pelo Babel se o Nuxt não estiver no [modo moderno](/docs/configuration-glossary/configuration-modern).
 
-## vueLoader
+## A propriedade vueLoader
 
-> Note: This config has been removed since Nuxt 2.0, please use [`build.loaders.vue`](#loaders)instead.
+> Nota: Esta configuração tem sido removida desde a versão 2.0 do Nuxt, ao invés desta use o [`build.loaders.vue`](#a-propriedade-loaders).
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
   ```js{}[nuxt.config.js]
   {
@@ -764,13 +766,13 @@ In this example, `ky` will be transpiled by Babel if Nuxt is not in [modern mode
   }
   ```
 
-> Specify the [Vue Loader Options](https://vue-loader.vuejs.org/options.html).
+> Especifica as [Opções do Carregador do Vue](https://vue-loader.vuejs.org/options.html).
 
-## watch
+## A propriedade watch
 
-> You can provide your custom files to watch and regenerate after changes. This feature is specially useful for using with [modules](/docs/directory-structure/modules).
+> Você pode fornecer os seus ficheiros personalizados para observar e regerar depois de mudanças. Esta funcionalidade é especialmente útil para ser usada com [módulos](/docs/directory-structure/modules).
 
-- Type: `Array<String>`
+- Tipo: `Array<String>`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -780,11 +782,11 @@ export default {
 }
 ```
 
-## followSymlinks
+## A propriedade followSymlinks
 
-> By default, the build process does not scan files inside symlinks. This boolean includes them, thus allowing usage of symlinks inside folders such as the "pages" folder, for example.
+> Por padrão, o processo de construção não examinar os ficheiros dentro de ligações simbólicas (symlinks). Este booleano inclui elas, permitindo assim o uso das ligações simbólicas dentro de pastas tais como a pasta "pages", por exemplo.
 
-- Type: `Boolean`
+- Tipo: `Boolean`
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/pt/docs/5.configuration-glossary/1.configuration-alias.md
+++ b/content/pt/docs/5.configuration-glossary/1.configuration-alias.md
@@ -1,13 +1,13 @@
 ---
-title: The alias Property
+title: A propriedade alias
 navigation.title: alias
-description: Nuxt allows you to use aliases to access custom directories within your JavaScript and CSS
+description: O Nuxt permite você usar apelidos para acessar diretórios personalizados dentro do seu JavaScript e do seu CSS
 menu: alias
 category: configuration-glossary
 ---
-# The alias property
+# A propriedade alias
 
-Nuxt allows you to use aliases to access custom directories within your JavaScript and CSS
+O Nuxt permite você usar apelidos para acessar diretórios personalizados dentro do seu JavaScript e do seu CSS
 
 ---
 
@@ -19,12 +19,12 @@ Nuxt allows you to use aliases to access custom directories within your JavaScri
     '@@': `<rootDir>`,
     '~': `<srcDir>`,
     '@': `<srcDir>`,
-    'assets': `<srcDir>/assets`, // (unless you have set a custom `dir.assets`)
-    'static': `<srcDir>/static`, // (unless you have set a custom `dir.static`)
+    'assets': `<srcDir>/assets`, // (a menos que você tenha definido um `dir.assets` personalizado)
+    'static': `<srcDir>/static`, // (a menos que você tenha definido um `dir.static` personalizado)
   }
   ```
 
-This option lets you define aliases to directories within your project (in addition to the ones above). These aliases can be used within your JavaScript and CSS.
+Esta opção permite você definir apelidos para os diretórios dentro do seu projeto (além daqueles acima). Estes apelidos podem ser usados dentro do seu JavaScript e do seu CSS.
 
 ```js{}[nuxt.config.js]
 import { resolve } from 'path'
@@ -60,9 +60,9 @@ body {
 ```
 
 ::alert{type="warning"}
-Within a Webpack context (image sources, CSS - but _not_ JavaScript) you must prefix your alias with `~` (as in the example above).
+Dentro de um contexto do Webpack (fontes de imagem, CSS - mas não JavaScript) você deve prefixar o apelidos com `~` (assim como no exemplo acima).
 ::
 
 ::alert{type="info"}
-If you are using TypeScript and want to use the alias you define within your TypeScript files, you will need to add the aliases to your `paths` object within `tsconfig.json`.
+Se você estiver usando o TypeScript e quiser usar os apelidos que você define dentro do seus ficheiros TypeScript, você precisará adicionar os apelidos ao seu objeto de `paths` dentro do ficheiro `tsconfig.json`.
 ::

--- a/content/pt/docs/5.configuration-glossary/10.configuration-extend-plugins.md
+++ b/content/pt/docs/5.configuration-glossary/10.configuration-extend-plugins.md
@@ -1,22 +1,22 @@
 ---
-title: The extendPlugins Property
+title: O propriedade extendPlugins
 navigation.title: extendPlugins
-description: The extendPlugins property lets you customize Nuxt plugins.
+description: A propriedade extendPlugins permite você personalizar os plugins do Nuxt.
 menu: extendPlugins
 category: configuration-glossary
 ---
-# The extendPlugins Property
+# A propriedade extendPlugins
 
-The extendPlugins property lets you customize Nuxt plugins. ([options.plugins](/docs/configuration-glossary/configuration-plugins)).
+A propriedade extendPlugins permite você personalizar os plugins do Nuxt. ([options.plugins](/docs/configuration-glossary/configuration-plugins)).
 
 ---
 
-- Type: `Function`
-- Default: `undefined`
+- Tipo: `Function`
+- Valor padrão: `undefined`
 
-You may want to extend plugins or change plugins order created by Nuxt. This function accepts an array of [plugin](/docs/configuration-glossary/configuration-plugins) objects and should return array of plugin objects.
+Você talvez queira estender os plugins ou mudar a ordem dos plugins criada pelo Nuxt. Esta função aceita um arranjo de objetos de [plugin](/docs/configuration-glossary/configuration-plugins) e deve retornar um arranjo de objetos de plugins.
 
-Example of changing plugins order:
+Exemplo de mudança de ordem dos plugins:
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/pt/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/pt/docs/5.configuration-glossary/11.configuration-generate.md
@@ -170,7 +170,7 @@ O caminho para o ficheiro HTML alternativo. Ele deve ser definido como a página
 fallback: false;
 ```
 
-Se estiver trabalhando com páginas estaticamente geradas então é recomendado usar um ficheiro `404.html` para páginas de erros e para aqueles cobertos pelo [excludes](/docs/configuration-glossary/#exclude) (os ficheiros que você não quer que sejam gerados como páginas estáticas).
+Se estiver trabalhando com páginas estaticamente geradas então é recomendado usar um ficheiro `404.html` para páginas de erros e para aqueles cobertos pelo [excludes](#a-propriedade-exclude) (os ficheiros que você não quer que sejam gerados como páginas estáticas).
 
 ```js{}[nuxt.config.js]
 fallback: true
@@ -194,7 +194,7 @@ Intervalo em milissegundos entre dois ciclos de renderização para evitar o tra
 ## A propriedade minify
 
 - **Depreciada!**
-- Use o [build.html.minify](/docs/configuration-glossary/configuration-build#htmlminify) no lugar instead
+- Use o [build.html.minify](/docs/configuration-glossary/configuration-build#a-propriedade-html.minify) no lugar instead
 
 ## A propriedade routes
 

--- a/content/pt/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/pt/docs/5.configuration-glossary/11.configuration-generate.md
@@ -29,7 +29,7 @@ export default {
 
 - Tipo: `Object` ou `false`
 
-Esta opção é usada pelo comando `nuxt generate` com o [alvo estático](/docs/features/deployment-targets#hospedagme-estática) para evitar a reconstrução quando nenhum ficheiro rastreado for mudado.
+Esta opção é usada pelo comando `nuxt generate` com o [alvo estático](/docs/features/deployment-targets#hospedagem-estática) para evitar a reconstrução quando nenhum ficheiro rastreado for mudado.
 
 Valores padrão:
 

--- a/content/pt/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/pt/docs/5.configuration-glossary/11.configuration-generate.md
@@ -1,19 +1,19 @@
 ---
-title: The generate Property
+title: A propriedade generate
 navigation.title: generate
-description: Configure the generation of your universal web application to a static web application.
+description: Configura a geração da sua aplicação web universal para uma aplicação web estática.
 menu: generate
 category: configuration-glossary
 ---
-# The generate property
+# A propriedade generate
 
-Configure the generation of your universal web application to a static web application.
+Configura a geração da sua aplicação web universal para uma aplicação web estática.
 
 ---
 
-- Type: `Object`
+- Tipo: `Object`
 
-When calling `nuxt.generate()`, Nuxt will use the configuration defined in the `generate` property.
+Quando estiver chamando o `nuxt.generate()`, o Nuxt usará a configuração definida dentro da propriedade `generate`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -23,15 +23,15 @@ export default {
 }
 ```
 
-## cache
+## A propriedade cache
 
-> Introduced in v2.14.0
+> Introduzida dentro da versão 2.14.0
 
-- Type: `Object` or `false`
+- Tipo: `Object` ou `false`
 
-This option is used by `nuxt generate` with [static target](/docs/features/deployment-targets#static-hosting) to avoid re-building when no tracked file has been changed.
+Esta opção é usada pelo comando `nuxt generate` com o [alvo estático](/docs/features/deployment-targets#hospedagme-estática) para evitar a reconstrução quando nenhum ficheiro rastreado for mudado.
 
-Defaults:
+Valores padrão:
 
 ```js
 {
@@ -47,31 +47,31 @@ Defaults:
 }
 ```
 
-If you want to avoid re-building when changing a configuration file, just add it to the list by providing the `cache.ignore` option:
+Se você quiser evitar a reconstrução quando estiver mudando um ficheiro de configuração, apenas adicione isto a lista pelo fornecimento da opção `cache.ignore`:
 
 ```js{}[nuxt.config.js]
 export default {
   generate: {
     cache: {
-      ignore: ['renovate.json'] // ignore changes applied on this file
+      ignore: ['renovate.json'] // ignorar mudanças aplicadas sobre este ficheiro
     }
   }
 }
 ```
 
-## concurrency
+## A propriedade concurrency
 
-- Type: `Number`
-- Default: `500`
+- Tipo: `Number`
+- Valor padrão: `500`
 
-The generation of routes are concurrent, `generate.concurrency` specifies the amount of routes that run in one thread.
+A geração de rotas são concorrentes, o `generate.concurrency` especifica a quantidade de rotas que executam em uma fila.
 
-## crawler
+## A propriedade crawler
 
-- Type: `boolean`
-- Default: true
+- Tipo: `boolean`
+- Valor padrão: `true`
 
-As of Nuxt >= v2.13 Nuxt comes with a crawler installed that will crawl your relative links and generate your dynamic links based on these links. If you want to disable this feature you can set the value to `false`
+Desde a versão `2.13` do Nuxt, o Nuxt vem com um rastreador instalado que rasteará usas ligações relativas e gerar suas ligações dinâmicas baseada nestas ligações. Se você quiser desativar esta funcionalidade você pode definir o valor para `false`
 
 ```js
 export default {
@@ -81,30 +81,30 @@ export default {
 }
 ```
 
-## dir
+## A propriedade dir
 
-- Type: `String`
-- Default: `'dist'`
+- Tipo: `String`
+- Valor padrão: `'dist'`
 
-Directory name created when building web applications using the `nuxt generate` command.
+O nome do diretório criado quando estiver construindo aplicações web com uso do comando `nuxt generate`.
 
-## devtools
+## A propriedade devtools
 
-- Type: `boolean`
-- Default: `false`
+- Tipo: `boolean`
+- Valor padrão: `false`
 
-Configure whether to allow [vue-devtools](https://github.com/vuejs/vue-devtools) inspection.
+Configura a permissão de inspeção para [vue-devtools](https://github.com/vuejs/vue-devtools).
 
-If you already activated through nuxt.config.js or otherwise, devtools enable regardless of the flag.
+Se você já ativou através do ficheiro `nuxt.config.js` ou outra forma, a ferramenta de desenvolvimento ativa independentemente da bandeira.
 
-## exclude
+## A propriedade exclude
 
-- Type: `Array`
-  - Items: `String` or `RegExp`
+- Tipo: `Array`
+  - Itens: `String` ou `RegExp`
 
-It accepts an array of string or regular expressions and will prevent generation of routes matching them. The routes will still be accessible when `generate.fallback` is used.
+Ela aceita um arranjo de sequência de caracteres ou expressões regulares e prevenirá a geração de rotas que correspondem a elas. As rotas continuarão a ser acessíveis quando o `generate.fallback` for usado.
 
-Taking this examples of structure:
+Considere este exemplos de estrutura:
 
 ```bash
 -| pages/
@@ -114,7 +114,7 @@ Taking this examples of structure:
 -----| index.vue
 ```
 
-By default, running `nuxt generate` a file will be created for each route.
+Por padrão, a execução do comando `nuxt generate` criará um ficheiro para cada rota.
 
 ```bash
 -| dist/
@@ -124,13 +124,13 @@ By default, running `nuxt generate` a file will be created for each route.
 -----| index.html
 ```
 
-When adding a regular expression which matches all routes with "ignore", it will prevent the generation of these routes.
+Quando estiver adicionando uma expressão regular a qual corresponde a todas rotas com o "ignore", ela prevenirá a geração dessas rotas.
 
 ```js{}[nuxt.config.js]
 export default {
   generate: {
     exclude: [
-      /^\/admin/ // path starts with /admin
+      /^\/admin/ // o caminho começa com /admin
     ]
   }
 }
@@ -141,7 +141,7 @@ export default {
 ---| index.html
 ```
 
-You can also exclude a specific route by giving a string:
+Você pode também excluir uma rota específica pela atribuição de uma sequência de caracteres:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -151,10 +151,10 @@ export default {
 }
 ```
 
-## fallback
+## A propriedade fallback
 
-- Type: `String` or `Boolean`
-- Default: `200.html`
+- Tipo: `String` ou `Boolean`
+- Valor padrão: `200.html`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -164,53 +164,53 @@ export default {
 }
 ```
 
-The path to the fallback HTML file. It should be set as the error page, so that also unknown routes are rendered via Nuxt. If unset or set to a falsy value, the name of the fallback HTML file will be `200.html`. If set to `true`, the filename will be `404.html`. If you provide a string as a value, it will be used instead.
+O caminho para o ficheiro HTML alternativo. Ele deve ser definido como a página de erro, assim também as rotas desconhecidas serão renderizadas através do Nuxt. Se for definida ou não para um valor de falsidade, o nome de um ficheiro HTML alternativo será `200.html`. Se for definido para `true`, o nome de ficheiro será `404.html`. Se você fornecer uma sequência de caracteres como um valor, ela será usada no lugar.
 
 ```{}[nuxt.config.js]
 fallback: false;
 ```
 
-If working with statically generated pages then it is recommended to use a `404.html` for error pages and for those covered by [excludes](/docs/configuration-glossary/#exclude) (the files that you do not want generated as static pages).
+Se estiver trabalhando com páginas estaticamente geradas então é recomendado usar um ficheiro `404.html` para páginas de erros e para aqueles cobertos pelo [excludes](/docs/configuration-glossary/#exclude) (os ficheiros que você não quer que sejam gerados como páginas estáticas).
 
 ```js{}[nuxt.config.js]
 fallback: true
 ```
 
-However, Nuxt allows you to configure any page you like so if you don't want to use the `200.html` or `404.html` you can add a string and then you just have to make sure you redirect to that page instead. This is of course not necessary and is best to redirect to `200.html`/`404.html`.
+Contudo, o Nuxt permite você configurar qualquer página que você quiser, assim se você não quiser usar o ficheiro `200.html` ou `404.html`, você pode adicionar uma sequência de caracteres e depois você apenas tem de certificar-se de redirecionar para aquela página no lugar.
 
 ```js{}[nuxt.config.js]
 fallback: 'fallbackPage.html'
 ```
 
-_Note: Multiple services (e.g. Netlify) detect a `404.html` automatically. If you configure your web server on your own, please consult its documentation to find out how to set up an error page (and set it to the `404.html` file)_
+_Nota: Vários serviços (por exemplo, Netlify) detetam um `404.html` automaticamente. Se você configura o seu servidor web por conta própria, consulte a sua documentação para saber como definir uma página de erro (e defina ela para o ficheiro `404.html`)_
 
-## interval
+## A propriedade interval
 
-- Type: `Number`
-- Default: `0`
+- Tipo: `Number`
+- Valor padrão: `0`
 
-Interval in milliseconds between two render cycles to avoid flooding a potential API with calls from the web application.
+Intervalo em milissegundos entre dois ciclos de renderização para evitar o transbordar de uma API em potencial com chamadas da aplicação web.
 
-## minify
+## A propriedade minify
 
-- **Deprecated!**
-- Use [build.html.minify](/docs/configuration-glossary/configuration-build#htmlminify) instead
+- **Depreciada!**
+- Use o [build.html.minify](/docs/configuration-glossary/configuration-build#htmlminify) no lugar instead
 
-## routes
+## A propriedade routes
 
-- Type: `Array`
+- Tipo: `Array`
 
 ::alert{type="info"}
-As of Nuxt v2.13 there is a crawler installed that will crawl your link tags and generate your routes when running `nuxt generate`.
+Desde a versão `2.13` do Nuxt, existe um rastreador instalado que rastreia suas tags de ligação e gerar suas rotas quando estiver executando o comando `nuxt generate`.
 
-If have unlinked pages (such as secret pages) and you would like these to also be generated then you can use the `generate.routes` property.
+Se tiver páginas desligadas (tais como páginas secretas) e você gostaria que também essas fossem geradas então você pode usar a propriedade `generate.routes`.
 ::
 
 ::alert{type="warning"}
-Dynamic routes are ignored by the `generate` command when using `Nuxt <= v2.12`
+As rotas dinâmicas são ignoradas pelo comando `generate` quando estiver usando uma versão do Nuxt menor ou igual a `2.12`
 ::
 
-Example:
+Exemplo:
 
 ```bash
 -| pages/
@@ -219,11 +219,11 @@ Example:
 -----| _id.vue
 ```
 
-Only the route `/` will be generated by Nuxt.
+Apenas a rota `/` será gerada pelo Nuxt.
 
-If you want Nuxt to generate routes with dynamic params, you need to set the `generate.routes` property to an array of dynamic routes.
+Se você quiser que o Nuxt gere rotas com parâmetros dinâmico, você precisa definir a propriedade `generate.routes` para um arranjo de rotas dinâmicas.
 
-We add routes for `/users/:id`:
+Nós adicionamos rotas para o `/users/:id`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -233,7 +233,7 @@ export default {
 }
 ```
 
-Then when we launch `nuxt generate`:
+Então quando nós executamos o comando `nuxt generate`:
 
 ```bash
 [nuxt] Generating...
@@ -250,12 +250,12 @@ nuxt:generate HTML Files generated in 7.6s +6ms
 [nuxt] Generate done
 ```
 
-Great, but what if we have **dynamic params**?
+Genial, mas como se nós temos **parâmetros dinâmicos**?
 
-1. Use a `Function` which returns a `Promise`.
-2. Use a `Function` with a `callback(err, params)`.
+1. Usa uma `Function` que retorna uma `Promise`.
+2. Usa uma `Function` com um `callback(err, params)`.
 
-### Function which returns a Promise
+### Função que retorna uma Promessa
 
 ```js{}[nuxt.config.js]
 import axios from 'axios'
@@ -273,7 +273,7 @@ export default {
 }
 ```
 
-### Function with a callback
+### Função com um callback
 
 ```js{}[nuxt.config.js]
 import axios from 'axios'
@@ -295,9 +295,9 @@ export default {
 }
 ```
 
-### Speeding up dynamic route generation with `payload`
+### Acelerando a geração de rota dinâmica com `payload`
 
-In the example above, we're using the `user.id` from the server to generate the routes but tossing out the rest of the data. Typically, we need to fetch it again from inside the `/users/_id.vue`. While we can do that, we'll probably need to set the `generate.interval` to something like `100` in order not to flood the server with calls. Because this will increase the run time of the generate script, it would be preferable to pass along the entire `user` object to the context in `_id.vue`. We do that by modifying the code above to this:
+No exemplo acima, estamos usando o `user.id` do servidor para gerar as rotas mas descartando o resto dos dados. Normalmente, nós precisamos requisitar ele novamente a partir de dentro do `/users/_id.vue`. Enquanto nós podemos fazer isso, iremos provavelmente precisar definir a propriedade `generate.interval` para alguma coisa como `100` no sentido não sobrecarregar o servidor com chamadas. Porque isso aumenta o tempo de execução do roteiro `generate`, seria preferível passar ao longo do objeto `user` inteiro para o contexto dentro do `_id.vue`. Nós fazemos isso pela modificação do código acima disto:
 
 ```js{}[nuxt.config.js]
 import axios from 'axios'
@@ -318,7 +318,7 @@ export default {
 }
 ```
 
-Now we can access the `payload` from `/users/_id.vue` like so:
+Agora nós podemos acessar o `payload` do `/users/_id.vue` desse jeito:
 
 ```js
 async asyncData ({ params, error, payload }) {
@@ -327,14 +327,14 @@ async asyncData ({ params, error, payload }) {
 }
 ```
 
-## subFolders
+## A propriedade subFolders
 
-- Type: `Boolean`
-- Default: `true`
+- Tipo: `Boolean`
+- Valor padrão: `true`
 
-By default, when running `nuxt generate`, Nuxt will create a directory for each route & serve an `index.html` file.
+Por padrão, quando estiver executando o comando `nuxt generate`, o Nuxt criará um diretório para cada rota e servir um ficheiro `index.html`.
 
-Example:
+Exemplo:
 
 ```bash
 -| dist/
@@ -346,7 +346,7 @@ Example:
 -------| index.html
 ```
 
-When set to false, HTML files are generated according to the route path:
+Quando definida para `false`, os ficheiros HTML são gerados de acordo com o caminho da rota:
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/pt/docs/5.configuration-glossary/12.configuration-global-name.md
+++ b/content/pt/docs/5.configuration-glossary/12.configuration-global-name.md
@@ -1,18 +1,18 @@
 ---
-title: The globalName property
+title: A propriedade globalName
 navigation.title: globalName
-description: Nuxt lets you customize the global ID used in the main HTML template as well as the main Vue instance name and other options.
+description: O Nuxt permite você personalizar o identificador global usado dentro do modelo do HTML principal bem como o nome da instância principal do Vue e outras opções.
 menu: globalName
 category: configuration-glossary
 ---
-# The globalName property
+# A propriedade globalName
 
-Nuxt lets you customize the global ID used in the main HTML template as well as the main Vue instance name and other options.
+O Nuxt permite você personalizar o identificador global usado dentro do modelo do HTML principal bem como o nome da instância principal do Vue e outras opções.
 
 ---
 
-- Type: `String`
-- Default: `nuxt`
+- Tipo: `String`
+- Valor padrão: `nuxt`
 
 ```js{}[nuxt.config.js]
 {
@@ -21,12 +21,12 @@ Nuxt lets you customize the global ID used in the main HTML template as well as 
 ```
 
 ::alert{type="warning"}
-The `globalName` needs to be a valid JavaScript identifier, and changing it may break support for certain plugins that rely on Nuxt-named functions. If you're looking to just change the visible `__nuxt` HTML ID, then use the `globals` property.
+A propriedade `globalName` precisa ser um identificador JavaScript, e modificar ele pode quebrar o suporta para certos plugins que dependem das funções nomeada do Nuxt. Se você estiver procurando apenas mudar o identificador `__nuxt` visível do HTML, então use a propriedade `globals`.
 ::
 
-## The globals property
+## A propriedade globals
 
-> Customizes specific global names which are based on `globalName` by default.
+> Personaliza nomes globais específicos os quais são baseados no `globalName` por padrão.
 
 - Type: `Object`
 - Default:

--- a/content/pt/docs/5.configuration-glossary/13.configuration-head.md
+++ b/content/pt/docs/5.configuration-glossary/13.configuration-head.md
@@ -1,17 +1,17 @@
 ---
-title: The head Property
+title: A propriedade head
 navigation.title: head
-description: Nuxt let you define all default meta for your application inside nuxt.config.js, use the same head property
+description: O Nuxt permite você definir todos os atributos meta padrão para sua aplicação dentro do ficheiro nuxt.config.js, usando a mesma propriedade head 
 menu: head
 category: configuration-glossary
 ---
-# The head property
+# A propriedade head
 
-Nuxt let you define all default meta for your application inside `nuxt.config.js`, use the same `head` property
+O Nuxt permite você definir todos os atributos meta padrão para sua aplicação dentro do ficheiro `nuxt.config.js`, usando a mesma propriedade head
 
 ---
 
-- Type: `Object` or `Function`
+- Tipo: `Object` ou `Function`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -21,17 +21,17 @@ export default {
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
 
-      // hid is used as unique identifier. Do not use `vmid` for it as it will not work
+      // hid é usado como identificador único. Não use o `vmid` para isso visto que isso não funcionará
       { hid: 'description', name: 'description', content: 'Meta description' }
     ]
   }
 }
 ```
 
-To know the list of options you can give to `head`, take a look at [vue-meta documentation](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
+Para conhecer a lista de opções que você pode atribuir ao `head`, consulte a [documentação do vue-meta](https://vue-meta.nuxtjs.org/api/#metainfo-properties).
 
-You can also use `head` as a function in your components to access the component data through `this` ([read more](/docs/components-glossary/head)).
+Você pode também usar o `head` como uma função dentro de seus componentes para acessar os dados do componente através do `this` ([leia mais](/docs/components-glossary/head)).
 
 ::alert{type="info"}
-To avoid duplicated meta tags when used in child component, set up a unique identifier with the `hid` key for your meta elements ([read more](https://vue-meta.nuxtjs.org/api/#tagidkeyname)).
+Para evitar marcação meta duplicadas quando for usada dentro de um componente filho, defina um identificador único com a chave `hid` para os seus elementos meta ([leia mais](https://vue-meta.nuxtjs.org/api/#tagidkeyname)).
 ::

--- a/content/pt/docs/5.configuration-glossary/14.configuration-hooks.md
+++ b/content/pt/docs/5.configuration-glossary/14.configuration-hooks.md
@@ -1,18 +1,17 @@
 ---
-title: The hooks Property
+title: O propriedade hooks
 navigation.title: hooks
-description: Hooks are listeners to Nuxt events that are typically used in Nuxt modules, but are also available in nuxt.config.js.
+description: Gatilhos são observadores para os eventos do Nuxt que são normalmente são usados dentro dos módulos do Nuxt, porém estão disponíveis dentro do ficheiro nuxt.config.js.
 menu: hooks
 category: configuration-glossary
 ---
-# The hooks property
+# A propriedade hooks
 
-Hooks are [listeners to Nuxt events](/docs/internals-glossary/internals) that are typically used in Nuxt modules, but are also available in `nuxt.config.js`.
-menu: hooks
+Gatilhos são [observadores para os eventos do Nuxt](/docs/internals-glossary/internals) que são normalmente são usados dentro dos módulos do Nuxt, porém estão disponíveis dentro do ficheiro `nuxt.config.js`.
 
 ---
 
-- Type: `Object`
+- Tipo: `Object`
 
 
 ```js{}[nuxt.config.js]
@@ -34,29 +33,29 @@ export default {
 }
 ```
 
-Internally, hooks follow a naming pattern using colons (e.g., `build:done`). For ease of configuration, you can structure them as an hierarchical object when using `nuxt.config.js` (as exemplified above) to set your own hooks. See [Nuxt Internals](/docs/internals-glossary/internals) for more detailed information on how they work.
+Internamente, gatilhos seguem um padrão de nomeação que usa dois pontos (por exemplo, `build:done`). Para facilitação da configuração, você pode estruturar eles como um objeto hierárquico quando estiver usando um ficheiro `nuxt.config.js` (como exemplificado acima) para definir seus próprios gatilhos. Consulte o [Interior do Nuxt](/docs/internals-glossary/internals) para ter acesso a informações mais detalhadas de como eles funcionam.
 
-## List of hooks
+## Lista de Gatilhos
 
-- [Nuxt hooks](/docs/internals-glossary/internals-nuxt#hooks)
-- [Renderer hooks](/docs/internals-glossary/internals-renderer#hooks)
-- [ModulesContainer hooks](/docs/internals-glossary/internals-module-container#hooks)
-- [Builder hooks](/docs/internals-glossary/internals-builder#hooks)
-- [Generator hooks](/docs/internals-glossary/internals-generator#hooks)
+- [Gatilhos do Nuxt](/docs/internals-glossary/internals-nuxt#gatilhos)
+- [Gatilhos do Renderer](/docs/internals-glossary/internals-renderer#gatilhos)
+- [Gatilhos do ModulesContainer](/docs/internals-glossary/internals-module-container#gatilhos)
+- [Gatilhos do Builder](/docs/internals-glossary/internals-builder#gatilhos)
+- [Gatilhos do Generator](/docs/internals-glossary/internals-generator#gatilhos)
 
-## Examples
+## Exemplos
 
-### Redirect to router.base when not on root
+### Redirecionar para router.base quando não estiver na raiz
 
-Let´s say you want to serve pages as `/portal` instead of `/`.
+Vamos dizer que você quer servir páginas como `/portal` ao invés de `/`.
 
-This is maybe an edge-case, and the point of _nuxt.config.js_’ `router.base` is for when a web server will serve Nuxt elsewhere than the domain root.
+Isto pode ser um caso estremo, e a finalidade do `router.base` do _nuxt.config.js_ é para quando um servidor web servir o Nuxt em algum lugar além da raiz do domínio.
 
-But when in local development, hitting _localhost_, when router.base is not / returns a 404. In order to prevent this, you can setup a Hook.
+Mas em ambiente de desenvolvimento local, acertar o _localhost_, quando o `router.base` não é `/` retorna um `404`. No sentido de prevenir isso, você pode definir um gatilho (Hook).
 
-Maybe redirecting is not the best use-case for a production Web site, but this will help you leverage Hooks.
+Talvez o redirecionamento não seja o melhor caso de uso para sítio da web em produção, mas isso ajudará você influenciar os gatilhos.
 
-To begin, you [can change `router.base`](/docs/configuration-glossary/configuration-router#base); Update your `nuxt.config.js`:
+Para começar, você [pode mudar o `router.base`](/docs/configuration-glossary/configuration-router#base); Atualize o seu ficheiro `nuxt.config.js`:
 
 ```js{}[nuxt.config.js]
 import hooks from './hooks'
@@ -68,9 +67,9 @@ export default {
 }
 ```
 
-Then, create a few files;
+Depois, crie alguns ficheiros;
 
-1. `hooks/index.js`, Hooks module
+1. `hooks/index.js`, módulo de gatilhos
 
    ```js{}[hooks/index.js]
    import render from './render'
@@ -80,7 +79,7 @@ Then, create a few files;
    })
    ```
 
-1. `hooks/render.js`, Render hook
+1. `hooks/render.js`, gatilho render
 
    ```js{}[hooks/render.js]
    import redirectRootToPortal from './route-redirect-portal'
@@ -101,24 +100,24 @@ Then, create a few files;
    }
    ```
 
-1. `hooks/route-redirect-portal.js`, The Middleware itself
+1. `hooks/route-redirect-portal.js`, O próprio intermédiario
 
    ```js{}[hooks/route-redirect-portal.js]
    /**
-    * Nuxt middleware hook to redirect from / to /portal (or whatever we set in nuxt.config.js router.base)
+    * Intermediário de gatilho do Nuxt para redirecionar de `/` para `/portal` (ou para o que definimos no router.base do nuxt.config.js)
     *
-    * Should be the same version as connect
+    * Deve ser a mesma versão que o connect
     * {@link node_modules/connect/package.json}
     */
    import parseurl from 'parseurl'
 
    /**
-    * Connect middleware to handle redirecting to desired Web Application Context Root.
+    * Conecta o intermediário para manipular o redirecionamento para Raiz do Contexto da Aplicação Web desejada.
     *
-    * Notice that Nuxt docs lacks explaining how to use hooks.
-    * This is a sample router to help explain.
+    * Note que a documentação do Nuxt carece de explicação de como usar gatilhos.
+    * Isto é um roteador de exemplo para ajudar a explicar.
     *
-    * See nice implementation for inspiration:
+    * Consulte boas implementações para obter inspiração:
     * - https://github.com/nuxt/nuxt.js/blob/dev/examples/with-cookies/plugins/cookies.js
     * - https://github.com/yyx990803/launch-editor/blob/master/packages/launch-editor-middleware/index.js
     *
@@ -149,4 +148,4 @@ Then, create a few files;
      }
    ```
 
-Then, whenever a colleague in development accidentally hits `/` to reach the development web development service, Nuxt will automatically redirect to `/portal`
+Então, sempre que um colega em desenvolvimento acidentalmente bater em `/` para alcançar o desenvolvimento do serviço de desenvolvimento web, o Nuxt irá redirecionar automaticamente para `/portal`

--- a/content/pt/docs/5.configuration-glossary/15.configuration-ignore.md
+++ b/content/pt/docs/5.configuration-glossary/15.configuration-ignore.md
@@ -1,64 +1,64 @@
 ---
-title: The ignore Property
+title: A propriedade ignore
 navigation.title: ignore
-description: Define the ignore files for your Nuxt application
+description: Define os ficheiros a serem ignorados pela sua aplicação Nuxt
 menu: ignore
 category: configuration-glossary
 ---
-# The ignore property
+# A propriedade ignore
 
-Define the ignore files for your Nuxt application
+Define os ficheiros a serem ignorados pela sua aplicação Nuxt
 
 ---
 
-## .nuxtignore
+## O ficheiro .nuxtignore
 
-You can use a `.nuxtignore` file to let Nuxt ignore `layout`, `page`, `store` and `middleware` files in your project’s root directory (`rootDir`) during the build phase. The `.nuxtignore` file is subject to the same specification as `.gitignore` and `.eslintignore` files, in which each line is a glob pattern indicating which files should be ignored.
+Você pode usar um ficheiro `.nuxtignore` para deixar o Nuxt ignorar ficheiros de `layout (esquema)`, `page (página)`, `store (memória)` e `middleware (intermediário)` dentro do diretório raiz (`rootDir`) do seu projeto durante a fase de construção. O ficheiro `.nuxtignore` está sujeito a mesma especificação que os ficheiros `.gitignore` e o `.eslintignore`, no qual cada linha é padrão global indicando quais ficheiros devem ser ignorados.
 
-For example:
+Por exemplo:
 
 ```
-# ignore layout foo.vue
+# ignora o esquema foo.vue
 layouts/foo.vue
-# ignore layout files whose name ends with -ignore.vue
+# ignora os ficheiros de esquema os quais os nomes termina com -ignore.vue
 layouts/*-ignore.vue
 
-# ignore page bar.vue
+# ignora a página bar.vue
 pages/bar.vue
-# ignore page inside ignore folder
+# ignora a página dentro da pasta ignore
 pages/ignore/*.vue
 
-# ignore store baz.js
+# ignora a memória baz.js
 store/baz.js
-# ignore store files match *.test.*
+# ignora os ficheiros de memória que correspondem a *.test.*
 store/ignore/*.test.*
 
-# ignore middleware files under foo folder except foo/bar.js
+# ignora os ficheiros de intermediários dentro da raiz da pasta foo exceto bar.js
 middleware/foo/*.js
 !middleware/foo/bar.js
 ```
 
-> More details about the spec are in [gitignore doc](https://git-scm.com/docs/gitignore)
+> Mais detalhes sobre a especificação estão dentro da [documentação do gitignore](https://git-scm.com/docs/gitignore)
 
-## The ignorePrefix Property
+## A propriedade ignorePrefix
 
-- Type: `String`
-- Default: `'-'`
+- Tipo: `String`
+- Valor padrão: `'-'`
 
-> Any file in pages/, layouts/, middleware/ or store/ will be ignored during building if its filename starts with the prefix specified by `ignorePrefix`.
+> Qualquer ficheiro dentro de pages/, layouts/, middleware/ ou store/ será ignorado durante a construção se o seu nome de ficheiro começar com o prefixo especificado pelo `ignorePrefix`.
 
-By default all files which start with `-` will be ignored, such as `store/-foo.js` and `pages/-bar.vue`. This allows for co-locating tests, utilities, and components with their callers without themselves being converted into routes, stores, etc.
+Por padrão todos ficheiros os quais começam com o `-` serão ignorados, ficheiros taís como `store/-foo.js` e `pages/-bar.vue`. Isto permite levar em consideração a co-localização de testes, utilitários, e componentes com seus chamadores sem eles mesmo serem convertidos em rotas, memórias, etc.
 
-## The ignore Property
+## A propriedade ignore
 
-- Type: `Array`
-- Default: `['**/*.test.*']`
+- Tipo: `Array`
+- Valor padrão: `['**/*.test.*']`
 
-> More customizable than `ignorePrefix`: all files matching glob patterns specified inside `ignore` will be ignored in building.
+> Mais personalizável do que o `ignorePrefix`: todos ficheiros correspondentes ao padrão global especificado dentro do `ignore` será ignorado na construção.
 
 ## ignoreOptions
 
-`nuxtignore` is using `node-ignore` under the hood, `ignoreOptions` can be configured as `options` of `node-ignore`.
+O `nuxtignore` está usando o `node-ignore` nos bastidores, o `ignoreOptions` pode ser configurado como `options` de `node-ignore`.
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/pt/docs/5.configuration-glossary/16.configuration-loading.md
+++ b/content/pt/docs/5.configuration-glossary/16.configuration-loading.md
@@ -1,17 +1,17 @@
 ---
-title: The loading Property
+title: A propriedade loading
 navigation.title: loading
-description: Nuxt uses its own component to show a progress bar between the routes. You can customize it, disable it or create your own component.
+description: O Nuxt usa o seu próprio componente para mostrar uma barra de progresso entre as rotas. Você pode personalizar ela, desativar ela ou criar o seu próprio componente.
 menu: loading
 category: configuration-glossary
 ---
-# The loading property
+# A propriedade loading
 
-Nuxt uses its own component to show a progress bar between the routes. You can customize it, disable it or create your own component.
+O Nuxt usa o seu próprio componente para mostrar uma barra de progresso entre as rotas. Você pode personalizar ela, desativar ela ou criar o seu próprio componente.
 
 ---
 
-- Type: `Boolean` or `Object` or `String`
+- Tipo: `Boolean` ou `Object` ou `String`
 
 ```javascript
 export default {
@@ -25,9 +25,9 @@ export default {
 }
 ```
 
-## Disable the Progress Bar
+## Desativar a Barra de Progresso
 
-- Type: `Boolean`
+- Tipo: `Boolean`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -35,9 +35,9 @@ export default {
 }
 ```
 
-## Customizing the Progress Bar
+## Personalizado a Barra de Progresso
 
-- Type: `Object`
+- Tipo: `Object`
 
 ```js
 export default {
@@ -48,30 +48,31 @@ export default {
 }
 ```
 
-List of properties to customize the progress bar.
-| Key | Type | Default | Description |
-| ------------- | ------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `color` | String | `'black'` | CSS color of the progress bar |
-| `failedColor` | String | `'red'` | CSS color of the progress bar when an error appended while rendering the route (if `data` or `fetch` sent back an error for example). |
-| `height` | String | `'2px'` | Height of the progress bar (used in the `style` property of the progress bar) |
-| `throttle` | Number | `200` | In ms, wait for the specified time before displaying the progress bar. Useful for preventing the bar from flashing. |
-| `duration` | Number | `5000` | In ms, the maximum duration of the progress bar, Nuxt assumes that the route will be rendered before 5 seconds. |
-| `continuous` | Boolean | `false` | Keep animating progress bar when loading takes longer than `duration`. |
-| `css` | Boolean | `true` | Set to false to remove default progress bar styles (and add your own). |
-| `rtl` | Boolean | `false` | Set the direction of the progress bar from right to left. |
+Lista de propriedades para personalizar a barra de progresso.
 
-## Using a Custom Loading Component
+| Chave         | Tipo    | Valor Padrão | Descrição |
+| ------------- | ------- | ------------ | ----------------------------------------------------------------------------- |
+| `color`       | String  | `'black'` | A cor de css da barra de progresso |
+| `failedColor` | String  | `'red'`   | A cor de css da barra de progresso quando um erro é acrescentado enquanto estiver renderizando a rota (se por exemplo o `data` ou `fetch` enviou um erro). |
+| `height`      | String  | `'2px'`   | Altura da barra de progresso (usada dentro da propriedade `style` da barra de progresso) |
+| `throttle`    | Number  | `200`     | Em milissegundos, espera pelo tempo especificado antes da exibição da barra de progresso. Útil para prevenir a barra de cintilar. |
+| `duration`    | Number  | `5000`    | Em milissegundos, a duração máxima da barra de progresso, o Nuxt assume que a rota será renderizada antes de 5 segundos. |
+| `continuous`  | Boolean | `false`   | Mantém animando a barra de progresso quando o carregamento demorar mais do que a `duration (duração)`. |
+| `css`         | Boolean | `true`    | Defina para `false` para remover os estilos padrão da barra de progresso (e adiciona o seu próprio estilo) |
+| `rtl`         | Boolean | `false`   | Define a direção da barra de progresso, da direita para esquerda. |
 
-- Type: `String`
+## Usando um Componente de Carregamento Personalizado
 
-**Your component has to expose some of these methods:**
+- Tipo: `String`
 
-| Method          | Required   | Description                                                                              |
+**O seu componente tem que expor alguns desses métodos:**
+
+| Método          | Obrigatório  | Descrição                                                                             |
 | --------------- | ---------- | ---------------------------------------------------------------------------------------- |
-| `start()`       | Required   | Called when a route changes, this is where you display your component.                   |
-| `finish()`      | Required   | Called when a route is loaded (and data fetched), this is where you hide your component. |
-| `fail(error)`   | _Optional_ | Called when a route couldn't be loaded (failed to fetch data for example).               |
-| `increase(num)` | _Optional_ | Called during loading the route component, `num` is an Integer < 100.                    |
+| `start()`       | Obrigatório | Chamado quando uma rota muda, isto é, onde você exibe o seu componente.                  |
+| `finish()`      | Obrigatório | Chamado quando uma rota é carregada (e os dados requisitados), isto é, onde você esconde o seu componente.  |
+| `fail(error)`   | _Opcional_ | Chamado quando uma rota não pode ser carregada (falhou em requisitar os dados por exemplo).              |
+| `increase(num)` | _Opcional_ | Chamado durante o carregamento do componente de rota, `num` é um Inteiro maior do que 100.                   |
 
 ```html{}[components/loading.vue]
 <template lang="html">

--- a/content/pt/docs/5.configuration-glossary/17.configuration-loading-indicator.md
+++ b/content/pt/docs/5.configuration-glossary/17.configuration-loading-indicator.md
@@ -1,21 +1,21 @@
 ---
-title: The loading indicator Property
+title: A propriedade loadingIndicator
 navigation.title: loading indicator
-description: Show fancy loading indicator while page is loading!
+description: Mostra um indicador de carregamento elegante enquanto a página estiver carregando!
 menu: loadingIndicator
 category: configuration-glossary
 ---
-# The loading indicator Property
+# A propriedade loadingIndicator
 
-Show fancy loading indicator while page is loading!
+Mostra um indicador de carregamento elegante enquanto a página estiver carregando!
 
 ---
 
-Without Server Side Rendering (when `ssr` option is `false`), there is no content from the server side on the first page load. So, instead of showing a blank page while the page loads, we may show a spinner.
+Sem a Renderização no Lado do Servidor (quando a opção `ssr` for `false`), não há conteúdo do lado do servidor no primeiro carregamento da página. Então, ao invés de mostrar uma página em branco enquanto a página carrega, nós podemos mostrar um rodopiador.
 
-This property can have 3 different types: `string` or `false` or `object`. If a string value is provided it is converted to object style.
+Esta propriedade pode ter três diferentes tipos: que podem ser `string` ou `boolean` ou `object`. Se um valor de sequência de caracteres for fornecido ele será convertido para estilo de objeto.
 
-Default value is:
+O valor padrão é:
 
 ```js
 loadingIndicator: {
@@ -25,9 +25,9 @@ loadingIndicator: {
 }
 ```
 
-## Built-in indicators
+## Indicadores embutidos
 
-These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com/spinkit) project. You can use its demo page to preview spinners.
+Esses indicadores são importados do incrível projeto do [SpinKit](http://tobiasahlin.com/spinkit). Você pode usar sua página de demonstração para pré-visualizar os rodopiadores.
 
 - circle
 - cube-grid
@@ -41,10 +41,10 @@ These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com/
 - three-bounce
 - wandering-cubes
 
-Built-in indicators support `color` and `background` options.
+Os indicadores embutidos suportam as opções `color` e `background`.
 
-## Custom indicators
+## Indicadores personalizados
 
-If you need your own special indicator, a String value or Name key can also be a path to an HTML template of indicator source code! All of the options are passed to the template, too.
+Se você precisar do seu próprio indicador especial, um valor de sequência de caracteres ou nome de chave pode também ser um caminho para um modelo HTML do código-fonte do indicador! Todas opções são passadas para o modelo também.
 
-Nuxt's built-in [source code](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) is also available if you need a base!
+O [código-fonte](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) do componente de carregamento embutido do Nuxt está disponível se você precisar de uma base!

--- a/content/pt/docs/5.configuration-glossary/18.configuration-mode.md
+++ b/content/pt/docs/5.configuration-glossary/18.configuration-mode.md
@@ -1,32 +1,32 @@
 ---
-title: The mode Property
+title: A propriedade mode
 navigation.title: mode
-description: Change default nuxt mode
+description: Muda o modo padrão do Nuxt
 menu: mode
 category: configuration-glossary
 ---
-# The mode property
+# A propriedade mode
 
-Change default nuxt mode
+Muda o modo padrão do Nuxt
 
 ---
 
-- Type: `string`
-  - Default: `universal`
-  - Possible values:
-    - `'spa'`: No server-side rendering (only client-side navigation)
-    - `'universal'`: Isomorphic application (server-side rendering + client-side navigation)
+- Tipo: `string`
+  - Valor padrão: `universal`
+  - Valores possíveis:
+    - `'spa'`: Sem renderização no lado do servidor (apenas navegação no lado do cliente)
+    - `'universal'`: Aplicação isomórfica (renderização no lado do servidor + navegação no lado do cliente)
 
-> You can use this option to change default nuxt mode for your project using `nuxt.config.js`
+> Você pode usar esta opção para mudar o modo padrão do Nuxt para o seu projeto usando o ficheiro `nuxt.config.js`
 
 ::alert{type="warning"}
-Deprecated: please use `ssr: false` instead of `mode: spa`
+Depreciado: use o `ssr: false` no lugar de `mode: spa`
 ::
 
 ::alert{type="next"}
-To learn more about the `ssr` option, checkout the [ssr property](/docs/configuration-glossary/configuration-ssr).
+Para saber mais sobre a opção `ssr`, consulte a [propriedade ssr](/docs/configuration-glossary/configuration-ssr).
 ::
 
 ::alert{type="next"}
-To learn more about the `mode` option, checkout the [rendering modes section](/docs/features/rendering-modes).
+Para saber mais sobre a opção `mode`, consulte a [seção de modos de renderização](/docs/features/rendering-modes).
 ::

--- a/content/pt/docs/5.configuration-glossary/19.configuration-modern.md
+++ b/content/pt/docs/5.configuration-glossary/19.configuration-modern.md
@@ -1,33 +1,33 @@
 ---
-title: The modern Property
+title: A propriedade modern
 navigation.title: modern
-description: Build and serve a modern bundle
+description: Constrói e serve um pacote moderno
 menu: modern
 category: configuration-glossary
 ---
-# The modern property
+# A propriedade modern
 
-Build and serve a modern bundle
+Constrói e serve um pacote moderno
 
 ---
 
-> This feature is inspired by [vue-cli modern mode](https://cli.vuejs.org/guide/browser-compatibility.html#modern-mode)
+> Esta funcionalidade é inspirada pelo [modo moderno do vue-cli](https://cli.vuejs.org/guide/browser-compatibility.html#modern-mode)
 
-- Type: `String` or `Boolean`
-  - Default: false
-  - Possible values:
-    - `'client'`: Serve both, the modern bundle `<script type="module">` and the legacy bundle `<script nomodule>` scripts, also provide a `<link rel="modulepreload">` for the modern bundle. Every browser that understands the `module` type will load the modern bundle while older browsers fall back to the legacy (transpiled) one.
-    - `'server'` or `true`: The Node.js server will check browser version based on the user agent and serve the corresponding modern or legacy bundle.
-    - `false`: Disable modern build
+- Tipo: `String` ou `Boolean`
+  - Valor padrão: `false`
+  - Valores possíveis:
+    - `'client'`: Serve ambos pacotes de roteiros, o pacote moderno `<script type="module">` e o pacote legado `<script nomodule>`, também fornece um `<link rel="modulepreload">` para o pacote moderno. Todo navegador que o tipo `module` carregará o pacote moderno enquanto navegadores antigos recuarão para o legado (transpilado).
+    - `'server'` ou `true`: O servidor Node.js consultará a versão do navegador baseado no agente de usuário e servirá o pacote moderno ou legado correspondente.
+    - `false`: Desativa a construção moderna
 
-The two versions of bundles are:
+As duas versões de pacotes são:
 
-1. Modern bundle: targeting modern browsers that support ES modules
-1. Legacy bundle: targeting older browsers based on babel config (IE9 compatible by default).
+1. Pacote moderno: apontando navegadores modernos que suportem os módulos do EcmaScript
+2. Pacote legado: apontando navegadores antigos baseado na configuração do Babel (compatível com IE9 por padrão).
 
-**Info:**
+**Informação:**
 
-- Use command option `[--modern | -m]=[mode]` to build/start modern bundles:
+- Use a opção de comando `[--modern | -m]=[mode]` para construir/iniciar pacotes modernos:
 
 ```json{}[package.json]
 {
@@ -38,16 +38,16 @@ The two versions of bundles are:
 }
 ```
 
-**Note about _nuxt generate_:** The `modern` property also works with the `nuxt generate` command, but in this case only the `client` option is honored and will be selected automatically when launching the `nuxt generate --modern` command without providing any values.
+**Nota sobre comando _nuxt generate_:** A propriedade `modern` também funciona com o comando `nuxt generate`, mas neste caso apenas a opção `client` é honrada e será selecionada automaticamente quando executar o comando `nuxt generate --modern` sem fornecer nenhum valor.
 
-- Nuxt will automatically detect `modern` build in `nuxt start` when `modern` is not specified, auto-detected mode is:
+- O Nuxt detetará automaticamente a construção `modern` no `nuxt start` quando o `modern` não for especificado, o modo de deteção automática é:
 
-| ssr   | Modern Mode |
-| ----- | :---------: |
-| true  |   server    |
-| false |   client    |
+| ssr   | Modo Moderno |
+| ----- | :---------:  |
+| true  |   servidor   |
+| false |   cliente    |
 
-- Modern mode for `nuxt generate` can only be `client`
-- Use [`render.crossorigin`](/docs/configuration-glossary/configuration-render#crossorigin) to set `crossorigin` attribute in `<link>` and `<script>`
+- O modo moderno para o comando `nuxt generate` apenas pode ser `client`
+- Use [`render.crossorigin`](/docs/configuration-glossary/configuration-render#crossorigin) para definir o atributo `crossorigin` dentro dos marcadores `<link>` e `<script>`
 
-> Please refer [Phillip Walton's excellent post](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) for more knowledge regarding modern builds.
+> Recorra a [exelente publicação do Phillip Walton](https://philipwalton.com/articles/deploying-es2015-code-in-production-today/) para mais conhecimentos que dizem respeito as construções modernas.

--- a/content/pt/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/pt/docs/5.configuration-glossary/2.configuration-build.md
@@ -1,30 +1,30 @@
 ---
-title: The build Property
+title: A propriedade build
 navigation.title: build
-description: Nuxt lets you customize the webpack configuration for building your web application as you want.
+description: O Nuxt permite você personalizar a configuração do webpack para construir a sua aplicação web como você quiser.
 menu: build
 category: configuration-glossary
 ---
-# The build property
+# A propriedade build
 
-Nuxt lets you customize the webpack configuration for building your web application as you want.
+O Nuxt permite você personalizar a configuração do webpack para construir a sua aplicação web como você quiser.
 
 ---
 
-## analyze
+## A propriedade analyze
 
-> Nuxt use [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) to let you visualize your bundles and how to optimize them.
+> O Nuxt usa o [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) para permitir você visualizar seus pacotes e como otimizar eles.
 
-- Type: `Boolean` or `Object`
-- Default: `false`
+- Tipo: `Boolean` ou `Object`
+- Padrão: `false`
 
-If an object, see available properties [here](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin).
+Se for um objeto, veja as propriedades disponíveis [aqui](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin).
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     analyze: true,
-    // or
+    // ou
     analyze: {
       analyzerMode: 'static'
     }
@@ -33,23 +33,23 @@ export default {
 ```
 
 ::alert{type="info"}
-**Info:** you can use the command `yarn nuxt build --analyze` or `yarn nuxt build -a` to build your application and launch the bundle analyzer on [http://localhost:8888](http://localhost:8888). If you are not using `yarn` you can run the command with `npx`.
+**Informação:** você pode usar o comando `yarn nuxt build --analyze` ou `yarn nuxt build -a` para construir a sua aplicação e lançar o analisador de pacote sobre o [http://localhost:8888](http://localhost:8888). Se você não estiver usando `yarn` você pode executar o comando com `npx`.
 ::
 
-## corejs
+## A propriedade corejs
 
-> As of [Nuxt@2.14](https://github.com/nuxt/nuxt.js/releases/tag/v2.14.0) Nuxt automatically detects the current version of `core-js` in your project, also you can specify which version you want to use.
+> Desde o [Nuxt@2.14](https://github.com/nuxt/nuxt.js/releases/tag/v2.14.0) o Nuxt automaticamente deteta a versão atual do `core-js` dentro do seu projeto, você também pode especificar qual versão você deseja usar.
 
-- Type: `number` | `string` (Valid values are `'auto'`, `2` and `3`)
-- Default: `'auto'`
+- Tipo: `number` | `string` (os valores válidos são `'auto'`, `2` e `3`)
+- Padrão: `'auto'`
 
-## babel
+## A propriedade babel
 
-> Customize Babel configuration for JavaScript and Vue files. `.babelrc` is ignored by default.
+> Personalize a configuração do Babel para os ficheiros JavaScript e Vue. `.babelrc` é ignorado por padrão.
 
-- Type: `Object`
-- See `babel-loader` [options](https://github.com/babel/babel-loader#options) and `babel` [options](https://babeljs.io/docs/en/options)
-- Default:
+- Tipo: `Object`
+- Consulte as [opções](https://github.com/babel/babel-loader#options) do `babel-loader` e as [opções](https://babeljs.io/docs/en/options) do `babel`
+- Padrão:
 
   ```js
   {
@@ -59,37 +59,37 @@ export default {
   }
   ```
 
-The default targets of [@nuxt/babel-preset-app](https://github.com/nuxt/nuxt.js/blob/dev/packages/babel-preset-app/src/index.js) are `ie: '9'` in the `client` build, and `node: 'current'` in the `server` build.
+A alvos padrão do [@nuxt/babel-preset-app](https://github.com/nuxt/nuxt.js/blob/dev/packages/babel-preset-app/src/index.js) são: `ie: '9'` na construição do `client`, e `node: 'current'` na construção do `server`.
 
-### presets
+### O método presets
 
-- Type: `Function`
-- Argument:
+- Tipo: `Function`
+- Argumento:
   1. `Object`: { isServer: true | false }
   2. `Array`:
-     - preset name `@nuxt/babel-preset-app`
-     - [`options`](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app#options) of `@nuxt/babel-preset-app`
+     - nome prédefinido `@nuxt/babel-preset-app`
+     - [`opções`](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app#options) do `@nuxt/babel-preset-app`
 
-**Note**: The presets configured in `build.babel.presets` will be applied to both, the client and the server build. The target will be set by Nuxt accordingly (client/server). If you want configure the preset differently for the client or the server build, please use `presets` as a function:
+**Nota:**: O `presets` configurado dentro do `build.babel.presets` será aplicado a ambas, construção cliente e a do servidor. O alvo será definido pelo Nuxt de acordo com o (cliente/servidor). Se você quiser configurar o `preset` diferentemente para a construção do cliente ou do servidor, use o `presets` como uma função:
 
-> We **highly recommend** to use the default preset instead of below customization
+> Nós **recomendamos fortemente** a usar o `preset` padrão ao invés da personalização abaixo
 
 ```js
 export default {
   build: {
     babel: {
       presets({ isServer }, [ preset, options ]) {
-        // change options directly
+        // muda as opções diretamente
         options.targets = isServer ? ... :  ...
         options.corejs = ...
-        // return nothing
+        // não retorna nada
       }
     }
   }
 }
 ```
 
-Or override default value by returning whole presets list:
+Ou sobrescreva o valor padrão ao retornar a lista de `presets` inteira:
 
 ```js
 export default {
@@ -105,7 +105,7 @@ export default {
             }
           ],
           [
-            // Other presets
+            // Outras predefinições
           ]
         ]
       }
@@ -114,49 +114,49 @@ export default {
 }
 ```
 
-## cache
+## A propriedade cache
 
-- Type: `Boolean`
-- Default: `false`
+- Tipo: `Boolean`
+- Padrão: `false`
 - ⚠️ Experimental
 
-> Enable cache of [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin#options) and [cache-loader](https://github.com/webpack-contrib/cache-loader#cache-loader)
+> Ativa o cache do [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin#options) e do [cache-loader](https://github.com/webpack-contrib/cache-loader#cache-loader)
 
-## cssSourceMap
+## A propriedade cssSourceMap
 
-- Type: `boolean`
-- Default: `true` for dev and `false` for production.
+- Tipo: `boolean`
+- Padrão: `true` para o desenvolvimento e `false` para a produção.
 
-> Enables CSS Source Map support
+> Ativa o suporte ao CSS Source Map (Mapa da Fonte do CSS)
 
-## devMiddleware
+## A propriedade devMiddleware
 
-- Type: `Object`
+- Tipo: `Object`
 
-See [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) for available options.
+Consulte o [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) para conhecer as opções disponíveis.
 
-## devtools
+## A propriedade devtools
 
-- Type: `boolean`
-- Default: `false`
+- Tipo: `boolean`
+- Padrão: `false`
 
-Configure whether to allow [vue-devtools](https://github.com/vuejs/vue-devtools) inspection.
+Configura-se para permitir inspeção do [vue-devtools](https://github.com/vuejs/vue-devtools).
 
-If you already activated through nuxt.config.js or otherwise, devtools enable regardless of the flag.
+Se você já a ativou através do ficheiro `nuxt.config.js` ou de outra maneira, a ferramenta de desenvolvimento ativa apesar da bandeira.
 
-## extend
+## O método extend
 
-> Extend the webpack configuration manually for the client & server bundles.
+> Estende a configuração do webpack manualmente para os pacotes do cliente e do servidor.
 
-- Type: `Function`
+- Tipo: `Function`
 
-The extend is called twice, one time for the server bundle, and one time for the client bundle. The arguments of the method are:
+O `extend` é chamado duas vezes, uma vez para o pacote do servidor, e uma vez para o pacote do cliente. Os argumentos do método são:
 
-1. The Webpack config object,
-2. An object with the following keys (all boolean except `loaders`): `isDev`, `isClient`, `isServer`, `loaders`.
+1. O objeto de configuração do Webpack,
+2. Um objeto com as seguintes chaves (todas booleanas exceto `loaders`): `isDev`, `isClient`, `isServer`, `loaders`.
 
 ::alert{type="warning"}
-**Warning:** The `isClient` and `isServer` keys provided in are separate from the keys available in [`context`](/docs/internals-glossary/context). They are **not** deprecated. Do not use `process.client` and `process.server` here as they are `undefined` at this point.
+**Aviso:** As chaves `isClient` e `isServer` fornecidas são separadas das chaves disponíveis dentro do [`contexto`](/docs/internals-glossary/context). Elas **não** estão depreciadas. Não use `process.client` e `process.server` aqui neste ponto quando eles forem `undefined`.
 ::
 
 ```js{}[nuxt.config.js]
@@ -172,17 +172,17 @@ export default {
 }
 ```
 
-If you want to see more about our default webpack configuration, take a look at our [webpack directory](https://github.com/nuxt/nuxt.js/tree/dev/packages/webpack/src/config).
+Se você quiser ver mais sobre nossa configuração padrão do webpack, dê uma vista de olhos no nosso [diretório do webpack](https://github.com/nuxt/nuxt.js/tree/dev/packages/webpack/src/config).
 
-### loaders in extend
+### O objeto loaders dentro do extend
 
-`loaders` has the same object structure as [build.loaders](#loaders), so you can change the options of loaders inside `extend`.
+O `loaders` tem a mesma estrutura de objeto que o [build.loaders](#a-propriedade-loaders), assim você pode mudar as opções de `loaders` dentro do `extend`.
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     extend(config, { isClient, loaders: { vue } }) {
-      // Extend only webpack config for client-bundle
+      // Estende a configuração do webpack somente para o pacote do cliente
       if (isClient) {
         vue.transformAssetUrls.video = ['src', 'poster']
       }
@@ -191,22 +191,22 @@ export default {
 }
 ```
 
-## extractCSS
+## A propriedade extractCSS
 
-> Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://ssr.vuejs.org/en/css.html).
+> Ativa a Common CSS Extraction (Extração Comum do CSS) usando as [orientações](https://ssr.vuejs.org/en/css.html) do Vue Server Renderer (Servidor Renderizador do Vue).
 
-- Type: `Boolean` or `Object`
-- Default: `false`
+- Tipo: `Boolean` ou `Object`
+- Padrão: `false`
 
-Using [`extract-css-chunks-webpack-plugin`](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/) under the hood, all your CSS will be extracted into separate files, usually one per component. This allows caching your CSS and JavaScript separately and is worth a try in case you have a lot of global or shared CSS.
+Ao usar o [`extract-css-chunks-webpack-plugin`](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/) nos bastidores, todo o seu CSS será extraido em ficheiros separados, normalmente um por componente. Isto permite o cacheamento do seu CSS e JavaScript separadamente e vale a pena tentar no caso de você ter um grande volume ou CSS partilhado.
 
-Example (`nuxt.config.js`):
+Exemplo (`nuxt.config.js`):
 
 ```js
 export default {
   build: {
     extractCSS: true,
-    // or
+    // ou
     extractCSS: {
       ignoreOrder: true
     }
@@ -215,13 +215,13 @@ export default {
 ```
 
 ::alert{type="info"}
-**Note:** There was a bug prior to Vue 2.5.18 that removed critical CSS imports when using this options.
+**Nota:** Havia um bug antes do Vue 2.5.18 que removia a importação de CSS crítico quando usada esta opção.
 ::
 
-You may want to extract all your CSS to a single file. There is a workaround for this:
+Você talvez queira extrair todo o seu CSS em ficheiro único. Existe uma maneira de dar a volta a isto:
 
 ::alert{type="warning"}
-It is not recommended to extract everything into a single file. Extracting into multiple CSS files is better for caching and preload isolation. It can also improve page performance by downloading and resolving only those resources that are needed.
+Não é recomendado extrair tudo em um ficheiro único. A extração em vários ficheiros CSS é melhor para o cacheamento e para isolação do precarregamento. Isto pode também melhorar o desempenho da página ao descarregar e resolver somente aqueles recursos que são necessários.
 ::
 
 ```js
@@ -244,12 +244,12 @@ export default {
 }
 ```
 
-## filenames
+## A propriedade filenames
 
-> Customize bundle filenames.
+> Personaliza os nomes de ficheiro de pacote.
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
   ```js
   {
@@ -262,7 +262,8 @@ export default {
   }
   ```
 
-This example changes fancy chunk names to numerical ids:
+Este exemplo muda pedaços agradáveis de nomes para identificadores numéricos:
+
 
 ```js{}[nuxt.config.js]
 export default {
@@ -274,37 +275,37 @@ export default {
 }
 ```
 
-To understand a bit more about the use of manifests, take a look at this [webpack documentation](https://webpack.js.org/guides/code-splitting/).
+Para entender um pouco mais sobre o uso de manifestos, dê uma vista de olhos na [documentação do webpack](https://webpack.js.org/guides/code-splitting/).
 
 ::alert{type="warning"}
-Be careful when using non-hashed based filenames in production as most browsers will cache the asset and not detect the changes on first load.
+Seja cuidadoso quando estiver usando nomes de ficheiros que não são baseados em hash em produção assim a maioria dos navegadores cachearão o recurso e não detectarão as mudanças no primeiro carregamento.
 ::
 
-## friendlyErrors
+## A propriedade friendlyErrors
 
-- Type: `Boolean`
-- Default: `true` (Overlay enabled)
+- Tipo: `Boolean`
+- Padrão: `true` (cobertura ativada)
 
-Enables or disables the overlay provided by [FriendlyErrorsWebpackPlugin](https://github.com/nuxt/friendly-errors-webpack-plugin)
+Ativa ou desativa a cobertura fornecida pelo [FriendlyErrorsWebpackPlugin](https://github.com/nuxt/friendly-errors-webpack-plugin)
 
-## hardSource
+##  A propriedade hardSource
 
-- Type: `Boolean`
-- Default: `false`
+- Tipo: `Boolean`
+- Padrão: `false`
 - ⚠️ Experimental
 
-Enables the [HardSourceWebpackPlugin](https://github.com/mzgoddard/hard-source-webpack-plugin) for improved caching
+Ativa o [HardSourceWebpackPlugin](https://github.com/mzgoddard/hard-source-webpack-plugin) para melhoramento do cache
 
-## hotMiddleware
+## A propriedade hotMiddleware
 
-- Type: `Object`
+- Tipo: `Object`
 
-See [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware) for available options.
+Consulte o [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware) para saber as opções disponíveis
 
-## html.minify
+## A propriedade html.minify
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
 ```js
 {
@@ -320,25 +321,25 @@ See [webpack-hot-middleware](https://github.com/glenjamin/webpack-hot-middleware
 }
 ```
 
-**Attention:** If you make changes to `html.minify`, they won't be merged with the defaults!
+**Atenção:** Se você fizer mudanças ao `html.minify`, elas não serão combinadas com os padrões!
 
-Configuration for the [html-minifier](https://github.com/kangax/html-minifier) plugin used to minify HTML files created during the build process (will be applied for _all modes_).
+Configuração para o plugin [html-minifier](https://github.com/kangax/html-minifier) usada para minificar os ficheiros HTML criados durante o processo de construção (serão aplicados a _todos os modos_).
 
-## indicator
+## A propriedade indicator
 
-> Display build indicator for hot module replacement in development (available in `v2.8.0+`)
+> Mostra o indicador de construção para o substituição forte de módulo em desenvolvimento (disponível nas versões `v2.8.0+`)
 
-- Type: `Boolean`
-- Default: `true`
+- Tipo: `Boolean`
+- Padrão: `true`
 
 ![nuxt-build-indicator](https://user-images.githubusercontent.com/5158436/58500509-93ba0f80-8197-11e9-8524-e115c6d32571.gif)
 
-## loaders
+## A propriedade loaders
 
-> Customize options of Nuxt integrated webpack loaders.
+> Personliaza as opções do Nuxt integradas aos loaders (carregadores) do webpack.
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
 ```js
 {
@@ -368,44 +369,45 @@ Configuration for the [html-minifier](https://github.com/kangax/html-minifier) p
 }
 ```
 
-> Note: In addition to specifying the configurations in `nuxt.config.js`, it can also be modified by [build.extend](#extend)
+> Nota: Além de especificar a configuração dentro do ficherio `nuxt.config.js`, ele pode também ser modificado pelo [build.extend](#extend)
 
-### loaders.file
+### A propriedade loaders.file
 
-> More details are in [file-loader options](https://github.com/webpack-contrib/file-loader#options).
+> Mais detalhes estão dentro das [opções do file-loader](https://github.com/webpack-contrib/file-loader#options).
 
-### loaders.fontUrl and loaders.imgUrl
+### As subpropriedades loaders.fontUrl e loaders.imgUrl
 
 > More details are in [url-loader options](https://github.com/webpack-contrib/url-loader#options).
+> Mais detalhes estão dentro das [opções do url-loader](https://github.com/webpack-contrib/url-loader#options).
 
-### loaders.pugPlain
+### A propriedade loaders.pugPlain
 
-> More details are in [pug-plain-loader](https://github.com/yyx990803/pug-plain-loader) or [Pug compiler options](https://pugjs.org/api/reference.html#options).
+> Mais detalhes estão dentro do [pug-plain-loader](https://github.com/yyx990803/pug-plain-loader) e das [opções do compilador do Pug](https://pugjs.org/api/reference.html#options).
 
-### loaders.vue
+### A propriedade loaders.vue
 
-> More details are in [vue-loader options](https://vue-loader.vuejs.org/options.html).
+> Mais detalhes estão dentro das [opões do vue-loader](https://vue-loader.vuejs.org/options.html).
 
-### loaders.css and loaders.cssModules
+### As subpropriedades loaders.css e loaders.cssModules
 
-> More details are in [css-loader options](https://github.com/webpack-contrib/css-loader#options). Note: cssModules is loader options for usage of [CSS Modules](https://vue-loader.vuejs.org/guide/css-modules.html#css-modules)
+> Mais detalhes estão dentro das [opções do css-loader](https://github.com/webpack-contrib/css-loader#options). O cssModules é a opção do carregador para o uso de [Módulos do CSS](https://vue-loader.vuejs.org/guide/css-modules.html#css-modules)
 
-### loaders.less
+### A propriedade loaders.less
 
-> You can pass any Less specific options to the `less-loader` via `loaders.less`. See the [Less documentation](http://lesscss.org/usage/#command-line-usage-options) for all available options in dash-case.
+> Você pode passar quaisqueres opções específicas do Less para o `less-loader` via `loaders.less`. Consulte a [documentação do Less](http://lesscss.org/usage/#command-line-usage-options) para saber todas opções disponíves dentro do dash-case
 
-### loaders.sass and loaders.scss
+### As subpropriedades loaders.sass e loaders.scss
 
-> See the [Sass documentation](https://github.com/sass/dart-sass#javascript-api) for all available Sass options. Note: `loaders.sass` is for [Sass Indented Syntax](http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html)
+> Consulte a [documentação do Sass](https://github.com/sass/dart-sass#javascript-api) para saber todas opções disponíveis para o Sass. Nota: O `loaders.sass` é para [Sintaxe Indentada do Sass](http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html)
 
-### loaders.vueStyle
+### A propriedade loaders.vueStyle
 
-> More details are in [vue-style-loader options](https://github.com/vuejs/vue-style-loader#options).
+> Mais detalhes estão dentro das [opções do vue-style-loader](https://github.com/vuejs/vue-style-loader#options).
 
-## optimization
+## A propriedade optimization
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
   ```js
   {
@@ -423,37 +425,37 @@ Configuration for the [html-minifier](https://github.com/kangax/html-minifier) p
   }
   ```
 
-The default value of `splitChunks.name` is `true` in `dev` or `analyze` mode.
+O valor padrão do `splitChunks.name` é `true` no modo `dev (desenvolvimento)` ou no modo `analyze (analise)`.
 
-You can set `minimizer` to a customized Array of plugins or set `minimize` to `false` to disable all minimizers. (`minimize` is being disabled for development by default)
+Você pode definir `minimizer` para um `Array` personalizado de plugins ou definir `minimize` para `false` para desativar todos minimizadores. (`minimize` está desativado para desativado para desenvolvimento por padrão)
 
-See [Webpack Optimization](https://webpack.js.org/configuration/optimization).
+Consulte a seção de [Otimização do Webpack](https://webpack.js.org/configuration/optimization).
 
-## optimizeCSS
+## A propriedade optimizeCSS
 
-- Type: `Object` or `Boolean`
-- Default:
+- Tipo: `Object` ou `Boolean`
+- Padrão:
   - `false`
-  - `{}` when extractCSS is enabled
+  - `{}` quando o extractCSS estiver ativado
 
-OptimizeCSSAssets plugin options.
+Opções do plugin OptimizeCSSAssets.
 
-See [NMFR/optimize-css-assets-webpack-plugin](https://github.com/NMFR/optimize-css-assets-webpack-plugin).
+Consulte o [NMFR/optimize-css-assets-webpack-plugin](https://github.com/NMFR/optimize-css-assets-webpack-plugin).
 
-## parallel
+## A propriedade parallel
 
-- Type: `Boolean`
-- Default: `false`
+- Tipo: `Boolean`
+- Padrão: `false`
 - ⚠️ Experimental
 
-> Enable [thread-loader](https://github.com/webpack-contrib/thread-loader#thread-loader) in webpack building
+> Ativa o [thread-loader](https://github.com/webpack-contrib/thread-loader#thread-loader) dentro da construção do webpack
 
-## plugins
+## A propriedade plugins
 
-> Add webpack plugins
+> Adiciona plugins do webpack
 
-- Type: `Array`
-- Default: `[]`
+- Tipo: `Array`
+- Padrão: `[]`
 
 ```js{}[nuxt.config.js]
 import webpack from 'webpack'
@@ -469,15 +471,15 @@ export default {
 }
 ```
 
-## postcss
+## A propriedade postcss
 
-> Customize [PostCSS Loader](https://github.com/postcss/postcss-loader#usage) plugins.
+> Personaliza os plugins do [Carregador do PostCSS](https://github.com/postcss/postcss-loader#usage) plugins.
 
-- Type: `Array` (legacy, will override defaults), `Object` (recommended), `Function` or `Boolean`
+- Tipo: `Array` (legado, sobrescreverá os padrões), `Object` (recomendado), `Function` ou `Boolean`
 
-  **Note:** Nuxt has applied [PostCSS Preset Env](https://github.com/csstools/postcss-preset-env). By default it enables [Stage 2 features](https://cssdb.org/) and [Autoprefixer](https://github.com/postcss/autoprefixer), you can use `build.postcss.preset` to configure it.
+  **Nota:** O Nuxt tem aplicado a [pré-definição de ambiente do PostCSS](https://github.com/csstools/postcss-preset-env). Por padrão ele ativa o [estágio de 2 funcionalidades](https://cssdb.org/) e o [Autoprefixer](https://github.com/postcss/autoprefixer), você pode usar o `build.postcss.preset` para configurar ele.
 
-- Default:
+- Padrão:
 
   ```js{}[nuxt.config.js]
   {
@@ -485,7 +487,7 @@ export default {
       'postcss-import': {},
       'postcss-url': {},
       'postcss-preset-env': this.preset,
-      'cssnano': { preset: 'default' } // disabled in dev mode
+      'cssnano': { preset: 'default' } // desativado no modo de desenvolvimento
     },
     order: 'presetEnvAndCssnanoLast',
     preset: {
@@ -494,16 +496,16 @@ export default {
   }
   ```
 
-Your custom plugin settings will be merged with the default plugins (unless you are using an `Array` instead of an `Object`).
+As suas definições personalizadas de plugin serão combinadas com os plugins padrão (a menos que você esteja usando um `Array` ao invés de um `Object`).
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     postcss: {
       plugins: {
-        // Disable `postcss-url`
+        // Desativa `postcss-url`
         'postcss-url': false,
-        // Add some plugins
+        // Adiciona alguns plugins
         'postcss-nested': {},
         'postcss-responsive-type': {},
         'postcss-hexrgba': {}
@@ -518,31 +520,31 @@ export default {
 }
 ```
 
-If the postcss configuration is an `Object`, `order` can be used for defining the plugin order:
+Se a configuração do PostCSS é um `Object`, o `order` pode ser usado para definição da ordem do plugin:
 
-- Type: `Array` (ordered plugin names), `String` (order preset name), `Function`
-- Default: `cssnanoLast` (put `cssnano` in last)
+- Tipo: `Array` (ordenado por nomes de plugin), `String` (ordena a pré-definição de nome), `Function`
+- Padrão: `cssnanoLast` (coloca `cssnano` em último)
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     postcss: {
-      // preset name
+      // pré-definição do nome
       order: 'cssnanoLast',
-      // ordered plugin names
+      // ordenado por nomes de plugin
       order: ['postcss-import', 'postcss-preset-env', 'cssnano']
-      // Function to calculate plugin order
+      // função para calcular a ordem do plugin
       order: (names, presets) => presets.cssnanoLast(names)
     }
   }
 }
 ```
 
-### postcss plugins & @nuxtjs/tailwindcss
+### A propriedade plugins do postcss e o módulo @nuxtjs/tailwindcss
 
-If you want to apply a postcss plugin (e.g. postcss-pxtorem) on the [@nuxtjs/tailwindcss](https://github.com/nuxt-community/tailwindcss-module) configuration, you have to change order and load tailwindcss first.
+Se você quiser aplicar um plugin de PostCSS (por exemplo, postcss-pxtorem) na configuração do módulo `@nuxtjs/tailwindcss`, você tem de mudar a ordem e carregar o `tailwindcss` primeiro.
 
-**This setup has no impact on nuxt-purgecss.**
+**Esta configuração não tem impacto sobre o `nuxt-purgecss`.**
 
 ```js{}[nuxt.config.js]
 import { join } from 'path'
@@ -562,19 +564,19 @@ export default {
 }
 ```
 
-## profile
+## A propriedade profile
 
-- Type: `Boolean`
-- Default: enabled by command line argument `--profile`
+- Tipo: `Boolean`
+- Padrão: ativado pelo argumento de linha de comando `--profile`
 
-> Enable the profiler in [WebpackBar](https://github.com/nuxt/webpackbar#profile)
+> Ativa o perfilador dentro do [WebpackBar](https://github.com/nuxt/webpackbar#profile)
 
-## publicPath
+## A propriedade publicPath
 
-> Nuxt lets you upload your dist files to your CDN for maximum performances, simply set the `publicPath` to your CDN.
+> O Nuxt deixa você carregar os seus ficheiros de distribuição para o seu CDN para o máximo desempenho, simplesmente defina o `PublicPath` para o seu CDN.
 
-- Type: `String`
-- Default: `'/_nuxt/'`
+- Tipo: `String`
+- Padrão: `'/_nuxt/'`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -584,21 +586,21 @@ export default {
 }
 ```
 
-Then, when launching `nuxt build`, upload the content of `.nuxt/dist/client` directory to your CDN and voilà!
+Depois, quando estiver executando o `nuxt build`, carrega o conteúdo do diretório `.nuxt/dist/client` para a sua CDN e voilà!.
 
-In Nuxt 2.15+, changing the value of this property at runtime will override the configuration of an app that has already been built.
+No Nuxt 2.15+, mudando o valor desta propriedade em tempo de execução sobrescreverá a configuração de uma aplicação que já tem sido construida.
 
-## quiet
+## A propriedade quiet
 
-> Suppresses most of the build output log
+> Suprime a maioria do registo de saída da construção 
 
-- Type: `Boolean`
-- Default: Enabled when a `CI` or `test` environment is detected by [std-env](https://github.com/blindmedia/std-env)
+- Tipo: `Boolean`
+- Padrão: Ativado quando uma `CI` ou ambiente de `test` é detetado pelo [std-env](https://github.com/blindmedia/std-env)
 
-## splitChunks
+## A propriedade splitChunks
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
   ```js{}[nuxt.config.js]
   export default {
@@ -612,50 +614,50 @@ In Nuxt 2.15+, changing the value of this property at runtime will override the 
   }
   ```
 
-Whether or not to create separate chunks for `layout`, `pages` and `commons` (common libs: vue|vue-loader|vue-router|vuex...). For more information, see [webpack docs](https://v4.webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks).
+Se criar ou não pedaços separados para o `layouts`, `pages` e `commons` (bibliotecas comuns: vue|vue-loader|vue-router|vuex...) Para mais informações, consulte a [documentação do webpack](https://v4.webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks).
 
-## ssr
+## A propriedade ssr
 
-> Creates special webpack bundle for SSR renderer.
+> Cria um pacote especial do webpack para o renderizador de SSR.
 
-- Type: `Boolean`
-- Default: `true` for universal mode and `false` for spa mode
+- Tipo: `Boolean`
+- Padrão: `true` para o modo universal e `false` para o modo de aplicação de página única
 
-This option is automatically set based on `mode` value if not provided.
+Esta opção é automaticamente definida com base no valor de `mode` se não for fornecida.
 
-## standalone
+## A propriedade standalone
 
-> Inline server bundle dependencies (advanced)
+> Dependências em linha do pacote do servidor (avançado)
 
-- Type: `Boolean`
-- Default: `false`
+- Tipo: `Boolean`
+- Padrão: `false`
 
-This mode bundles `node_modules` that are normally preserved as externals in the server build ([more information](https://github.com/nuxt/nuxt.js/pull/4661)).
+Este mode empacota o `node_modules` que é normalmente preservado como externo dentro da construção de servidor ([mais informações](https://github.com/nuxt/nuxt.js/pull/4661)).
 
 ::alert{type="warning"}
-Runtime dependencies (modules, `nuxt.config`, server middleware and static directory) are not bundled. This feature only disables use of [webpack-externals](https://webpack.js.org/configuration/externals/) for server-bundle.
+Dependências do tempo de execução (módulos, `nuxt.config`, intermediário do servidor e diretório estático (static)) não são empacotados. Esta funcionalidade desativa o uso do [webpack-externals](https://webpack.js.org/configuration/externals/) para o pacote de servidor (server-bundle).
 ::
 
 ::alert{type="info"}
-you can use the command `yarn nuxt build --standalone` to enable this mode on the command line. (If you are not using `yarn` you can run the command with `npx`.)
+Você pode usar o comando `yarn nuxt build --standalone` para desativar este modo na linha de comando. (Se você não está usando o `yarn` você pode executar o comando com o `npx`.)
 ::
 
-## styleResources
+## A propriedade styleResources
 
-- Type: `Object`
-- Default: `{}`
+- Tipo: `Object`
+- Padrão: `{}`
 
 ::alert{type="warning"}
-This property is deprecated. Please use the [style-resources-module](https://github.com/nuxt-community/style-resources-module/) instead for improved performance and better DX!
+Esta propriedade está depreciada. Ao invés desta use o [style-resources-module](https://github.com/nuxt-community/style-resources-module/) para melhorado desempenho e melhor experiência do desenvolvedor!
 ::
 
-This is useful when you need to inject some variables and mixins in your pages without having to import them every time.
+Isto é útil quando você precisa injetar algumas variáveis e mixins dentro das suas páginas sem ter que importar elas a todo momento.
 
-Nuxt uses https://github.com/yenshih/style-resources-loader to achieve this behavior.
+O Nuxt usa o [style-resources-loader](https://github.com/yenshih/style-resources-loader) para alcançar este comportamento.
 
-You need to specify the patterns/path you want to include for the given pre-processors: `less`, `sass`, `scss` or `stylus`
+Você precisa especificar os padrões/caminhos que você quer incluir para os dados pré-processadores: `less`, `sass`, `scss` ou `stylus`
 
-You cannot use path aliases here (`~` and `@`), you need to use relative or absolute paths.
+Você não pode usar os apelidos de caminho aqui (`~` e `@`), você precisa usar caminhos relativos e caminhos absolutos.
 
 ```js{}[nuxt.config.js]
 {
@@ -666,29 +668,29 @@ You cannot use path aliases here (`~` and `@`), you need to use relative or abso
       // sass: ...,
       // scss: ...
       options: {
-        // See https://github.com/yenshih/style-resources-loader#options
-        // Except `patterns` property
+        // Consulte o https://github.com/yenshih/style-resources-loader#options
+        // Exceto a propriedade `patterns`
       }
     }
   }
 }
 ```
 
-## templates
+## A propriedade templates
 
-> Nuxt allows you provide your own templates which will be rendered based on Nuxt configuration. This feature is specially useful for using with [modules](/docs/directory-structure/modules).
+> O Nuxt permite você fornecer os seus próprios modelos os quais serão renderizados com base na configuração do Nuxt. Esta funcionalidade é especialmente útil para uso com [módulos](/docs/directory-structure/modules).
 
-- Type: `Array`
+- Tipo: `Array`
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     templates: [
       {
-        src: '~/modules/support/plugin.js', // `src` can be absolute or relative
-        dst: 'support.js', // `dst` is relative to project `.nuxt` dir
+        src: '~/modules/support/plugin.js', // `src` pode ser absoluto ou relativo
+        dst: 'support.js', // `dst` é relativo ao diretório `.nuxt` do projeto
         options: {
-          // Options are provided to template as `options` key
+          // Opções são fornecidas ao modelo como chave `options`
           live_chat: false
         }
       }
@@ -697,12 +699,12 @@ export default {
 }
 ```
 
-Templates are rendered using [`lodash.template`](https://lodash.com/docs/#template) you can learn more about using them [here](https://github.com/learn-co-students/javascript-lodash-templates-lab-v-000).
+Os modelos são renderizados usando o [`lodash.template`](https://lodash.com/docs/#template) que você pode aprender sobre como usar eles [aqui](https://github.com/learn-co-students/javascript-lodash-templates-lab-v-000).
 
-## terser
+## A propriedade terser
 
-- Type: `Object` or `Boolean`
-- Default:
+- Tipo: `Object` or `Boolean`
+- Padrão:
 
 ```js{}[nuxt.config.js]
 {
@@ -720,20 +722,20 @@ Templates are rendered using [`lodash.template`](https://lodash.com/docs/#templa
 }
 ```
 
-Terser plugin options. Set to `false` to disable this plugin.
+Opções do plugin Terser. Defina para `false` para desativar este plugin.
 
-Enabling `sourceMap` will leave `//# sourceMappingURL` linking comment at the end of each output file if webpack `config.devtool` is set to `source-map`.
+A ativação do `sourceMap` deixará o comentário de ligação `//# sourceMappingURL` no final de cada ficheiro de saída se o webpack `config.devtool` estiver definido para `source-map`.
 
-See [webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin).
+Consulte o [webpack-contrib/terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin).
 
-## transpile
+## A propriedade transpile
 
-- Type: `Array<String | RegExp | Function>`
-- Default: `[]`
+- Tipo: `Array<String | RegExp | Function>`
+- Padrão: `[]`
 
-If you want to transpile specific dependencies with Babel, you can add them in `build.transpile`. Each item in transpile can be a package name, a string or regex object matching the dependency's file name.
+Se você quiser transpilar dependências específicas com Babel, você pode adicionar elas dentro do `build.transpile`. Cada item dentro da propriedade `transpile` pode ser um nome de pacote, uma sequência de caracteres e objeto de expressões regulares correspondem ao nome do ficheiro da dependência.
 
-Starting with `v2.9.0`, you can also use a function to conditionally transpile, the function will receive a object (`{ isDev, isServer, isClient, isModern, isLegacy }`):
+A partir da versão `2.9.0`, você pode também usar uma função para transpilar condicionalmente, a função receberá um objeto (`{ isDev, isServer, isClient, isModern, isLegacy }`):
 
 ```js{}[nuxt.config.js]
 {
@@ -743,14 +745,14 @@ Starting with `v2.9.0`, you can also use a function to conditionally transpile, 
 }
 ```
 
-In this example, `ky` will be transpiled by Babel if Nuxt is not in [modern mode](/docs/configuration-glossary/configuration-modern).
+Neste exemplo, o `ky` será transpilado pelo Babel se o Nuxt não estiver no [modo moderno](/docs/configuration-glossary/configuration-modern).
 
-## vueLoader
+## A propriedade vueLoader
 
-> Note: This config has been removed since Nuxt 2.0, please use [`build.loaders.vue`](#loaders)instead.
+> Nota: Esta configuração tem sido removida desde a versão 2.0 do Nuxt, ao invés desta use o [`build.loaders.vue`](#a-propriedade-loaders).
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Padrão:
 
   ```js{}[nuxt.config.js]
   {
@@ -764,13 +766,13 @@ In this example, `ky` will be transpiled by Babel if Nuxt is not in [modern mode
   }
   ```
 
-> Specify the [Vue Loader Options](https://vue-loader.vuejs.org/options.html).
+> Especifica as [Opções do Carregador do Vue](https://vue-loader.vuejs.org/options.html).
 
-## watch
+## A propriedade watch
 
-> You can provide your custom files to watch and regenerate after changes. This feature is specially useful for using with [modules](/docs/directory-structure/modules).
+> Você pode fornecer os seus ficheiros personalizados para observar e regerar depois de mudanças. Esta funcionalidade é especialmente útil para ser usada com [módulos](/docs/directory-structure/modules).
 
-- Type: `Array<String>`
+- Tipo: `Array<String>`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -780,11 +782,11 @@ export default {
 }
 ```
 
-## followSymlinks
+## A propriedade followSymlinks
 
-> By default, the build process does not scan files inside symlinks. This boolean includes them, thus allowing usage of symlinks inside folders such as the "pages" folder, for example.
+> Por padrão, o processo de construção não examinar os ficheiros dentro de ligações simbólicas (symlinks). Este booleano inclui elas, permitindo assim o uso das ligações simbólicas dentro de pastas tais como a pasta "pages", por exemplo.
 
-- Type: `Boolean`
+- Tipo: `Boolean`
 
 ```js{}[nuxt.config.js]
 export default {

--- a/content/pt/docs/5.configuration-glossary/20.configuration-modules.md
+++ b/content/pt/docs/5.configuration-glossary/20.configuration-modules.md
@@ -1,59 +1,59 @@
 ---
-title: The modules Property
+title: A propriedade modules
 navigation.title: modules
-description: Modules are Nuxt extensions which can extend its core functionality and add endless integrations.
+description: Módulos são extensões do Nuxt que podem estender seu núcleo de funcionalidades e adicionar integrações intermináveis.
 menu: modules
 category: configuration-glossary
 ---
-# The modules property
+# A propriedade modules
 
-Modules are Nuxt extensions which can extend its core functionality and add endless integrations. [Learn More](/docs/directory-structure/modules)
+Módulos são extensões do Nuxt que podem estender seu núcleo de funcionalidades e adicionar integrações intermináveis. [Saiba mais](/docs/directory-structure/modules)
 
 ---
 
-- Type: `Array`
+- Tipo: `Array`
 
-Example (`nuxt.config.js`):
+Exemplo (`nuxt.config.js`):
 
 ```js
 export default {
   modules: [
-    // Using package name
+    // Usando o nome do pacote
     '@nuxtjs/axios',
 
-    // Relative to your project srcDir
+    // Relativo ao `srcDir` do seu projeto
     '~/modules/awesome.js',
 
-    // Providing options
+    // Fornecendo opções
     ['@nuxtjs/google-analytics', { ua: 'X1234567' }],
 
-    // Inline definition
+    // Definição em linha
     function () {}
   ]
 }
 ```
 
-Module developers usually provide additionally needed steps and details for usage.
+Desenvolvedores de módulo normalmente fornecem adicionalmente passos necessários e detalhes para uso.
 
-Nuxt tries to resolve each item in the modules array using node require path (in the `node_modules`) and then will be resolved from project `srcDir` if `~` alias is used. Modules are executed sequentially so the order is important.
+O Nuxt tenta resolver cada item dentro do arranjo de módulos usando o caminho exigido do node (dentro do `node_modules`) e depois será resolvido a partir do `srcDir` do projeto se o apelido `~` for usado. Os módulos são executados sequencialmente então a ordem é importante.
 
-**Note:** Any plugins injected by modules are added to the *beginning* of the plugins list. Your options are to:
-- Manually add your plugin to the end of the list of plugins (`this.nuxt.options.plugins.push(...`)
-- Reverse the order of the modules if it depends on another
+**Nota:** Qualquer plugin injetado pelos módulos são adicionados ao **inicio** da lista de plugins. As suas opções são para:
+- Manualmente adicionar o seu plugin no final da lista de plugins (`this.nuxt.options.plugins.push(...`)
+- Reverter a ordem dos módulos se um depender de um outro.
 
-Modules should export a function to enhance nuxt build/runtime and optionally return a promise until their job is finished. Note that they are required at runtime so should be already transpiled if depending on modern ES6 features.
+Os módulos devem exportar uma função para melhorar a construção/tempo de execução do Nuxt e opcionalmente retornar uma promessa até o trabalho deles estiver terminado. Nota que eles são obrigatórios no tempo de execução então devem já estar transpilados se dependerem de funcionalidades modernas do EcmaScript 6.
 
-Please see [Modules Guide](/docs/directory-structure/modules) for more detailed information on how they work or if interested developing your own module. Also we have provided an official [Modules](https://github.com/nuxt-community/awesome-nuxt#modules) Section listing dozens of production ready modules made by Nuxt Community.
+Consulte o [Guia dos Módulos](/docs/directory-structure/modules) para mais informações detalhadas sobre como eles funcionam ou se estiver interessado em desenvolver o seu próprio módulo. Nós também fornecemos uma secção de [módulos](https://github.com/nuxt-community/awesome-nuxt#modules) oficiais listando milhares de módulos feitos pela comunidade do Nuxt prontos para produção.
 
-## `buildModules`
+## A propriedade buildModules
 
 ::alert{type="info"}
-This feature is available since Nuxt v2.9
+Esta funcionalidade está disponível desde a versão 2.9 do Nuxt
 ::
 
-Some modules are only required during development and build time. Using `buildModules` helps to make production startup faster and also significantly decreasing `node_modules` size for production deployments. Please refer to each module docs to see if it is recommended to use `modules` or `buildModules`.
+Alguns módulos apenas são exigidos durante o tempo de desenvolvimento e construção. Usar o `buildModules` ajuda tornar o início em produção mais rápido e também diminuir significativamente o tamanho da pasta `node_modules` para desdobramentos em produção. Recorra a documentação de cada módulo para consultar se é recomendado usar `modules` ou `buildModules`.
 
-The usage difference is:
+A diferença de uso é:
 
-- Instead of adding to `modules` inside `nuxt.config.js`, use `buildModules`
-- Instead of adding to `dependencies` inside `package.json`, use `devDependencies` (`yarn add --dev` or `npm install --save-dev`)
+- Ao invés de adicionar ao `modules` dentro do ficheiro `nuxt.config.js`, usa o `buildModules`
+- Ao invés de adicionar ao `dependencies` dentro do `package.json`, usa o `devDependencies` (`yarn add --dev` ou `npm install --save-dev`)

--- a/content/pt/docs/5.configuration-glossary/21.configuration-modulesdir.md
+++ b/content/pt/docs/5.configuration-glossary/21.configuration-modulesdir.md
@@ -1,20 +1,20 @@
 ---
-title: The modulesDir Property
+title: A propriedade modulesDir
 navigation.title: modulesDir
-description: Define the modules directory for your Nuxt application
+description: Define o diretório dos módulos para sua aplicação Nuxt
 menu: modulesDir
 category: configuration-glossary
 ---
-# The modulesDir property
+# A propriedade modulesDir
 
-Define the modules directory for your Nuxt application
+Define o diretório dos módulos para sua aplicação Nuxt
 
 ---
 
-- Type: `Array`
-- Default: `['node_modules']`
+- Tipo: `Array`
+- Valor padrão: `['node_modules']`
 
-> Used to set the modules directories for path resolving, for example: Webpack's `resolveLoading`, `nodeExternals` and `postcss`. Configuration path is relative to [options.rootDir](/docs/configuration-glossary/configuration-rootdir) (default: `process.cwd()`).
+> Usada para definir os diretórios dos módulos para resolução de caminho, por exemplo: `resolveLoading`, `nodeExternals` e o `postcss` do Webpack. O caminho da configuração é relativo ao [options.rootDir](/docs/configuration-glossary/configuration-rootdir) (valor padrão: `process.cwd()`).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -22,4 +22,4 @@ export default {
 }
 ```
 
-Setting this field may be necessary if your project is organized as a Yarn workspace-styled mono-repository.
+A definição deste campo pode ser necessária se o seu projeto estiver organizado como um espaço de trabalho estilizado de um repositório Yarn monólito. 

--- a/content/pt/docs/5.configuration-glossary/22.configuration-plugins.md
+++ b/content/pt/docs/5.configuration-glossary/22.configuration-plugins.md
@@ -1,37 +1,37 @@
 ---
-title: The plugins Property
+title: A propriedade plugins
 navigation.title: plugins
-description: Use vue.js plugins with the plugins option of Nuxt.
+description: Usa os plugins de vue.js com as opções de plugins do Nuxt.
 menu: plugins
 category: configuration-glossary
 ---
-# The plugins property
+# A propriedade plugins
 
-Use vue.js plugins with the plugins option of Nuxt.
+Usa os plugins de vue.js com as opções de plugins do Nuxt.
 
 ---
 
-**Note**: Since Nuxt 2.4, `mode` has been introduced as option of `plugins` to specify plugin type, possible value are: `client` or `server`. `ssr: false` will be adapted to `mode: 'client'` and deprecated in next major release.
+**Nota**: Desde a versão 2.4 do Nuxt, o `mode` tem sido introduzido como a opção de `plugins` para especificar o tipo do plugin, os possíveis valores são: `client` ou `server`. O `ssr: false` será adotado para o `mode: client` e depreciado no próximo principal lançamento.
 
-- Type: `Array`
-  - Items: `String` or `Object`
+- Tipo: `Array`
+  - Itens: `String` ou `Object`
 
-If the item is an object, the properties are:
+Se o item for um objeto, as propriedades são:
 
-- src: `String` (path of the file)
-- mode: `String` (can be `client` or `server`) _If defined, the file will be included only on the respective (client or server) side._
+- src: `String` (caminho do ficheiro)
+- mode: `String` (pode ser `client` ou `server`) _Se definida, o ficheiro será incluído apenas no respetivo lado do (cliente ou servidor)._
 
-**Note**: Old version
+**Nota**: Versão antiga
 
-- Type: `Array`
-  - Items: `String` or `Object`
+- Tipo: `Array`
+  - Itens: `String` ou `Object`
 
-If the item is an object, the properties are:
+Se o item for um objeto, as propriedades são:
 
-- src: `String` (path of the file)
-- ssr: `Boolean` (default to `true`) _If false, the file will be included only on the client-side._
+- src: `String` (caminho do ficheiro)
+- ssr: `Boolean` (padrão ao `true`) _Se for `false`, o ficheiro será incluído apenas no lado do cliente._
 
-> The plugins property lets you add Vue.js plugins easily to your main application.
+> A propriedade plugins permite você adicionar plugins de Vue.js facilmente à sua aplicação principal.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -52,11 +52,11 @@ export default {
 ```js{}[plugins/ant-design-vue.js]
 import Vue from 'vue'
 import Antd from 'ant-design-vue'
-import 'ant-design-vue/dist/antd.css' // Per Ant Design's docs
+import 'ant-design-vue/dist/antd.css' // conforme documentação do Ant Design
 
 Vue.use(Antd)
 ```
 
-Note that the css was [imported as per Ant Design Documentation](https://vue.ant.design/docs/vue/getting-started/#3.-Use-antd's-Components 'External tip relevant to building plugins')
+Nota que o CSS foi [importado conforme a documentação do Ant Design](https://vue.ant.design/docs/vue/getting-started/#3.-Use-antd's-Components 'Dica externa relevante para construção dos plugins')
 
-All the paths defined in the `plugins` property will be **imported** before initializing the main application.
+Todos os caminhos definidos dentro da propriedade `plugins` serão **importados** antes da inicialização da aplicação principal.

--- a/content/pt/docs/5.configuration-glossary/23.configuration-render.md
+++ b/content/pt/docs/5.configuration-glossary/23.configuration-render.md
@@ -1,21 +1,21 @@
 ---
-title: The render Property
+title: A propriedade render
 navigation.title: render
-description: Nuxt lets you customize runtime options for rendering pages
+description: O Nuxt permite você personalizar as opções do tempo de execução para renderização de páginas
 menu: render
 category: configuration-glossary
 ---
-# The render property
+# A propriedade render
 
-Nuxt lets you customize runtime options for rendering pages
+O Nuxt permite você personalizar as opções do tempo de execução para renderização de páginas
 
 ---
 
-## bundleRenderer
+## A propriedade bundleRenderer
 
-- Type: `Object`
+- Tipo: `Object`
 
-> Use this option to customize vue SSR bundle renderer. This option is skipped if `ssr: false`.
+> Use esta opção para personalizar pacote renderizador da Renderização no Lado do Servidor do Vue. Esta opção é ignorada se houver definido `ssr: false`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -23,7 +23,7 @@ export default {
     bundleRenderer: {
       directives: {
         custom1(el, dir) {
-          // something ...
+          // alguma coisa...
         }
       }
     }
@@ -31,18 +31,18 @@ export default {
 }
 ```
 
-Learn more about available options on [Vue SSR API Reference](https://ssr.vuejs.org/en/api.html#renderer-options). It is recommended to not use this option as Nuxt is already providing best SSR defaults and misconfiguration might lead to SSR problems.
+Saiba mais sobre as opções disponíveis na [Referência da API de Renderização no Lado do Servidor do Vue](https://ssr.vuejs.org/en/api.html#renderer-options). É recomendado não usar esta opção visto que o Nuxt já está fornecendo os melhores padrões de renderização no lado do servidor e uma configuração errada pode levar a problemas na Renderização no Lado do Servidor. 
 
-## etag
+## A propriedade etag
 
-- Type: `Object`
-  - Default: `{ weak: true }`
+- Tipo: `Object`
+  - Valor padrão: `{ weak: true }`
 
-To disable etag for pages set `etag: false`
+Para desativar o `etag` para páginas defina `etag: false`
 
-See [etag](https://www.npmjs.com/package/etag) docs for possible options.
+Consulte a documentação do [etag](https://www.npmjs.com/package/etag) para conhecer as possíveis opções.
 
-You can use your own hash function by specifying `etag.hash`:
+Você pode usar a sua própria função `hash` ao especificar `etag.hash`:
 
 ```js{}[nuxt.config.js]
 import { murmurHash128 } from 'murmurhash-native'
@@ -56,38 +56,38 @@ export default {
 }
 ```
 
-In this case we use [murmurhash-native](https://github.com/royaltm/node-murmurhash-native), which is faster for larger HTML body sizes. Note that the `weak` option is ignored, when specifying your own hash function.
+Neste caso usamos o [murmurhash-native](https://github.com/royaltm/node-murmurhash-native), o qual é mais rápido para tamanhos de corpo de HTML muito maiores. Repare que a opção `weak` é ignorada, quando estiver especificando a sua própria função de `hash`.
 
-## compressor
+## A propriedade compressor
 
-- Type `Object`
-  - Default: `{ threshold: 0 }`
+- Tipo `Object`
+  - Valor padrão: `{ threshold: 0 }`
 
-When providing an object, the [compression](https://www.npmjs.com/package/compression) middleware will be used (with respective options).
+Quando estiver fornecendo um objeto, o intermediário do [compression](https://www.npmjs.com/package/compression) será usado (com as respetivas opções).
 
-If you want to use your own compression middleware, you can reference it directly (e.g. `otherComp({ myOptions: 'example' })`).
+Se você quiser usar o seu próprio intermediário de compressão, você pode referenciar ele diretamente (por exemplo, `otherComp({ myOptions: 'example' })`).
 
-To disable compression, use `compressor: false`.
+Para desativar a compressão, use `compressor: false`.
 
-## fallback
+## A propriedade fallback
 
-- Type `Object`
-  - Default: `{ dist: {}, static: { skipUnknown: true } }`
-  - `dist` key is for routes matching the [publicPath](/docs/configuration-glossary/configuration-build#publicpath) (ie: `/_nuxt/*`)
-  - `static` key is for routes matching routes matching `/*`
+- Tipo `Object`
+  - Valor padrão: `{ dist: {}, static: { skipUnknown: true } }`
+  - a chave `dist` é para rotas correspondentes ao [publicPath](/docs/configuration-glossary/configuration-build#publicpath) (por exemplo: `/_nuxt/*`)
+  - a chave `static` é para rotas correspondentes ao `/*`
 
-> `dist` and `static` values are forwarded to [serve-placeholder](https://github.com/nuxt-contrib/serve-placeholder) middleware.
+> Os valores `dist` e `static` são encaminhados para o intermediário [serve-placeholder](https://github.com/nuxt-contrib/serve-placeholder).
 
-If you want to disable one of them or both, you can pass a falsy value.
+Se você quiser desativar um deles ou ambos, você pode passar um valor de falsidade.
 
-Example of allowing `.js` extension for routing (ex: `/repos/nuxt.js`):
+Exemplo permitindo a extensão `.js` para roteamento (por exemplo: `/repos/nuxt.js`):
 
 ```js [nuxt.config.js]
 export default {
   render: {
     fallback: {
       static: {
-        // Avoid sending 404 for these extensions
+        // Evite enviar o 404 para estas extensões
         handlers: {
           '.js': false
         }
@@ -97,16 +97,16 @@ export default {
 }
 ```
 
-## http2
+## A propriedade http2
 
-- Type `Object`
-  - Default: `{ push: false, pushAssets: null }`
+- Tipo `Object`
+  - Valor padrão: `{ push: false, pushAssets: null }`
 
-> Activate HTTP2 push headers.
+> Ativa o empurrar de cabeçalhos de HTTP2
 
-You can control what links to push using `pushAssets` function.
+Você pode controlar quais ligações empurrar usando a função `pushAssets`.
 
-Example:
+Exemplo:
 
 ```js
 pushAssets: (req, res, publicPath, preloadFiles) =>
@@ -115,117 +115,117 @@ pushAssets: (req, res, publicPath, preloadFiles) =>
     .map(f => `<${publicPath}${f.file}>; rel=preload; as=${f.asType}`)
 ```
 
-You can add your own assets to the array as well. Using `req` and `res` you can decide what links to push based on the request headers, for example using the cookie with application version.
+Você pode adicionar adicionar os seus próprios recursos ao arranjo também. Usando o `req` e o `res` você pode decidir quais ligações para empurrar baseado nos cabeçalhos da requisição, por exemplo usando o `cookie` com a versão da aplicação.
 
-The assets will be joined together with `,` and passed as a single `Link` header.
+Os recursos serão juntados com o `,` e passados como um cabeçalho `Link` único.
 
-## asyncScripts
+## A propriedade asyncScripts
 
-- Type: `Boolean`
-  - Default: `false`
+- Tipo: `Boolean`
+  - Valor padrão: `false`
 
-> Adds an `async` attribute to `<script>` tags for Nuxt bundles, enabling them to be fetched in parallel to parsing (available with `2.14.8+`). [More information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).
+> Adiciona um atributo `async` para os marcadores de `<script>` para pacotes do Nuxt, habilitando eles a serem requisitados em paralelo para parseamento (disponível desde a versão `2.14.8+` do Nuxt). [Mais informações](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script).
 
-## injectScripts
+## A propriedade injectScripts
 
-- Type: `Boolean`
-  - Default: `true`
+- Tipo: `Boolean`
+  - Valor padrão: `true`
 
-> Adds the `<script>` for Nuxt bundles, set it to `false` to render pure HTML without JS (available with `2.8.0+`)
+> Adiciona o `<script>` para os pacotes do Nuxt, defina ele para `false` para renderizar HTML puro sem JavaScript (disponível desde a versão `2.14.8+` do Nuxt)
 
-## resourceHints
+## A propriedade resourceHints
 
-- Type: `Boolean`
-  - Default: `true`
+- Tipo: `Boolean`
+  - Valor padrão: `true`
 
-> Adds `prefetch` and `preload` links for faster initial page load time.
+> Adiciona as ligações `prefetch` e `preload` para acelerar o tempo de carregamento da página.
 
-You may want to only disable this option if you have many pages and routes.
+Você talvez queira apenas desativar esta opção se você tiver muitas páginas e rotas.
 
-## ssr
+## A propriedade ssr
 
-- Type: `Boolean`
-  - Default: `true`
+- Tipo: `Boolean`
+  - Valor padrão: `true`
   - `false` only client side rendering
 
-> Enable SSR rendering
+> Ativa a Renderização no Lado do Servidor
 
-This option is automatically set based on global `ssr` value if not provided. This can be useful to dynamically enable/disable SSR on runtime after image builds (with docker for example).
+Esta opção é automaticamente definida baseada no valor global de `ssr` se não for fornecida. Isto pode ser útil para dinamicamente ativar/desativar a Renderização no Lado do Servidor em tempo de execução depois da construção da imagem (com o docker por exemplo).
 
-## crossorigin
+## A propriedade crossorigin
 
-- Type: `String`
-- Default: `undefined`
+- Tipo: `String`
+- Valor padrão: `undefined`
 
-  Configure the `crossorigin` attribute on `<link rel="stylesheet">` and `<script>` tags in generated HTML.
+  Configura o atributo `crossorigin` nos marcadores `<link rel="stylesheet">` e `<script>` dentro do HTML gerado.
 
-  More Info: [CORS settings attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
+  Mais Informações: [atributos de definições de CORS](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes)
 
-## ssrLog
+## A propriedade ssrLog
 
-- Type: `Boolean` | `String`
-  - Default: `true` in dev mode and `false` in production
+- Tipo: `Boolean` | `String`
+  - Valor padrão: `true` em modo de desenvolvimento e `false` em produção
 
-> Forward server-side logs to the browser for better debugging (only available in development)
+> Encaminha os registos do lado do servidor para o navegador para melhor depuração (apenas disponível em desenvolvimento)
 
-To collapse the logs, use `'collapsed'` value.
+Para colapsar os registos, use o valor `'collapsed'`.
 
-## static
+## A propriedade static
 
-- Type: `Object`
-  - Default: `{}`
+- Tipo: `Object`
+  - Valor padrão: `{}`
 
-> Configure the `static/` directory behavior
+> Configura o comportamento do diretório `static/`
 
-See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible options.
+Consulta a documentação [serve-static](https://www.npmjs.com/package/serve-static) para conhecer as possíveis opções.
 
-Additional to them, we introduced a `prefix` option which defaults to `true`. It will add the router base to your static assets.
+Adicionalmente a eles, nós introduzimos uma opção `prefix` a qual valor padrão é definida para `true`. Ela adicionará a base do roteador aos seus recursos estáticos.
 
-**Example:**
+**Exemplo:**
 
-- Assets: `favicon.ico`
-- Router base: `/t`
-- With `prefix: true` (default): `/t/favicon.ico`
-- With `prefix: false`: `/favicon.ico`
+- Recursos: `favicon.ico`
+- Base do Roteador: `/t`
+- Com o `prefix: true` (valor padrão): `/t/favicon.ico`
+- Com o `prefix: false`: `/favicon.ico`
 
-**Caveats:**
+**Avisos:**
 
-Some URL rewrites might not respect the prefix.
+Algumas restrições de URL podem não respeitar o prefixo.
 
-## dist
+## A propriedade dist
 
-- Type: `Object`
-  - Default: `{ maxAge: '1y', index: false }`
+- Tipo: `Object`
+  - Valor padrão: `{ maxAge: '1y', index: false }`
 
-> Options used for serving distribution files. Only applicable in production.
+> Opções usadas para servir a distribuição de ficheiros. Somente aplicável em produção.
 
-See [serve-static](https://www.npmjs.com/package/serve-static) docs for possible options.
+Consulte a documentação [serve-static](https://www.npmjs.com/package/serve-static) para conhecer as possíveis opções.
 
-## csp
+## A propriedade csp
 
-- Type: `Boolean` or `Object`
-  - Default: `false`
+- Tipo: `Boolean` ou `Object`
+  - Valor padrão: `false`
 
-> Use this to configure Content-Security-Policy to load external resources
+> Use isto para configurar a Política de Segurança de Conteúdo para carregar recursos externos
 
-**Prerequisites:**
+**Pré-requisitos:**
 
-These CSP settings are only effective when using Nuxt with `target: 'server'` to serve your SSR application. The Policies defined under `csp.policies` are added to the response `Content-Security-Policy` HTTP header.
+Estas definições de Política de Segurança de Conteúdo apenas são eficazes quando estiver usando o Nuxt com o `target: 'server'` para servir a sua aplicação Renderizada no Lado do Servidor. As políticas definidas conforme o `csp.policies` são adicionadas ao cabeçalho `Content-Security-Policy` da resposta do HTTP.
 
-**Updating settings:**
+**Atualizando definições:**
 
-These settings are read by the Nuxt server directly from `nuxt.config.js`. This means changes to these settings take effect when the server is restarted. There is no need to rebuild the application to update the CSP settings.
+Estas definições são lidas pelo servidor do Nuxt diretamente a partir do ficheiro `nuxt.config.js`. Isto significa para mudanças para essas definições tem efeito quando o servidor é reiniciado. Não há necessidade de reconstruir a aplicação para atualizar as definições da Política de Segurança de Conteúdo.
 
-**HTML meta tag:**
+**Marcador meta do HTML:**
 
-In order to add [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to the `<head>` you need to set `csp.addMeta` to `true`. Please note that this feature is independent of the `csp.policies` configuration:
+NO sentido de adicionar [`<meta http-equiv="Content-Security-Policy"/>`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) ao `<head>` você precisa definir o `csp.addMeta` para `true`. Repare que essa funcionalidade é independente da configuração do `csp.policies`:
 
-- it only adds a `script-src` type policy, and
-- the `script-src` policy only contains the hashes of the inline `<script>` tags.
+- ele apenas adiciona uma política do tipo `script-src`, e
+- a política `script-src` apenas contém os hashes dos marcadores `<script>` em linha.
 
-When `csp.addMeta` is set to `true`, the complete set of the defined policies are still added to the HTTP response header.
+Quando o `csp.addMeta` estiver definido para `true`, o conjunto completo das políticas definidas continuam a serem adicionadas ao cabeçalho da resposta do HTTP.
 
-Note that CSP hashes will not be added as `<meta>` if `script-src` policy contains `'unsafe-inline'`. This is due to browser ignoring `'unsafe-inline'` if hashes are present. Set option `unsafeInlineCompatibility` to `true` if you want both hashes and `'unsafe-inline'` for CSPv1 compatibility. In that case the `<meta>` tag will still only contain the hashes of the inline `<script>` tags, and the policies defined under `csp.policies` will be used in the `Content-Security-Policy` HTTP response header.
+Repare que as hashes da Política de Segurança de Conteúdo não serão adicionadas como `<meta>` se a política `script-src` conter o `'unsafe-inline'`. Isto é para navegador ignorar `'unsafe-inline'` se as hashes estiverem presentes. Defina a opção `unsafeInlineCompatibility` para `true` se você quiser ambas hashes e o `'unsafe-inline'` para compatibilidade com a versão 1 da Política de Segurança de Conteúdo. Neste caso o marcador `<meta>` continuará contendo somente as hashes dos marcadores `<script>` em linha, e as políticas definidas conforme `csp.policies` serão usadas dentro do cabeçalho `Content-Security-Policy` da resposta do HTTP.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -234,7 +234,7 @@ export default {
   }
 }
 
-// OR
+// OU
 
 export default {
   render: {
@@ -252,15 +252,15 @@ export default {
   }
 }
 
-// OR
+// OU
 /*
-  The following example allows Google Analytics, LogRocket.io, and Sentry.io
-  for logging and analytic tracking.
+  O seguinte exemplo permite o Google Analytics, LogRocket.io, e o Sentry.io
+  fazerem o registo e rastreio analítico.
 
-  Review to this blog on Sentry.io
+  Consulte este blogue no Sentry.io
   https://blog.sentry.io/2018/09/04/how-sentry-captures-csp-violations
 
-  To learn what tracking link you should use.
+  Para saber qual ligação de rastreio você deve usar.
 */
 const PRIMARY_HOSTS = `loc.example-website.com`
 export default {

--- a/content/pt/docs/5.configuration-glossary/24.configuration-rootdir.md
+++ b/content/pt/docs/5.configuration-glossary/24.configuration-rootdir.md
@@ -1,23 +1,23 @@
 ---
-title: The rootDir Property
+title: A propriedade rootDir
 navigation.title: rootDir
-description: Define the workspace of Nuxt application
+description: Define o espaço de trabalho da aplicação Nuxt
 menu: rootDir
 category: configuration-glossary
 ---
-# The rootDir property
+# A propriedade rootDir
 
-Define the workspace of Nuxt application
+Define o espaço de trabalho da aplicação Nuxt
 
 ---
 
-- Type: `String`
-- Default: `process.cwd()`
+- Tipo: `String`
+- Valor padrão: `process.cwd()`
 
-This property will be overwritten by the nuxt commands(nuxt start, nuxt build etc) if an argument is passed to them. Eg running `nuxt ./my-app/` will set the `rootDir` to the absolute path of `./my-app/` from the current/working directory.
+Esta propriedade será sobrescrita pelos comandos do Nuxt (`nuxt start`, `nuxt build`, etc) se um argumento for passado para eles. Por exemplo executar `nuxt ./my-app/` definirá o `rootDir` para o caminho absoluto de `./my-app/` do diretório atual/de trabalho.
 
-Because of that its normally not needed to configure this option unless you will use [Nuxt programmatically](/docs/internals-glossary/nuxt).
+Por causa disto ele normalmente não precisa configurar esta opção a menos que você use o [Nuxt programaticamente](/docs/internals-glossary/nuxt).
 
 ::alert{type="info"}
-Both `rootDir` as the package root containing the `node_modules` directory need to be within the same directory tree to be able to <a href="https://nodejs.org/api/modules.html#modules_all_together">resolve dependencies</a>. See the [`srcDir` option](/docs/configuration-glossary/configuration-srcdir) for examples of directory structure when that is not the case.
+Ambos o `rootDir` como a raiz do pacote contendo o diretório `node_modules` precisam estar dentro da mesma árvore de diretório para serem capazes de [resolver dependências](https://nodejs.org/api/modules.html#modules_all_together). Consulte a [opção `srcDir`](/docs/configuration-glossary/configuration-srcdir) para exemplos de estruturas de diretório quando esse não for o caso.
 ::

--- a/content/pt/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/pt/docs/5.configuration-glossary/25.configuration-router.md
@@ -1,28 +1,28 @@
 ---
-title: The router Property
+title: A propriedade router
 navigation.title: router
-description: The router property lets you customize Nuxt router.
+description: A propriedade router permite você personalizar o roteador do Nuxt.
 menu: router
 category: configuration-glossary
 ---
-# The router property
+# A propriedade router
 
-The router property lets you customize Nuxt router. ([vue-router](https://router.vuejs.org/en/)).
+A propriedade router permite você personalizar o roteador do Nuxt. ([vue-router](https://router.vuejs.org/en/)).
 
 ---
 
-## base
+## A propriedade base
 
-- Type: `String`
-- Default: `'/'`
+- Tipo: `String`
+- Valor padrão: `'/'`
 
-The base URL of the app. For example, if the entire single page application is served under `/app/`, then base should use the value `'/app/'`.
+A base da URL da aplicação. Por exemplo, se aplicação de página única inteira for servida debaixo de `/app/`, então a base deve usar o valor `'/app/'`.
 
-This can be useful if you need to serve Nuxt as a different context root, from within a bigger Web site. Notice that you may, or may not set up a Front Proxy Web Server.
+Isto pode ser útil se você precisar servir o Nuxt como uma raiz de contexto diferente, a partir de dentro de um sítio maior na teia de computadores. Repare que você pode, ou não definir um Servidor de Procuração de Rede Frontal (Front Proxy Web Server).
 
-If you want to have a redirect to `router.base`, you can do so [using a Hook, see _Redirect to router.base when not on root_](/docs/configuration-glossary/configuration-hooks#redirect-to-routerbase-when-not-on-root).
+Se você quiser ter um redirecionamento para o `router.base`, você pode fazer isso [usando um Gatilho, consulte o _Redirecionar para `router.base` quando não estiver na raiz_](/docs/configuration-glossary/configuration-hooks#redirecionar-para-routerbase-quando-não-estiver-na-raiz).
 
-In Nuxt 2.15+, changing the value of this property at runtime will override the configuration of an app that has already been built.
+Desde a versão 2.15 do Nuxt, a mudança do valor desta propriedade em tempo de execução sobrescreverá a configuração de uma aplicação que já foi construída.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -33,17 +33,17 @@ export default {
 ```
 
 ::alert{type="info"}
-When `base` is set, Nuxt will also add in the document header `<base href="{{ router.base }}"/>`.
+Quando o `base` estiver definido, o Nuxt também adicionará dentro do cabeçalho do documento o `<base href="{{ router.base }}"/>`.
 ::
 
-> This option is given directly to the vue-router [base](https://router.vuejs.org/api/#base).
+> Esta opção é dada diretamente ao [`base`](https://router.vuejs.org/api/#base) do `vue-router`.
 
-## routeNameSplitter
+## A propriedade routeNameSplitter
 
-- Type: `String`
-- Default: `'-'`
+- Tipo: `String`
+- Valor padrão: `'-'`
 
-You may want to change the separator between route names that Nuxt uses. You can do so via the `routeNameSplitter` option in your configuration file. Imagine we have the page file `pages/posts/_id.vue`. Nuxt will generate the route name programmatically, in this case `posts-id`. Changing the `routeNameSplitter` config to `/` the name will therefore change to `posts/id`.
+Você pode querer mudar o separador entre os nomes de rota que o Nuxt usa. Você pode fazer isso através da opção `routerNameSplitter` dentro do seu ficheiro de configuração. Imagina que nós temos um ficheiro de página `pages/posts/_id.vue`. O Nuxt gerará o nome da rota programaticamente, neste caso o `posts-id`. Mudando a configuração do `routerNameSplitter` para `/` o nome mudará então para `posts/id`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -53,11 +53,11 @@ export default {
 }
 ```
 
-## extendRoutes
+## A propriedade extendRoutes
 
-- Type: `Function`
+- Tipo: `Function`
 
-You may want to extend the routes created by Nuxt. You can do so via the `extendRoutes` option.
+Você pode querer estender as rotas criadas pelo Nuxt. Você pode fazer isso através da opção `extendRoutes`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -73,26 +73,26 @@ export default {
 }
 ```
 
-If you want to sort your routes, you can use the `sortRoutes(routes)` function from `@nuxt/utils`:
+Se você quiser organizar as suas rotas, você pode usar a função `sortRoutes(routes)` do módulo `@nuxt/utils`:
 
 ```js{}[nuxt.config.js]
 import { sortRoutes } from '@nuxt/utils'
 export default {
   router: {
     extendRoutes(routes, resolve) {
-      // Add some routes here ...
+      // Adicione algumas rotas aqui...
 
-      // and then sort them
+      // e depois organize elas
       sortRoutes(routes)
     }
   }
 }
 ```
 
-The schema of the route should respect the [vue-router](https://router.vuejs.org/en/) schema.
+O estrutura da rota deve respeitar o estrutura do [`vue-router`](https://router.vuejs.org/en/).
 
 ::alert{type="warning"}
-When adding routes that use Named Views, don't forget to add the corresponding `chunkNames` of named `components`.
+Quando estiver adicionando rotas que usam Apresentações Nomeadas, não esqueça de adicionar o `chunkNames` correspondente dos `components` nomeados.
 ::
 
 ```js{}[nuxt.config.js]
@@ -102,7 +102,7 @@ export default {
       routes.push({
         path: '/users/:id',
         components: {
-          default: resolve(__dirname, 'pages/users'), // or routes[index].component
+          default: resolve(__dirname, 'pages/users'), // ou routes[index].component
           modal: resolve(__dirname, 'components/modal.vue')
         },
         chunkNames: {
@@ -114,23 +114,23 @@ export default {
 }
 ```
 
-## fallback
+## A propriedade fallback
 
-- Type: `boolean`
-- Default: `false`
+- Tipo: `boolean`
+- Valor padrão: `false`
 
-Controls whether the router should fallback to hash mode when the browser does not support history.pushState but mode is set to history.
+Controla se a roteador deve recuar para o modo de `hash` quando o navegador não suporta o modo histórico. Empurra o estado mas o modo é definido para histórico.
 
-Setting this to false essentially makes every router-link navigation a full page refresh in IE9. This is useful when the app is server-rendered and needs to work in IE9, because a hash mode URL does not work with SSR.
+Definindo isto para `false` essencialmente faz um recarregamento completo da página em toda navegação do `router-link` no Internet Explorer 9. Isto é útil quando a aplicação é renderizada no servidor e precisa funcionar no Internet Explorer 9, porque o modo de `hash` da URL não funciona com a Renderização no Lado do Servidor.
 
-> This option is given directly to the vue-router [fallback](https://router.vuejs.org/api/#fallback).
+> Esta opção é dada diretamente ao [`fallback`](https://router.vuejs.org/api/#fallback) do `vue-router`.
 
-## linkActiveClass
+## A propriedade linkActiveClass
 
-- Type: `String`
-- Default: `'nuxt-link-active'`
+- Tipo: `String`
+- Valor padrão: `'nuxt-link-active'`
 
-Globally configure [`<nuxt-link>`](/docs/features/nuxt-components#the-nuxtlink-component) default active class.
+Configura globalmente a classe ativa padrão do componente [`<nuxt-link>`](/docs/features/nuxt-components#the-nuxtlink-component).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -140,14 +140,14 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkActiveClass](https://router.vuejs.org/api/#linkactiveclass).
+> Esta opção é dada diretamente ao [`linkActiveClass`](https://router.vuejs.org/api/#linkactiveclass) do `vue-router`.
 
-## linkExactActiveClass
+## A propriedade linkExactActiveClass
 
-- Type: `String`
-- Default: `'nuxt-link-exact-active'`
+- Tipo: `String`
+- Valor padrão: `'nuxt-link-exact-active'`
 
-Globally configure [`<nuxt-link>`](/docs/features/nuxt-components#the-nuxtlink-component) default exact active class.
+Configura globalmente a classe ativa exata padrão do componente [`<nuxt-link>`](/docs/features/nuxt-components#the-nuxtlink-component).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -157,14 +157,14 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkExactActiveClass](https://router.vuejs.org/api/#linkexactactiveclass).
+> Esta opção é dada diretamente ao [`linkExactActiveClass`](https://router.vuejs.org/api/#linkexactactiveclass) do `vue-router`.
 
-## linkPrefetchedClass
+## A propriedade linkPrefetchedClass
 
-- Type: `String`
-- Default: `false`
+- Tipo: `String`
+- Valor padrão: `false`
 
-Globally configure [`<nuxt-link>`](/docs/features/nuxt-components#the-nuxtlink-component) default prefetch class (feature disabled by default)
+Configura globalmente a classe de pré-requisição padrão do componente [`<nuxt-link>`](/docs/features/nuxt-components#the-nuxtlink-component) (funcionalidade desativada por padrão).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -174,17 +174,17 @@ export default {
 }
 ```
 
-## middleware
+## A propriedade middleware
 
-- Type: `String` or `Array`
-  - Items: `String`
+- Tipo: `String` ou `Array`
+  - Itens: `String`
 
-Set the default(s) middleware for every page of the application.
+Define o(s) intermediário(s) padrão para cada página da aplicação.
 
 ```js{}[nuxt.config.js]
 export default {
   router: {
-    // Run the middleware/user-agent.js on every page
+    // Executa o middleware/user-agent.js em cada página
     middleware: 'user-agent'
   }
 }
@@ -192,21 +192,21 @@ export default {
 
 ```js{}[middleware/user-agent.js]
 export default function (context) {
-  // Add the userAgent property in the context (available in `asyncData` and `fetch`)
+  // Adiciona a propriedade `userAgent` dentro do contexto (disponível dentro do gatilho `asyncData` e `fetch`)
   context.userAgent = process.server
     ? context.req.headers['user-agent']
     : navigator.userAgent
 }
 ```
 
-To learn more about the middleware, see the [middleware guide](/docs/directory-structure/middleware#router-middleware).
+Para saber mais sobre o intermediário, consulte o [guia do intermédiario](/docs/directory-structure/middleware#o-intermédiario-do-roteador).
 
-## mode
+## A propriedade mode
 
-- Type: `String`
-- Default: `'history'`
+- Tipo: `String`
+- Valor padrão: `'history'`
 
-Configure the router mode, this is not recommended to change it due to server-side rendering.
+Configura o modo do roteador, não é recomendado mudar ele por causa da renderização no lado do servidor.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -216,26 +216,26 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [mode](https://router.vuejs.org/api/#mode).
+> Esta opção é dada diretamente ao [`mode`](https://router.vuejs.org/api/#mode) do `vue-router`.
 
-## parseQuery / stringifyQuery
+## A propriedade parseQuery / stringifyQuery
 
-- Type: `Function`
+- Tipo: `Function`
 
-Provide custom query string parse / stringify functions. Overrides the default.
+Fornece analise personalizada de sequência de caracteres de consulta / transforma funções em sequências de caracteres. Sobrescreve o valor padrão.
 
-> This option is given directly to the vue-router [parseQuery / stringifyQuery](https://router.vuejs.org/api/#parsequery-stringifyquery).
+> Esta opção é dada diretamente ao [`parseQuery` / `stringifyQuery`](https://router.vuejs.org/api/#parsequery-stringifyquery) do `vue-router`.
 
-## prefetchLinks
+## A propriedade prefetchLinks
 
-> Added with Nuxt v2.4.0
+> Adicionada com a versão 2.4.0 do Nuxt
 
-- Type: `Boolean`
-- Default: `true`
+- Tipo: `Boolean`
+- Valor padrão: `true`
 
-Configure `<nuxt-link>` to prefetch the _code-splitted_ page when detected within the viewport. Requires [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to be supported (see [Caniuse](https://caniuse.com/#feat=intersectionobserver)).
+Configura o componente `<nuxt-link>` para pré-requisitar o _código separado_ da página quando detetado dentro da janela de visualização. Requer o [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) para ser suportado (consulte o [CanIUse](https://caniuse.com/#feat=intersectionobserver)).
 
-We recommend conditionally polyfilling this feature with a service like [Polyfill.io](https://polyfill.io):
+Nós recomendamos condicionalmente preencher esta funcionalidade com um serviço como o [Polyfill.io](https://polyfill.io):
 
 ```js{}[nuxt.config.js]
 export default {
@@ -251,14 +251,14 @@ export default {
 }
 ```
 
-To disable the prefetching on a specific link, you can use the `no-prefetch` prop. Since Nuxt v2.10.0, you can also use the `prefetch` prop set to `false`:
+Para desativar a pré-requisição em uma ligação específica, você pode usar o atributo `no-prefetch`. Desde a versão 2.10.0 do Nuxt, você pode também usar o atributo `prefetch` para definir para `false`:
 
 ```html
 <nuxt-link to="/about" no-prefetch>About page not prefetched</nuxt-link>
 <nuxt-link to="/about" :prefetch="false">About page not prefetched</nuxt-link>
 ```
 
-To disable the prefetching on all links, set the `prefetchLinks` to `false`:
+Para desativar a pré-requisição em todas as ligações, defina a propriedade `prefetchLinks` para `false`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -268,28 +268,28 @@ export default {
 }
 ```
 
-Since Nuxt v2.10.0, if you have set `prefetchLinks` to `false` but you want to prefetch a specific link, you can use the `prefetch` prop:
+Desde a versão 2.10.0 do Nuxt, se você tiver o `prefetchLinks` definido como `false` mas você quer pré-requisitar uma ligação específica, você pode usar o atributo `prefetch`:
 
 ```html
 <nuxt-link to="/about" prefetch>About page prefetched</nuxt-link>
 ```
 
-## prefetchPayloads
+## A propriedade prefetchPayloads
 
-> Added with v2.13.0, only available for [static target](/docs/features/deployment-targets#static-hosting).
+> Adicionada com a versão 2.13.0 do Nuxt, apenas disponível para o [alvo estático](/docs/features/deployment-targets#hospedagem-estática).
 
-- Type: `Boolean`
-- Default: `true`
+- Tipo: `Boolean`
+- Valor padrão: `true`
 
-When using `nuxt generate` with `target: 'static'`, Nuxt will generate a `payload.js` for each page.
+Quando usar o comando `nuxt generate` com o `target: 'static'`, o Nuxt gerará um ficheiro `payload.js` para cada página.
 
-With this option enabled, Nuxt will automatically prefetch the payload of the linked page when the `<nuxt-link>` is visible in the viewport, making **instant navigation**.
+Com esta opção ativada, o Nuxt pré-requisitará automaticamente o `payload` da página ligada quando o componente `<nuxt-link>` estiver visível dentro da janela de visualização, tornando a **navegação instantânea**.
 
 ::alert{type="info"}
-This option depends of the [prefetchLinks](#prefetchlinks) option to be enabled.
+Esta opção precisa que a opção [`prefetchLinks`](#a-propriedade-prefetchlinks) esteja ativada.
 ::
 
-You can disable this behavior by setting `prefetchPaylods` to `false`:
+Você pode desativar este comportamento ao definir `prefetchPaylods` para `false`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -299,25 +299,25 @@ export default {
 }
 ```
 
-## scrollBehavior
+## A propriedade scrollBehavior
 
-- Type: `Function`
+- Tipo: `Function`
 
-The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered. To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+A opção `scrollBehavior` permite você definir um comportamento personalizado para a posição da rolagem entre as rotas. Este método é chamado toda vez que uma página é renderizada. Para saber mais sobre ele, consulte a [documentação do `scrollBehavior` do `vue-router`](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
 
 <div class="Alert Alert-blue">
 
-Starting from v2.9.0, you can use a file to overwrite the router scrollBehavior, this file should be placed in `~/app/router.scrollBehavior.js` (note: filename is case-sensitive if running on Windows).
+Desde a versão 2.9.0 do Nuxt, você pode usar um ficheiro para sobrescrever o `scrollBehavior` do roteador, este ficheiro deve ser colocado dentro de `~/app/router.scrollBehavior.js` (Repare que: o nome do ficheiro é sensível a caixa dos caracteres se estiver executando no Windows).
 
 </div>
 
 ::alert{type="warning"}
-The `router.scrollBehavior.js` file must be in the `app` folder, which in turn is in the project's root.
+O ficheiro `router.scrollBehavior.js` deve estar dentro da pasta `app`, a qual por sua vez está dentro da raiz do projeto.
 ::
 
-You can see Nuxt default `router.scrollBehavior.js` file here: [packages/vue-app/template/router.scrollBehavior.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/router.scrollBehavior.js).
+Você pode consultar o ficheiro `router.scrollBehavior.js` padrão do Nuxt aqui: [packages/vue-app/template/router.scrollBehavior.js](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/router.scrollBehavior.js).
 
-Example of forcing the scroll position to the top for every routes:
+Exemplo de forçamento da posição da rolagem ao topo para todas as rotas:
 
 `app/router.scrollBehavior.js`
 
@@ -327,19 +327,19 @@ export default function (to, from, savedPosition) {
 }
 ```
 
-## trailingSlash
+## A propriedade trailingSlash
 
-- Type: `Boolean` or `undefined`
-- Default: `undefined`
-- Available since: v2.10
+- Tipo: `Boolean` ou `undefined`
+- Valor padrão: `undefined`
+- Disponível desde versão: 2.10
 
-If this option is set to true, trailing slashes will be appended to every route. If set to false, they'll be removed.
+Se esta opção estiver definida para `true`, rastos de barras serão acrescentados à cada rota. Se estiver definida para `false`, os rastos de barras serão removidos.
 
-**Attention**: This option should not be set without preparation and has to be tested thoroughly. When setting `router.trailingSlash` to something else than `undefined`, the opposite route will stop working. Thus 301 redirects should be in place and your _internal linking_ has to be adapted correctly. If you set `trailingSlash` to `true`, then only `example.com/abc/` will work but not `example.com/abc`. On false, it's vice-versa
+**Atenção**: Esta opção não deve ser definida sem preparação e tem de ser testada cuidadosamente. Quando estiver definindo `router.trailingSlash` para alguma coisa diferente de `undefined`, a rota oposta parará de funcionar. Assim os redirecionamentos de 301 deve estar no lugar e a sua _ligação interna_ tem de estar corretamente adaptada. Se você definir a propriedade `trailingSlash` para `true`, então apenas o `example.com/abc/` funcionará mas não o `example.com/abc`. Se você definir para `false`, será o contrário.
 
-### Example behavior (with child routes)
+### Exemplo do comportamento (com as rotas filhas)
 
-For a directory with this structure:
+Para um diretório com esta estrutura:
 
 ```bash
 -| pages/
@@ -350,7 +350,7 @@ For a directory with this structure:
 -----| index.vue
 ```
 
-This is the behavior for each possible setting of `trailingSlash`:
+Este é o comportamento para cada possível definição da propriedade `trailingSlash`:
 
 ::code-group
 ```bash [default]

--- a/content/pt/docs/5.configuration-glossary/26.configuration-runtime-config.md
+++ b/content/pt/docs/5.configuration-glossary/26.configuration-runtime-config.md
@@ -1,25 +1,25 @@
 ---
-title: RuntimeConfig properties
+title: As propriedades do RuntimeConfig
 navigation.title: RuntimeConfig
-description: Runtime config allows passing dynamic config and environment variables to the nuxt context.
+description: O runtimeConfig permite a passagem de configurações dinâmicas e variáveis de ambiente ao contexto do Nuxt.
 menu: runtimeConfig
 category: configuration-glossary
 ---
-# Runtime config properties
+# As propriedades do RuntimeConfig
 
-Runtime config allows passing dynamic config and environment variables to the nuxt context. For more information of usage, please see [runtime config guide](/docs/directory-structure/nuxt-config#runtimeconfig)
+O runtimeConfig permite a passagem de configurações dinâmicas e variáveis de ambiente ao contexto do Nuxt. Para mais informações de uso, consulte o [guia do runtimeConfig](/docs/directory-structure/nuxt-config#a-propriedade-runtimeconfig)
 
 ---
 
 
 ## `publicRuntimeConfig`
 
-- Type: `Object`
+- Tipo: `Object`
 
-Value of this object is **accessible from both client and server** using `$config`.
+O valor deste objeto é **acessível a partir de ambos cliente e servidor** com uso do `$config`.
 
 ## `privateRuntimeConfig`
 
-- Type: `Object`
+- Tipo: `Object`
 
-Value of this object is accessible from **server only** using `$config`. Overrides `publicRuntimeConfig` for server.
+O valor deste objeto é acessível apenas a partir do **servidor** com uso do `$config`. Sobrescreve o `publicRuntimeConfig` para o servidor.

--- a/content/pt/docs/5.configuration-glossary/27.configuration-server.md
+++ b/content/pt/docs/5.configuration-glossary/27.configuration-server.md
@@ -1,33 +1,33 @@
 ---
-title: The server Property
+title: A propriedade server
 navigation.title: server
-description: Nuxt let you define the server connection variables for your application inside nuxt.config.js.
+description: O Nuxt permite você definir as variáveis de conexão do servidor para a sua aplicação dentro do ficheiro nuxt.config.js.
 menu: server
 category: configuration-glossary
 ---
-# The server property
+# A propriedade server
 
-Nuxt let you define the server connection variables for your application inside `nuxt.config.js`.
+O Nuxt permite você definir as variáveis de conexão do servidor para a sua aplicação dentro do ficheiro `nuxt.config.js`.
 
 ---
 
-- Type: `Object`
+- Tipo: `Object`
 
-## Basic example:
+## Exemplo Básico:
 
 ```js{}[nuxt.config.js]
 export default {
   server: {
-    port: 8000, // default: 3000
-    host: '0.0.0.0', // default: localhost,
+    port: 8000, // valor padrão: 3000
+    host: '0.0.0.0', // valor padrão: localhost,
     timing: false
   }
 }
 ```
 
-This lets you specify the [host and port](/docs/features/configuration#edit-host-and-port) for your Nuxt server instance.
+Isto permite você especificar o [hospedeiro e a porta](/docs/features/configuration#editar-o-hospedeiro-e-a-porta) para a sua instância de servidor do Nuxt.
 
-## Example using HTTPS configuration
+## Exemplo usando a configuração do HTTPS
 
 ```js{}[nuxt.config.js]
 import path from 'path'
@@ -43,9 +43,9 @@ export default {
 }
 ```
 
-You can find additional information on creating server keys and certificates on `localhost` on [certificates for localhost](https://letsencrypt.org/docs/certificates-for-localhost/) article.
+Você pode encontrar informações adicionais sobre a criação de chaves e certificados de servidor no `localhost` no artigo [certificados para o `localhost`](https://letsencrypt.org/docs/certificates-for-localhost/).
 
-## Example using sockets configuration
+## Exemplo usando configuração do sockets
 
 ```js{}[nuxt.config.js]
 export default {
@@ -55,16 +55,16 @@ export default {
 }
 ```
 
-## timing
+## A propriedade timing
 
-- Type: `Object` or `Boolean`
-- Default: `false`
+- Tipo: `Object` ou `Boolean`
+- Valor padrão: `false`
 
-Enabling the `server.timing` option adds a middleware to measure the time elapsed during server-side rendering and adds it to the headers as 'Server-Timing'
+A ativação da opção `server.timing` adiciona um intermediário para medir o tempo decorrido durante a renderização no lado do servidor e adiciona ele aos cabeçalhos como `Server-Timing`
 
-### Example using timing configuration
+### Exemplo usando a configuração do timing
 
-`server.timing` can be an object for providing options. Currently, only `total` is supported (which directly tracks the whole time spent on server-side rendering)
+O `server.timing` pode ser um objeto para fornecimento de opções. Atualmente, apenas o `total` é suportado (o qual rastreia diretamente o tempo todo gasto na renderização do lado do servidor)
 
 ```js{}[nuxt.config.js]
 export default {
@@ -76,33 +76,33 @@ export default {
 }
 ```
 
-### Using timing API
+### Usando a API do timing
 
-The `timing` API is also injected into the `response` on server-side when `server.time` is enabled.
+A API do `timing` é também injetada dentro do `response` no lado do servidor quando o `server.time` estiver ativado.
 
-#### Syntax
+#### A Sintaxe
 
 ```js
 res.timing.start(name, description)
 res.timing.end(name)
 ```
 
-#### Example using timing in serverMiddleware
+#### Exemplo usando o timing dentro do serverMiddleware
 
 ```js
 export default function (req, res, next) {
   res.timing.start('midd', 'Middleware timing description')
-  // server side operation..
+  // operação no lado do servidor...
   // ...
   res.timing.end('midd')
   next()
 }
 ```
 
-Then `server-timing` head will be included in response header like:
+Depois o cabeçalho `server-timing` será incluído dentro do cabeçalho de resposta como:
 
 ```bash
 Server-Timing: midd;desc="Middleware timing description";dur=2.4
 ```
 
-Please refer to [Server-Timing MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) for more details.
+Recorra ao [MDN do server-timing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) para mais detalhes.

--- a/content/pt/docs/5.configuration-glossary/28.configuration-servermiddleware.md
+++ b/content/pt/docs/5.configuration-glossary/28.configuration-servermiddleware.md
@@ -1,82 +1,82 @@
 ---
-title: The serverMiddleware Property
+title: A propriedade serverMiddleware
 navigation.title: serverMiddleware
-description: Define server-side middleware.
+description: Define o intermediário no lado do servidor.
 menu: serverMiddleware
 category: configuration-glossary
 ---
-# The serverMiddleware property
+# A propriedade serverMiddleware
 
-Define server-side middleware.
+Define o intermediário no lado do servidor.
 
 ---
 
-- Type: `Array`
-  - Items: `String` or `Object` or `Function`
+- Tipo: `Array`
+  - Itens: `String` ou `Object` ou `Function`
 
-Nuxt internally creates a [connect](https://github.com/senchalabs/connect) instance that you can add your own custom middleware to. This allows us to register additional routes (typically `/api` routes) **without need for an external server**.
+O Nuxt internamente cria um instância de [connect](https://github.com/senchalabs/connect) que você pode adicionar ao seu próprio intermediário. Isto permite-nos registar rotas adicionais (normalmente rotas `/api`) **sem precisar de um servidor externo**.
 
-Because connect itself is a middleware, registered middleware will work with both `nuxt start` and also when used as a middleware with programmatic usages like [express-template](https://github.com/nuxt-community/express-template). Nuxt [Modules](/docs/directory-structure/modules) can also provide `serverMiddleware` using [this.addServerMiddleware()](/docs/internals-glossary/internals-module-container#addservermiddleware-middleware)
+Por `connect` mesmo ser um intermediário, o intermediário registado funcionará com ambos `nuxt start` e também quando usado como um intermediário com uso programático como o [express-template](https://github.com/nuxt-community/express-template). Os [Módulos](/docs/directory-structure/modules) do Nuxt pode também fornecer o `serverMiddleware` usando o [this.addServerMiddleware()](/docs/internals-glossary/internals-module-container#addservermiddleware-middleware)
 
-Additional to them, we introduced a `prefix` option which defaults to `true`. It will add the router base to your server middlewares.
+Adicionalmente a eles, nós introduzimos uma opção `prefix` a qual o valor padrão será `true`. Ela adicionará uma base de roteador para os intermediários do seu servidor. 
 
-**Example:**
+**Exemplo:**
 
-- Server middleware path: `/server-middleware`
-- Router base: `/admin`
-- With `prefix: true` (default): `/admin/server-middleware`
-- With `prefix: false`: `/server-middleware`
+- Caminho do intermediário do servidor: `/server-middleware`
+- Base de roteador: `/admin`
+- Com o `prefix: true` (valor padrão): `/admin/server-middleware`
+- Com o `prefix: false`: `/server-middleware`
 
 ## serverMiddleware vs middleware!
 
-Don't confuse it with [routes middleware](/docs/directory-structure/middleware) which are called before each route by Vue in Client Side or SSR. Middleware listed in the `serverMiddleware` property runs server-side **before** `vue-server-renderer` and can be used for server specific tasks like handling API requests or serving assets.
+Não confunda ele com o [intermediários de rotas](/docs/directory-structure/middleware) as quais são chamadas antes de cada rota pelo Vue no lado do cliente ou na renderização no lado do servidor. O intermediário listado dentro da propriedade `serverMiddleware` executa no lado do servidor **antes** do `vue-server-renderer` e pode ser usado para tarefas específicas do servidor como manipulando de requisições de API ou servindo recursos.
 
 ::alert{type="warning"}
-Do not add serverMiddleware to the middleware/ directory.
+Não adicione o `serverMiddleware` ao diretório `middleware/`.
 
-Middleware, are bundled by webpack into your production bundle and run on beforeRouteEnter. If you add serverMiddleware to the middleware/ directory it will be wrongly picked up by Nuxt as middleware and will add wrong dependencies to your bundle or generate errors.
+Os intermediários são empacotados pelo webpack dentro do seu pacote de produção e executam sobre o gatilho `beforeRouteEnter`. Se você adicionar o `serverMiddleware` ao diretório `middleware/` ele será erradamente tomado pelo Nuxt como um intermediário comum e adicionará dependências erradas ao seu pacote ou gerar erros.
 ::
 
-## Usage
+## Uso
 
-If middleware is String Nuxt will try to automatically resolve and require it.
+Se o intermediário for um sequência de caracteres o Nuxt tentará pedir e resolver ele automaticamente.
 
 ```js{}[nuxt.config.js]
 import serveStatic from 'serve-static'
 
 export default {
   serverMiddleware: [
-    // Will register redirect-ssl npm package
+    // Registará o pacote `redirect-ssl` de npm 
     'redirect-ssl',
 
-    // Will register file from project server-middleware directory to handle /server-middleware/* requires
+    // Registará o ficheiro do diretório `server-middleware` do projeto manipular os pedidos de  `/server-middleware/*`
     { path: '/server-middleware', handler: '~/server-middleware/index.js' },
 
-    // We can create custom instances too
+    // Podemos também criar instâncias personalizadas
     { path: '/static2', handler: serveStatic(__dirname + '/static2') }
   ]
 }
 ```
 
 ::alert{type="warning"}
-If you don't want middleware to register for all routes you have to use Object form with specific path, otherwise nuxt default handler won't work!
+Se você não quiser o intermediário para registar para todas rotas, você tem que usar a forma de objeto com um caminho específico, de outra maneira o manipulador padrão do Nuxt não funcionará!
 ::
 
-## Custom Server Middleware
+## Intermediário de Servidor Personalizado
 
-It is also possible to write custom middleware. For more information See [Connect Docs](https://github.com/senchalabs/connect#appusefn).
+É também possível escrever um intermediário personalizado. Para mais informações consulte a [Documentação do `Connect`](https://github.com/senchalabs/connect#appusefn).
 
-Middleware (`server-middleware/logger.js`):
+Intermediário (`server-middleware/logger.js`):
 
 ```js{}[server-middleware/logger.js]
 export default function (req, res, next) {
-  // req is the Node.js http request object
+  // O `req` é o objeto de requisição http do Node.js
   console.log(req.url)
 
-  // res is the Node.js http response object
+  // O `res` é o objeto de resposta http do Node.js
 
-  // next is a function to call to invoke the next middleware
-  // Don't forget to call next at the end if your middleware is not an endpoint!
+  // O `next` é uma função para chamar o próximo intermediário
+  // Não esqueça de chamar o `next` no final se o seu intermediário não for um ponto final!
   next()
 }
 ```
@@ -85,9 +85,9 @@ export default function (req, res, next) {
 serverMiddleware: ['~/server-middleware/logger']
 ```
 
-## Custom API endpoint
+## Ponto Final de API Personalizada
 
-A server middleware can also extend Express. This allows the creation of REST endpoints.
+Um intermediário de servidor pode também estender o `Express`. Isto permite a criação de pontos finais de REST.
 
 ```js{}[server-middleware/rest.js]
 const bodyParser = require('body-parser')
@@ -107,9 +107,9 @@ serverMiddleware: [
 ],
 ```
 
-## Object Syntax
+## A Sintaxe de Objeto
 
-If your server middleware consists of a list of functions mapped to paths:
+Se o seu intermediário de servidor compreende em uma lista de funções mapeadas para os caminhos:
 
 ```js
 export default {
@@ -121,7 +121,7 @@ export default {
 }
 ```
 
-You can alternatively pass an object to define them, as follows:
+Você pode alternativamente passar um objeto para definir eles, como o seguinte:
 
 ```js
 export default {

--- a/content/pt/docs/5.configuration-glossary/29.configuration-srcdir.md
+++ b/content/pt/docs/5.configuration-glossary/29.configuration-srcdir.md
@@ -1,22 +1,22 @@
 ---
-title: The srcDir Property
+title: A propriedade srcDir
 navigation.title: srcDir
-description: Define the source directory of your Nuxt application.
+description: Define o diretório da fonte da sua aplicação Nuxt.
 menu: srcDir
 category: configuration-glossary
 ---
-# The srcDir property
+# A propriedade srcDir
 
-Define the source directory of your Nuxt application.
+Define o diretório da fonte da sua aplicação Nuxt.
 
 ---
 
-- Type: `String`
-- Default: [rootDir value](/docs/configuration-glossary/configuration-rootdir)
+- Tipo: `String`
+- Valor padrão: [valor do rootDir](/docs/configuration-glossary/configuration-rootdir)
 
-If a relative path is specified it will be relative to the `rootDir`.
+Se um caminho relativo for especificado ele será relativo ao `rootDir`.
 
-Example 1: Prerequisites:
+Exemplo 1: Pré-requisitos:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -30,7 +30,7 @@ export default {
   }
 ```
 
-works with the following folder structure (note that nuxt.config is listed in the app directory)
+funciona com a seguinte estrutura de pasta (nota que o ficheiro `nuxt.config` é listado dentro do diretório `app`, diretório da aplicação)
 
 ```bash
 -| app/
@@ -48,25 +48,25 @@ works with the following folder structure (note that nuxt.config is listed in th
 ------| store/
 ```
 
-Example 2:
+Exemplo 2:
 
-Instead of example 1 you can also move the nuxt.config into your `client` folder. In this case you only need to specify `client` as the `rootDir` and you can leave `srcDir` empty:
+No lugar do exemplo 1 você pode também mover o ficheiro `nuxt.config` dentro da sua pasta `client`. Neste caso você apenas precisa especificar o `client` como o `rootDir` e você pode deixar o `srcDir` vazio.
 
-Prerequisites:
+Pré-requisitos:
 
 ```js{}[nuxt.config.js]
 export default {
-  srcDir: '' // or just remove it
+  srcDir: '' // ou apenas remova ele
 }
 ```
 
 ```js{}[package.json]
   "script": {
-    "dev": "yarn nuxt client" // this sets client as the rootDir
+    "dev": "yarn nuxt client" // isto define a pasta `client` como o `rootDir`
   }
 ```
 
-works with the following folder structure (note that nuxt.config is listed in the client directory)
+funciona com a seguinte estrutura de pasta (nota que o `nuxt.config` está listado dentro do diretório `client`, diretório do cliente)
 
 ```bash
 -| app/

--- a/content/pt/docs/5.configuration-glossary/3.configuration-builddir.md
+++ b/content/pt/docs/5.configuration-glossary/3.configuration-builddir.md
@@ -1,18 +1,18 @@
 ---
-title: The buildDir Property
+title: A propriedade builDir
 navigation.title: buildDir
-description: Define the dist directory for your Nuxt application
+description: Define o diretório de dist (distribuição) para a sua aplicação Nuxt 
 menu: buildDir
 category: configuration-glossary
 ---
-# The buildDir property
+# A propriedade builDir
 
-Define the dist directory for your Nuxt application
+Define o diretório de dist (distribuição) para a sua aplicação Nuxt
 
 ---
 
-- Type: `String`
-- Default: `.nuxt`
+- Tipo: `String`
+- Padrão: `.nuxt`
 
 ```js{}[nuxt.config.js]
 export default {
@@ -20,4 +20,4 @@ export default {
 }
 ```
 
-By default, many tools assume that `.nuxt` is a hidden directory, because its name starts with a dot. You can use this option to prevent that.
+Por padrão, muitas ferramentas assumem que o diretório `.nuxt` é um diretório oculto, porque o seu nome começa com um ponto. Você pode usar esta opção para prevenir isso.

--- a/content/pt/docs/5.configuration-glossary/30.configuration-ssr.md
+++ b/content/pt/docs/5.configuration-glossary/30.configuration-ssr.md
@@ -1,30 +1,30 @@
 ---
-title: The ssr Property
+title: A propriedade ssr
 navigation.title: ssr
-description: Change default nuxt ssr value
+description: Muda o valor padrão do ssr do Nuxt
 menu: ssr
 category: configuration-glossary
 ---
-# The ssr property
+# A propriedade ssr
 
-Change default nuxt ssr value
+Muda o valor padrão do ssr do Nuxt
 
 ---
 
-- Type: `boolean`
-- Default: `true`
-- Possible values:
-  - `true`: Server-side rendering enabled
-  - `false`: No server-side rendering (only client-side rendering)
+- Tipo: `boolean`
+- Valor padrão: `true`
+- Possíveis valores:
+  - `true`: Renderização no Lado do Servidor ativada 
+  - `false`: Sem renderização no lado do servidor (apenas renderização no lado do cliente)
 
-> You can set this option to `false` when you want **only client side rendering**
+> Você pode definir esta opção para `false` quando você quiser **apenas a renderização no lado do cliente**
 
 ```js{}[nuxt.config.js]
 export default {
-  ssr: false // Disable Server Side rendering
+  ssr: false // Desativa a renderização no lado do servidor 
 }
 ```
 
 ::alert{type="next"}
-Previously, `mode` was used to disable or enable server-side rendering. Here is the [`mode` documentation](/docs/configuration-glossary/configuration-mode).
+Anteriormente, o `mode` era usado para desativar e ativar a renderização no lado do servidor. Aqui está a [documentação do `mode`](/docs/configuration-glossary/configuration-mode).
 ::

--- a/content/pt/docs/5.configuration-glossary/31.configuration-target.md
+++ b/content/pt/docs/5.configuration-glossary/31.configuration-target.md
@@ -1,24 +1,24 @@
 ---
-title: The target Property
+title: A propriedade target
 navigation.title: target
-description: Change default nuxt target
+description: Muda o alvo padrão do Nuxt
 menu: target
 category: configuration-glossary
 ---
-# The target property
+# A propriedade target
 
-Change default nuxt target
+Muda o alvo padrão do Nuxt
 
 ---
 
-Deployment targets for Nuxt >= v2.13:
+Alvos do desdobramento para o Nuxt na versão igual ou superior a 2.13:
 
-- Type: `string`
-  - Default: `server`
-  - Possible values:
-    - `'server'`: For server side rendering
-    - `'static'`: For static sites
+- Tipo: `string`
+  - Valor padrão: `server`
+  - Possíveis valores:
+    - `'server'`: Para renderização no lado do servidor
+    - `'static'`: Para sítios estáticos
 
-> You can use this option to change default nuxt target for your project using `nuxt.config.js`
+> Você pode usar esta opção para mudar o alvo padrão do Nuxt para o seu projeto usando o ficheiro `nuxt.config.js`
 
-To learn more about the target option check out the [deployment targets section](/docs/features/deployment-targets).
+Para saber mais sobre a opção `target` consulte a [secção de alvos do desdobramento](/docs/features/deployment-targets).

--- a/content/pt/docs/5.configuration-glossary/32.configuration-telemetry.md
+++ b/content/pt/docs/5.configuration-glossary/32.configuration-telemetry.md
@@ -1,58 +1,58 @@
 ---
-title: The telemetry Property
+title: A propriedade telemetry
 navigation.title: telemetry
-description: Nuxt collects anonymous telemetry data about general usage. This helps us to accurately gauge Nuxt feature usage and customization across all our users.
+description: O Nuxt coleta dados de telemetria anónimos sobre o uso em geral. Isto ajuda-nos avaliar precisamente o uso de funcionalidade e personalização através de todos nossos usuários.
 menu: telemetry
 category: configuration-glossary
 ---
-# The telemetry property
+# A propriedade telemetry
 
-Nuxt collects anonymous telemetry data about general usage. This helps us to accurately gauge Nuxt feature usage and customization across all our users.
+O Nuxt coleta dados de telemetria anónimos sobre o uso em geral. Isto ajuda-nos avaliar precisamente o uso de funcionalidade e personalização através de todos nossos usuários.
 
 ---
 
-## The telemetry Property
+## A propriedade telemetry
 
-> Nuxt v2.13.0 introduces Nuxt Telemetry to collect anonymous telemetry data about general usage. This helps us to accurately gauge Nuxt feature usage and customization across all our users.
+> O versão 2.13.0 introduz o `Nuxt Telemetry (Telemetria do Nuxt)` para coletar dados de telemetria anónimos sobre o uso em geral. Isto ajuda-nos avaliar precisamente o uso de funcionalidade e personalização através de todos nossos usuários.
 
-- Type: `Boolean`
-- Default is based on your user preferences
+- Tipo: `Boolean`
+- Valor padrão é baseado nas preferências do seu usuário
 
-## Why collect Telemetry
+## Porquê coletar a Telemetria
 
-Nuxt has grown a lot from its [initial release](https://github.com/nuxt/nuxt.js/releases/tag/v0.2.0) (7 Nov 2016) and we are keep listening to [community feedback](https://github.com/nuxt/nuxt.js/issues) to improve it.
+O Nuxt tem crescido muito desde o seu [lançamento inicial](https://github.com/nuxt/nuxt.js/releases/tag/v0.2.0) (7 Nov 2016) e nós continuamos ouvindo a [reação da comunidade](https://github.com/nuxt/nuxt.js/issues) para melhorar ele.
 
-However, this manual process only collects feedback from a subset of users that takes the time to fill the issue template and it may have different needs or use-case than you.
+No entanto, este processo manual apenas coleta reações de um subconjunto de usuários que reservam tempo para preencher o modelo de questões e ele pode ter diferentes necessidades ou caso de uso do que você.
 
-Nuxt Telemetry collects **anonymous telemetry data about general usage**. This helps us to accurately gauge feature usage and customization across all our users. This data will let us better understand how Nuxt is used globally, measuring improvements made (DX and performances) and their relevance.
+A Telemetria do Nuxt coleta **coleta dados de telemetria anónimos sobre o uso em geral**. Isto ajuda-nos avaliar precisamente o uso de funcionalidade e personalização através de todos nossos usuários. Estes dados irá permitir-nos entender melhor como o Nuxt é usado globalmente, medindo melhorias feitas (experiência do desenvolvedor e desempenhos) e suas relevâncias.
 
-We collect multiple events:
+Nós coletamos vários eventos:
 
-- Command invoked (nuxt dev, nuxt build, etc)
-- Versions of Nuxt and Node.js
-- General machine information (MacOS/Linux/Windows and if command is run within CI, the CI name)
-- Duration of the Webpack build and average size of the application, as well as the generation stats (when using nuxt generate)
-- What are the public dependency of your project (Nuxt modules)
+- Comando invocado (`nuxt dev`, `nuxt build`, etc)
+- Versões do Nuxt e Node.js
+- Informações da máquina em geral (MacOS/Linux/Windows e se o comando é executado dentro de um CI, o nome do CI)
+- Duração da construção do Webpack e tamanho médio da aplicação, bem como as estatísticas da geração (quando estiver usando o `nuxt generate`)
+- Quais são as dependências públicas do seu projeto (módulos do Nuxt)
 
-The code is open source and available at https://github.com/nuxt/telemetry.
+O código é de código-aberto e está disponível no repositório [nuxt-telemetry](https://github.com/nuxt/telemetry).
 
-## Opting-out
+## Opção de saída
 
-You can disable [Nuxt Telemetry](https://github.com/nuxt/telemetry) for your project with several ways:
+Você pode desativar a [Telemetria do Nuxt](https://github.com/nuxt/telemetry) para seu projeto de várias maneiras:
 
-1. Using `npx nuxt telemetry disable`
+1. Usando o `npx nuxt telemetry disable`
 
 ```bash
 npx nuxt telemetry [status|enable|disable] [-g,--global] [dir]
 ```
 
-2. Using an environment variable
+2. Usando uma variável de ambiente
 
 ```bash
 NUXT_TELEMETRY_DISABLED=1
 ```
 
-3. Setting `telemetry: false` in your `nuxt.config.js`:
+3. Definindo `telemetry: false` dentro do seu ficheiro `nuxt.config.js`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -60,4 +60,4 @@ export default {
 }
 ```
 
-You can learn more about Nuxt Telemetry and the events sent on https://github.com/nuxt/telemetry
+Você pode saber mais sobre a Telemetria do Nuxt e os eventos enviados no repositório [nuxt-telemetry](https://github.com/nuxt/telemetry) no GitHub.

--- a/content/pt/docs/5.configuration-glossary/33.configuration-transition.md
+++ b/content/pt/docs/5.configuration-glossary/33.configuration-transition.md
@@ -1,25 +1,25 @@
 ---
-title: Transition Properties
+title: As propriedades de transition
 navigation.title: transition
-description: Set the default properties of the page and layout transitions.
+description: Define as propriedades padrão das transições de página e esquema.
 menu: transition
 category: configuration-glossary
 ---
-# Transition properties
+# As propriedades de transition
 
-Set the default properties of the page and layout transitions.
+Define as propriedades padrão das transições de página e esquema.
 
 ---
 
-## The pageTransition Property
+## A propriedade pageTransition
 
-> Nuxt v2.7.0 introduces key "pageTransition" in favor of the "transition" key to consolidate the naming with layout transition keys.
+> A versão 2.7.0 do Nuxt introduz a chave `pageTransition` em favor da chave `transition` para consolidar a nomeação com as chaves de transição de esquema.
 
-- Type: `String` or `Object`
+- Tipo: `String` ou `Object`
 
-> Used to set the default properties of the page transitions.
+> Usada para definir as propriedades padrão das transições de página
 
-Default:
+Valor padrão:
 
 ```js
 {
@@ -31,7 +31,7 @@ Default:
 ```js{}[nuxt.config.js]
 export default {
   pageTransition: 'page'
-  // or
+  // ou
   pageTransition: {
     name: 'page',
     mode: 'out-in',
@@ -42,15 +42,15 @@ export default {
 }
 ```
 
-The transition key in `nuxt.config.js` is used to set the default properties for the page transitions. To learn more about the available keys when the `transition` key is an object, see the [pages transition property](/docs/features/transitions).
+A chave da transição dentro do ficheiro `nuxt.config.js` é usada para definir as propriedades padrão das transições de página. Para saber mais sobre as chaves disponíveis quando a chave `transition` é um objeto, consulte [propriedade da transição de páginas](/docs/features/transitions).
 
-## The layoutTransition Property
+## A propriedade layoutTransition
 
-- Type: `String` or `Object`
+- Tipo: `String` ou `Object`
 
-> Used to set the default properties of the layout transitions. The value provided in the `name` option is configured to work with the name provided in `layout` from your `layouts` folder.
+> Usada para definir as propriedades padrão das transições de esquema. O valor fornecido dentro da opção `name` é configurado para funcionar com o nome fornecido no `layout` da sua pasta `layouts`.
 
-Default:
+Valor padrão:
 
 ```js
 {
@@ -62,7 +62,7 @@ Default:
 ```js{}[nuxt.config.js]
 export default {
   layoutTransition: 'layout'
-  // or
+  // ou
   layoutTransition: {
     name: 'layout',
     mode: 'out-in'

--- a/content/pt/docs/5.configuration-glossary/34.configuration-vue-config.md
+++ b/content/pt/docs/5.configuration-glossary/34.configuration-vue-config.md
@@ -1,22 +1,22 @@
 ---
-title: The vue.config Property
+title: A propriedade vue.config
 navigation.title: vue.config
-description: A config object for Vue.config
+description: Um objeto de configuração para o Vue.config
 menu: vue.config
 category: configuration-glossary
 ---
-# The vue.config property
+# A propriedade vue.config
 
-A config object for Vue.config
+Um objeto de configuração para o `Vue.config`
 
 ---
 
-- Type: `Object`
-- Default: `{ silent: !isDev, performance: isDev }`
+- Tipo: `Object`
+- Valor padrão: `{ silent: !isDev, performance: isDev }`
 
-> The vue.config property provides a direct configuration bridge for the `Vue.config`
+> A propriedade vue.config fornece uma ponte de configuração direta para o `Vue.config`
 
-**Example**
+**Exemplo**
 
 ```js{}[nuxt.config.js]
 export default {
@@ -29,13 +29,13 @@ export default {
 }
 ```
 
-This configuration will lead to the following Vue.config:
+Esta configuração resultará no seguinte `Vue.config`:
 
 ```js
 Vue.config.productionTip // true
 Vue.config.devtools // false
-Vue.config.silent // !isDev [default value]
-Vue.config.performance // isDev [default value]
+Vue.config.silent // !isDev [valor padrão]
+Vue.config.performance // isDev [valor padrão]
 ```
 
-To learn more about the `Vue.config` API, check out the [official Vue documentation](https://vuejs.org/v2/api/#Global-Config)
+Para saber mais sobre a API do `Vue.config`, consulte a [documentação oficial do Vue](https://vuejs.org/v2/api/#Global-Config)

--- a/content/pt/docs/5.configuration-glossary/35.configuration-watch.md
+++ b/content/pt/docs/5.configuration-glossary/35.configuration-watch.md
@@ -1,21 +1,21 @@
 ---
-title: The watch Property
+title: A propriedade watch
 navigation.title: watch
-description: The watch property lets you watch custom files for restarting the server.
+description: A propriedade watch permite você observar ficheiros personalizados para reinicialização do servidor.
 menu: watch
 category: configuration-glossary
 ---
-# The watch property
+# A propriedade watch
 
-The watch property lets you watch custom files for restarting the server.
+A propriedade `watch` permite você observar ficheiros personalizados para reinicialização do servidor.
 
 ---
 
-- Type: `Object`
-- Default: `[]`
+- Tipo: `Object`
+- Valor padrão: `[]`
 
 ```js
 watch: ['~/custom/*.js']
 ```
 
-[chokidar](https://github.com/paulmillr/chokidar) is used to set up the watchers. To learn more about chokidar's pattern options, see the [chokidar API](https://github.com/paulmillr/chokidar#api).
+O [chokidar](https://github.com/paulmillr/chokidar) é usado para definir os observadores. Para saber mais sobre as opções do padrão do chokidar, consulte a [API do chokidar](https://github.com/paulmillr/chokidar#api).

--- a/content/pt/docs/5.configuration-glossary/36.configuration-watchers.md
+++ b/content/pt/docs/5.configuration-glossary/36.configuration-watchers.md
@@ -1,30 +1,30 @@
 ---
-title: The watchers Property
+title: A propriedade watchers
 navigation.title: watchers
-description: The watchers property lets you overwrite watchers configuration in your nuxt.config.js.
+description: A propriedade watchers permite você sobrescrever a configuração dos observadores dentro do seu ficheiro nuxt.config.js.
 menu: watchers
 category: configuration-glossary
 ---
-# The watchers property
+# A propriedade watchers
 
-The watchers property lets you overwrite watchers configuration in your nuxt.config.js.
+A propriedade `watchers` permite você sobrescrever a configuração dos observadores dentro do seu ficheiro `nuxt.config.js`.
 
 ---
 
-- Type: `Object`
-- Default: `{}`
+- Tipo: `Object`
+- Valor padrão: `{}`
 
-## chokidar
+## A propriedade chokidar
 
-- Type: `Object`
-- Default: `{}`
+- Tipo: `Object`
+- Valor padrão: `{}`
 
-To learn more about chokidar options, see the [chokidar API](https://github.com/paulmillr/chokidar#api).
+Para saber mais sobre as opções do `chokidar`, consulte a [API do chokidar](https://github.com/paulmillr/chokidar#api).
 
-## webpack
+## A propriedade webpack
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Valor padrão:
 
 ```js
 watchers: {
@@ -35,10 +35,10 @@ watchers: {
 }
 ```
 
-To learn more about webpack watchOptions, see the [webpack documentation](https://webpack.js.org/configuration/watch/#watchoptions).
+Para saber mais sobre as opções de observação do webpack, consulte a [documentação do webpack](https://webpack.js.org/configuration/watch/#watchoptions).
 
-### What's next
+### O que se segue
 
 ::alert{type="next"}
-Check out the [Internals Glossary book](/docs/internals-glossary/$nuxt)
+Consulte o livro [Glossário de Interiores](/docs/internals-glossary/$nuxt)
 ::

--- a/content/pt/docs/5.configuration-glossary/4.configuration-cli.md
+++ b/content/pt/docs/5.configuration-glossary/4.configuration-cli.md
@@ -1,21 +1,21 @@
 ---
-title: The cli Property
+title: A propriedade cli
 navigation.title: cli
-description: Nuxt lets you customize the CLI configuration.
+description: O Nuxt permite você personalizar o configuração da interface de linha de comando.
 menu: cli
 category: configuration-glossary
 ---
-# The cli property
+# A propriedade cli
 
-Nuxt lets you customize the CLI configuration.
+O Nuxt permite você personalizar o configuração da interface de linha de comando.
 
 ---
 
-## badgeMessages
+## A propriedade badgeMessages
 
-- Type `Array`
+- Tipo: `Array`
 
-Add a message to the CLI banner.
+Adiciona uma mensagem à faixa da interface de linha de comando.
 
 ```js{}[nuxt.config.js]
 cli: {
@@ -25,14 +25,14 @@ cli: {
 
 ![](/img/docs/cli-badge.png)
 
-## bannerColor
+## A propriedade bannerColor
 
-- Type: `String`
-  - Default: `'green'`
+- Tipo: `String`
+  - Padrão: `'green'`
 
-Change the color of the 'Nuxt' title in the CLI banner.
+Muda a color do título 'Nuxt' dentro da faixa da interface de linha de comando.
 
-**Available colors:**
+**Cores disponíveis:**
 
 `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`, `redBright`, `greenBright`, `yellowBright`, `blueBright`, `magentaBright`, `cyanBright`, `whiteBright`
 

--- a/content/pt/docs/5.configuration-glossary/5.configuration-css.md
+++ b/content/pt/docs/5.configuration-glossary/5.configuration-css.md
@@ -1,17 +1,17 @@
 ---
-title: The css Property
+title: A propriedade css
 navigation.title: css
-description: Nuxt lets you define the CSS files/modules/libraries you want to set globally (included in every page).
+description: O Nuxt permite você definir ficheiros/módulos/bibliotecas CSS que você quiser para definir globalmente (incluído em todas páginas).
 menu: css
 category: configuration-glossary
 ---
-# The css property
+# A propriedade css
 
-Nuxt lets you define the CSS files/modules/libraries you want to set globally (included in every page).
+O Nuxt permite você definir ficheiros/módulos/bibliotecas CSS que você quiser para definir globalmente (incluído em todas páginas).
 
 ---
 
-In case you want to use `sass` make sure that you have installed `sass` and `sass-loader` packages. If you didn't just
+No caso de você quiser usar `sass` certifique-se que você tenha instalado os pacotes `sass` e `sass-loader`. Se você não tiver, apenas
 
 ::code-group
 ```sh [Yarn]
@@ -22,27 +22,27 @@ npm install --save-dev sass sass-loader@10
 ```
 ::
 
-- Type: `Array`
-  - Items: `string`
+- Tipo: `Array`
+  - Itens: `string`
 
 ```js{}[nuxt.config.js]
 export default {
   css: [
-    // Load a Node.js module directly (here it's a Sass file)
+    // Carrega um módulo de Node.js diretamente (aqui está um ficheiro Sass)
     'bulma',
-    // CSS file in the project
+    // Ficheiro CSS dentro do projeto
     '@/assets/css/main.css',
-    // SCSS file in the project
+    // Ficheiro SCSS dentro do projeto
     '@/assets/css/main.scss'
   ]
 }
 ```
 
-Nuxt will automatically guess the file type by its extension and use the appropriate pre-processor loader for webpack. You will still need to install the required loader if you need to use them.
+O Nuxt irá automaticamente adivinhar o tipo do ficheiro pela sua extensão e usar o carregador do pré-processador adequado para o webpack. Você continuará a precisar instalar o carregador exibido se você precisar usar eles.
 
-### Style Extensions
+### Extensões de Estilo
 
-You can omit the file extension for CSS/SCSS/Postcss/Less/Stylus/... files listed in the css array in your nuxt config file.
+Você pode omitir a extensão do ficheiro para os ficheiros CSS/SCSS/PostCSS/Less/Stylus listados no array css dentro do seu ficheiro `nuxt.config`.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -51,7 +51,7 @@ export default {
 ```
 
 ::alert{type="warning"}
-If you have two files with the same name e.g. `main.scss` and `main.css`, and don't specify an extension in the css array entry, e.g. `css: ['~/assets/css/main']`, then only one file will be loaded depending on the order of `styleExtensions`. In this case only the `css` file will be loaded and the `scss` file will be ignored because `css` comes first in the default `styleExtension` array.
+Se você tem dois ficheiros com o mesmo nome por exemplo `main.scss` e `main.css`, e não especificar uma extensão na entrada do array css, por exemplo `css: ['~/assets/css/main']`, então apenas um ficheiro será carregado dependendo da ordem do `styleExtensions`. Neste caso apenas o ficheiro `css` será carregado e o ficheiro `scss` será ignorado porque o `css` vem primeiro no array `styleExtension` padrão.
 ::
 
-Default order: `['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']`
+Ordem padrão: `['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']`

--- a/content/pt/docs/5.configuration-glossary/6.configuration-components.md
+++ b/content/pt/docs/5.configuration-glossary/6.configuration-components.md
@@ -1,79 +1,80 @@
 ---
-title: The components Property
+title: A propriedade components
 navigation.title: components
-description: 'Nuxt 2.13+ can scan and auto import your components'
+description: 'O Nuxt 2.13+ pode examinar e importar automaticamente os seus componentes'
 menu: components
 category: configuration-glossary
 ---
-# The components property
+# A propriedade components
 
-Nuxt 2.13+ can scan and auto import your components using @nuxt/components module
+O Nuxt 2.13+ pode examinar e importar automaticamente os seus componentes usando o módulo `@nuxt/components`
 
 ---
 
 ::alert
-It is possible to use this feature with Nuxt 2.10 - 2.12. Just manually install and add `@nuxt/components` to `buildModules` inside `nuxt.config`.
+É possível usar esta funcionalidade com Nuxt 2.10 - 2.12. Apenas instale manualmente e adicione o `@nuxt/components` ao `buildModules` dentro do ficheiro `nuxt.config.js`.
 ::
 
-- Type: `Boolean` or `Array`
-- Default: `false`
+- Tipo: `Boolean` ou `Array`
+- Valor padrão: `false`
 
-When set to `true` or an options object, Nuxt will include [@nuxt/components](https://github.com/nuxt/components) and auto-import your components wherever you use them within your pages, layouts (and other components).
+Quando definir para `true` ou para um objeto de opções, o Nuxt incluirá [`@nuxt/components`](https://github.com/nuxt/components) e importar automaticamente o seus componentes sempre que você user eles dentro das suas páginas, esquemas (e outros componentes).
 
 ::alert{type="info"}
-For more information on how to use, please refer to [component auto-discovery documentation](/docs/features/component-discovery) for more information.
+Para mais informações de como usar, recorra a [documentação da descoberta automática de componente](/docs/features/component-discovery) para mais detalhes.
 ::
 
-## Configuration
+## Configuração
 
 ```js{}[nuxt.config.js]
 export default {
-  // This will automatically load components from `~/components`
+  // Isto irá carregar automaticamente os componentes da pasta `~/components`
   components: true
 }
 ```
 
-With `components: true`, by default the `~/components` directory will be included.
+Como o `components: true`, por padrão o diretório `~/components` será incluído.
 
-However you can customize auto-discovery behaviour by providing additional directories to scan:
+No entanto você pode personalizar comportamento da descoberta automática pelo fornecimento de diretórios adicionais para examinar:
+
 
 ```js{}[nuxt.config.js]
 export default {
   components: [
-    // Equivalent to { path: '~/components' }
+    // Equivalente a { path: '~/components' }
     '~/components',
     { path: '~/components/other', extensions: ['vue'] }
   ]
 }
 ```
 
-#### path
+#### A propriedade path
 
-Each item can be either string or object. A string value is a shortcut for `{ path }`.
+Cada item pode ser tanto uma sequência de caracteres ou um objeto. Uma valor de sequência de caracteres é um atalho para `{ path: }`.
 
 ::alert{type="info"}
-Don't worry about ordering or overlapping directories! The components module will take care of it. (Each file will be only matched once with longest path.)
+Não se preocupe com a organização ou sobreposição de diretórios! O módulo de componentes cuidará disso. (Cada ficheiro será correspondido apenas uma vez com o caminho mais longo.)
 ::
 
-### path
+### A propriedade path
 
-- Required
-- Type: `String`
+- Obrigatório
+- Tipo: `String`
 
-Path (absolute or relative) to the directory containing your components.
+O caminho (absoluto ou relativo) para o diretório que contém seus componentes.
 
-You can use Nuxt aliases (`~` or `@`) to refer to directories inside the project or directly use a npm package path (similar to using `require` within your project).
+Você pode usar os apelidos do Nuxt (`~` ou `@`) para referir aos diretórios dentro do projeto ou usar diretamente um caminho de pacote npm (similar ao uso de `require` dentro do seu projeto).
 
-### extensions
+### A propriedade extensions
 
-- Type: `Array<string>`
-- Default:
-  - Extensions supported by Nuxt builder (`builder.supportedExtensions`)
-  - Default supported extensions `['vue', 'js']` or `['vue', 'js', 'ts', 'tsx']` depending on your environment
+- Tipo: `Array<string>`
+- Valor padrão:
+  - Extensões suportadas pelo construtor do Nuxt (`builder.supportedExtensions`)
+  - Extensões padrão suportadas `['vue', 'js']` ou `['vue', 'js', 'ts', 'tsx']` dependendo do seu ambiente
 
-**Example:** Support multi-file component structure
+**Exemplo:** Suportar a estrutura de componente de vários ficheiros
 
-If you prefer to split your SFCs into `.js`, `.vue` and `.css`, you could choose only to scan for `.vue` files:
+Se você preferir separar seus componentes de ficheiro único (SFCs) em `.js`, `.vue` e `.css`, você pode escolher apenas examinar ficheiros `.vue`:
 
 ```
 | components
@@ -90,29 +91,29 @@ export default {
 }
 ```
 
-### pattern
+### A propriedade pattern
 
-- Type: `string` ([glob pattern](https://github.com/isaacs/node-glob#glob-primer))
-- Default: `**/*.${extensions.join(',')}`
+- Tipo: `string` ([padrão glob](https://github.com/isaacs/node-glob#glob-primer))
+- Valor padrão: `**/*.${extensions.join(',')}`
 
-Within the specified `path`, only files that match this pattern will be included.
+Dentro do `path` (caminho) especificado, apenas ficheiros que corresponderem a este padrão serão incluídos.
 
-### ignore
+### A propriedade ignore
 
-- Type: `Array`
-- Items: `string` ([glob pattern](https://github.com/isaacs/node-glob#glob-primer))
-- Default: `[]`
+- Tipo: `Array`
+- Itens: `string` ([padrão glob](https://github.com/isaacs/node-glob#glob-primer))
+- Valor padrão: `[]`
 
-Patterns to exclude files within the specified `path`.
+Padrões para excluir ficheiros dentro do `path` (caminho) especificado.
 
-### prefix
+### A propriedade prefix
 
-- Type: `String`
-- Default: `''` (no prefix)
+- Tipo: `String`
+- Valor padrão: `''` (sem prefixo)
 
-Prefix all matched components.
+Prefixa todos componentes correspondidos.
 
-The example below adds the `awesome-`/`Awesome` prefix to the name of components in the `awesome/` directory.
+O exemplo abaixo adiciona o prefixo `awesome-`/`awesome` ao nome dos componentes dentro do diretório `awesome/`.
 
 ```js
 // nuxt.config.js
@@ -140,52 +141,52 @@ export default {
 </template>
 ```
 
-### pathPrefix
+### A propriedade pathPrefix
 
-- Type: `Boolean`
-- Default: `true`
+- Tipo: `Boolean`
+- Valor padrão: `true`
 
-Prefix component name by its path.
+Prefixa o nome do componente pelo seu caminho.
 
-### watch
+### A propriedade watch
 
-- Type: `Boolean`
-- Default: `true`
+- Tipo: `Boolean`
+- Valor padrão: `true`
 
-Watch the specified `path` for changes, including file additions and file deletions.
+Observa mudanças no `path` (caminho) especificado, incluindo adição e eliminação de ficheiros.
 
-### transpile
+### A propriedade transpile
 
-- Type: `Boolean`
-- Default: `'auto'`
+- Tipo: `Boolean`
+- Valor padrão: `'auto'`
 
-Transpile specified `path` using [`build.transpile`](/docs/configuration-glossary/configuration-build#transpile). By default (`'auto'`) it will set `transpile: true` if `node_modules/` is in `path`.
+Transpila o `path` (caminho) especificado usando o [`build.transpile`](/docs/configuration-glossary/configuration-build#transpile). Por padrão (`'auto'`) definirá `transpile: true` se o `node_modules` estiver dentro `path` (caminho).
 
-### level
+### A propriedade level
 
-- Type: `Number`
-- Default: `0`
+- Tipo: `Number`
+- Valor padrão: `0`
 
-Levels are used to define allow overwriting components that have the same name in two different directories. This can be useful for library authors who want to allow users to override their components, or for custom themes.
+Níveis são usados para definir permissão sobrescrevendo componentes que tem o mesmo nome dentro dentro de diretórios diferentes. Isto pode ser útil para autores de bibliotecas que desejam permitir os usuários sobrescrever seus componentes, ou personalizar os temas.
 
 ```js
 export default {
   components: [
-    '~/components', // default level is 0
+    '~/components', // O nível padrão é 0
     { path: 'my-theme/components', level: 1 }
   ]
 }
 ```
 
-A component in `~/components` will then overwrite one with the same name in `my-theme/components`. The lowest value takes priority.
+Um componente dentro de `~/components` irá então sobrescrever um componente com o mesmo nome dentro de `my-theme/components`. O valor mais baixo recebe prioridade.
 
-## Advanced
+## Avançado
 
-### Overwriting Components
+### Sobrescrevendo Componentes
 
-It is possible to have a way to overwrite components using the [level](#level) option. This is very useful for modules and theme authors.
+É possível ter uma maneira para sobrescrever componentes usando a opção [level](#a-propriedade-level). Isto é muito útil para autores de módulos e temas.
 
-Considering this structure:
+Considerando esta estrutura:
 
 ```bash
 | node_modules/
@@ -196,24 +197,24 @@ Considering this structure:
 ---| Header.vue
 ```
 
-Then defining in the `nuxt.config`:
+Então definindo dentro do `nuxt.config`:
 
 ```js
 components: [
-  '~/components', // default level is 0
+  '~/components', // O nível padrão é 0
   { path: 'node_modules/my-theme/components', level: 1 }
 ]
 ```
 
-Our `components/Header.vue` will overwrite our theme component since the lowest level takes priority.
+O nosso `components/Header.vue` sobrescreverá o nosso componente do tema visto que o valor nível mais baixo recebe prioridade.
 
-### Library Authors
+### Autores de Biblioteca
 
-Making Vue Component libraries with automatic tree-shaking and component registration is now super easy ✨
+Produzir bibliotecas de componentes de Vue com sacudidela de árvore (tree-shaking) automática e registo de componente é agora super fácil✨
 
-This module exposes a hook named `components:dirs` so you can easily extend the directory list without requiring user configuration in your Nuxt module.
+Este módulo expõe um gatilho nomeado `components:dirs` assim você pode facilmente estender a lista de diretório sem a exigência de configuração do usuário dentro do seu módulo do Nuxt.
 
-Imagine a directory structure like this:
+Imagina uma estrutura de diretório como esta:
 
 ```bash
 | node_modules/
@@ -227,14 +228,14 @@ Imagine a directory structure like this:
 | nuxt.config.js
 ```
 
-Then in `awesome-ui/nuxt.js` you can use the `components:dir` hook:
+Depois dentro `awesome-ui/nuxt.js` você pode usar o gatilho `components:dir`:
 
 ```js
 import { join } from 'path'
 
 export default function () {
   this.nuxt.hook('components:dirs', dirs => {
-    // Add ./components dir to the list
+    // Adiciona diretório ./components à lista
     dirs.push({
       path: join(__dirname, 'components'),
       prefix: 'awesome'
@@ -243,7 +244,7 @@ export default function () {
 }
 ```
 
-That's it! Now in your project, you can import your ui library as a Nuxt module in your `nuxt.config.js`:
+E é isso! Agora dentro do seu projeto, você pode importar sua biblioteca de UI como um módulo do Nuxt dentro do seu `nuxt.config.js`:
 
 ```js
 export default {
@@ -251,7 +252,7 @@ export default {
 }
 ```
 
-And directly use the module components (prefixed with `awesome-`), our `pages/index.vue`:
+E use o módulo de componentes diretamente (prefixado com `awesome-`), em nossa `pages/index.vue`:
 
 ```vue
 <template>
@@ -262,6 +263,6 @@ And directly use the module components (prefixed with `awesome-`), our `pages/in
 </template>
 ```
 
-It will automatically import the components only if used and also support HMR when updating your components in `node_modules/awesome-ui/components/`.
+Ele importará automaticamente os componentes somente se usado e se também suportar HMR quando estiver atualizando seus componentes dentro de `node_modules/awesome-ui/components/`.
 
-**Next**: publish your `awesome-ui` module to [npm](https://www.npmjs.com) and share it with the other Nuxters ✨
+**Proximo**: publicar o seu módulo `awesome-ui` no [npm](https://www.npmjs.com) e partilhar ele com outros Nuxteres ✨

--- a/content/pt/docs/5.configuration-glossary/7.configuration-dev.md
+++ b/content/pt/docs/5.configuration-glossary/7.configuration-dev.md
@@ -1,25 +1,25 @@
 ---
-title: The dev Property
+title: A propriedade dev
 navigation.title: dev
-description: Define the development or production mode.
+description: Define o modo de desenvolvimento ou produção.
 menu: dev
 category: configuration-glossary
 ---
-# The dev property
+# A propriedade dev
 
-Define the development or production mode.
+Define o modo de desenvolvimento ou produção.
 
 ---
 
-- Type: `Boolean`
-- Default: `true`
+- Tipo: `Boolean`
+- Valor padrão: `true`
 
-This property is overwritten by the nuxt commands:
+Esta propriedade é sobrescrita pelos comandos do Nuxt:
 
-- `dev` is forced to `true` with `nuxt`
-- `dev` is forced to `false` with `nuxt build`, `nuxt start` and `nuxt generate`
+- `dev` é forçado para `true` com o comando `nuxt`
+- `dev` é forçado para `false` com o comando `nuxt build`, `nuxt start` e `nuxt generate`
 
-This property should be used when using [Nuxt programmatically](/docs/internals-glossary/nuxt):
+Esta propriedade deve ser usada quando estiver usando o [Nuxt programaticamente](/docs/internals-glossary/nuxt):
 
 ```js{}[nuxt.config.js]
 export default {
@@ -32,17 +32,17 @@ const { Nuxt, Builder } = require('nuxt')
 const app = require('express')()
 const port = process.env.PORT || 3000
 
-// We instantiate Nuxt with the options
+// Instanciámos o Nuxt com as opções
 const config = require('./nuxt.config.js')
 const nuxt = new Nuxt(config)
 app.use(nuxt.render)
 
-// Build only in dev mode
+// Construa somente no de desenvolvimento
 if (config.dev) {
   new Builder(nuxt).build()
 }
 
-// Listen the server
+// Oiça o servidor
 app.listen(port, '0.0.0.0').then(() => {
   console.log(`Server is listening on port: ${port}`)
 })

--- a/content/pt/docs/5.configuration-glossary/8.configuration-dir.md
+++ b/content/pt/docs/5.configuration-glossary/8.configuration-dir.md
@@ -1,18 +1,18 @@
 ---
-title: The dir Property
+title: A propriedade dir
 navigation.title: dir
-description: Define the custom directories for your Nuxt application
+description: Define diretórios personalizados para a sua aplicação Nuxt
 menu: dir
 category: configuration-glossary
 ---
-# The dir property
+# A propriedade dir
 
-Define the custom directories for your Nuxt application
+Define diretórios personalizados para a sua aplicação Nuxt
 
 ---
 
-- Type: `Object`
-- Default:
+- Tipo: `Object`
+- Valor padrão:
 
 ```js
 {

--- a/content/pt/docs/5.configuration-glossary/9.configuration-env.md
+++ b/content/pt/docs/5.configuration-glossary/9.configuration-env.md
@@ -1,30 +1,30 @@
 ---
-title: The env property
+title: A propriedade env
 navigation.title: env
-description: Share environment variables between client and server.
+description: Partilhe variáveis de ambiente entre o cliente e o servidor.
 menu: env
 category: configuration-glossary
 ---
 
-# The env property
+# A propriedade env
 
-Share environment variables between client and server.
+Partilhe variáveis de ambiente entre o cliente e o servidor.
 
 ---
 
-- Type: `Object`
+- Tipo: `Object`
 
-> Nuxt lets you create environment variables client side, also to be shared from server side.
+> O Nuxt permite você criar variáveis de ambiente do lado do cliente, e também serem partilhadas a partir do lado do servidor.
 
-The env property defines environment variables that should be available on the client side. They can be assigned using server side environment variables, the [dotenv module](https://github.com/nuxt-community/dotenv-module) ones or similar.
+A propriedade env define variáveis de ambiente que devem estar disponível no lado do cliente. Eles podem ser atribuídos usando variáveis de ambiente do lado do servidor, com o [módulo dotenv](https://github.com/nuxt-community/dotenv-module) ou similares.
 
 ::alert
-For nuxt versions > 2.12+, in cases where environment variables are required at runtime (not build time) it is recommended to subsitute the `env` property with [runtimeConfig properties](/docs/configuration-glossary/configuration-runtime-config): `publicRuntimeOptions` and `privateRuntimeOptions`. 
-<br>
-Learn more with our tutorial about [moving from @nuxtjs/dotenv to runtime config](/tutorials/moving-from-nuxtjs-dotenv-to-runtime-config/).
+Para versões do Nuxt > 2.12+, nos casos onde variáveis de ambiente forem exigidas em tempo de execução (não em tempo de construção) é recomendado para substituir a propriedade `env` com as [propriedades do runtimeConfig](/docs/configuration-glossary/configuration-runtime-config): `publicRuntimeOptions` e `privateRuntimeOptions`.
+
+Aprenda mais com o nosso tutorial sobre o [movendo do @nuxtjs/dotenv para configuração do tempo de execução](/tutorials/moving-from-nuxtjs-dotenv-to-runtime-config/).
 ::
 
-**Make sure to read about `process.env` and `process.env == {}` below for better troubleshooting.**
+**Certifique-se de ler sobre o `process.env` e o `process.env == {}` abaixo para melhor resolução de problemas.**
 
 ```js{}[nuxt.config.js]
 export default {
@@ -34,16 +34,16 @@ export default {
 }
 ```
 
-This lets you create a `baseUrl` property that will be equal to the `BASE_URL` server side environment variable if available or defined. If not, `baseUrl` in client side will be equal to `'http://localhost:3000'`. The server side variable BASE_URL is therefore copied to the client side via the `env` property in the `nuxt.config.js`. Alternatively, the other value is defined (http://localhost:3000).
+Isto permite você criar uma propriedade `baseUrl` que será equal a variável de ambiente `BASE_URL` do lado do servidor se estiver disponível ou definida. Se não, O `baseUrl` no lado do cliente será igual a `'http://localhost:3000'`. A variável `BASE_URL` do lado do cliente é então copiada para o lado do cliente através da propriedade `env` dentro do ficheiro `nuxt.config.js`. Alternativamente, o outro valor é definido (`http://localhost:3000`).
 
-Then, I can access my `baseUrl` variable in 2 ways:
+Depois, Eu posso acessar minha variável `baseUrl` em duas maneiras:
 
-1. Via `process.env.baseUrl`.
-2. Via `context.env.baseUrl`, see [context API](/docs/internals-glossary/context).
+1. Através do `process.env.baseUrl`.
+2. Através do `context.env.baseUrl`, consulte a [API de contexto](/docs/internals-glossary/context).
 
-You can use the `env` property for giving a public token for example.
+Você pode usar a propriedade `env` para atribuir uma chave pública por exemplo.
 
-For the example above, we can use it to configure [axios](https://github.com/mzabriskie/axios).
+Para o exemplo acima, nós podemos usar ele para configurar o [axios](https://github.com/mzabriskie/axios).
 
 ```js{}[plugins/axios.js]
 import axios from 'axios'
@@ -53,30 +53,30 @@ export default axios.create({
 })
 ```
 
-Then, in your pages, you can import axios like this: `import axios from '~/plugins/axios'`
+Então, dentro da suas páginas, você pode importar o `axios` desse jeito: `import axios from '~/plugins/axios'`
 
-## Automatic injection of environment variables
+## Injeção automática de variáveis de ambiente
 
-If you define environment variables starting with `NUXT_ENV_` in the build phase (e.g. `NUXT_ENV_COOL_WORD=freezing nuxt build` or `SET NUXT_ENV_COOL_WORD=freezing & nuxt build` for the Windows console, they'll be automatically injected into the process environment. Be aware that they'll potentially take precedence over defined variables in your `nuxt.config.js` with the same name.
+Se você definir variáveis de ambiente começando com o `NUXT_ENV_` na fase de construção (por exemplo, `NUXT_ENV_COOL_WORD=freezing nuxt build` ou `SET NUXT_ENV_COOL_WORD=freezing & nuxt build` para a consola do Windows, eles serão automaticamente injetados dentro do ambiente de processo). Esteja ciente que eles irão potencialmente ter precedência sobre variáveis definidas dentro do seu ficheiro `nuxt.config.js` com o mesmo nome.
 
 ## process.env == {}
 
-Note that Nuxt uses webpack's `definePlugin` to define the environmental variable. This means that the actual `process` or `process.env` from Node.js is neither available nor defined. Each of the `env` properties defined in nuxt.config.js is individually mapped to `process.env.xxxx` and converted during compilation.
+Nota que o Nuxt usa o `definePlugin` do webpack para definir a variável de ambiente. Isto significa que o atual `process` ou `process.env` do Node.js não está nem disponível nem definido. Cada propriedade de `env` definida dentro do ficheiro `nuxt.config.js` é individualmente mapeado para `process.env.xxxx` e convertido durante a compilação.
 
-Meaning, `console.log(process.env)` will output `{}` but `console.log(process.env.your_var)` will still output your value. When webpack compiles your code, it replaces all instances of `process.env.your_var` with the value you've set it to, e.g.: `env.test = 'testing123'`. If you use `process.env.test` in your code somewhere, it is actually translated to 'testing123'.
+Querendo dizer que, o `console.log(process.env)` imprimirá `{}` mas o `console.log(process.env.your_var)` continuará a imprimir seu valor. Quando o webpack compila o seu código, ele substitui todas instâncias de `process.env.your_var` com o valor que você tem definido, por exemplo: `env.test = 'testing123'`. Se você usar `process.env.test` em algum lugar do seu código, ele é de fato traduzido para `'testing123'`.
 
-before
+antes
 
 ```js
 if (process.env.test == 'testing123')
 ```
 
-after
+depois
 
 ```js
 if ('testing123' == 'testing123')
 ```
 
-## serverMiddleware
+## A propriedade serverMiddleware
 
-As [serverMiddleware](/docs/configuration-glossary/configuration-servermiddleware) is decoupled from the main Nuxt build, `env` variables defined in `nuxt.config.js` are not available there.
+Visto que a propriedade [serverMiddleware](/docs/configuration-glossary/configuration-servermiddleware) é desligada da construção principal do Nuxt, variáveis de `env` definidas dentro do ficheiro `nuxt.config.js` não estão disponíveis lá.

--- a/content/pt/docs/5.configuration-glossary/index.md
+++ b/content/pt/docs/5.configuration-glossary/index.md
@@ -1,4 +1,5 @@
 ---
+title: Glossário de Configuração
 navigation:
   collapse: true
   redirect: /docs/configuration-glossary/configuration-alias


### PR DESCRIPTION
In this commit, only the `pt/docs/configuration-glossary/` changes,
are being sent, I will be waiting for the result of reviews and ready
to make the necessary corrections if something is in the wrong place.

@smarroufin now you can see if some content part missing, since it
was a common mistake did some previous pull request 😊.

@ChristopheCVB I am anxious for your reviews to improve this version of
changes if something need be redone, thanks for your time 😊.