### PR TITLE
chore(content): fix markdown link

### DIFF
--- a/content/en/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/en/docs/5.configuration-glossary/11.configuration-generate.md
@@ -170,7 +170,7 @@ The path to the fallback HTML file. It should be set as the error page, so that 
 fallback: false;
 ```
 
-If working with statically generated pages then it is recommended to use a `404.html` for error pages and for those covered by [excludes](/docs/configuration-glossary/#exclude) (the files that you do not want generated as static pages).
+If working with statically generated pages then it is recommended to use a `404.html` for error pages and for those covered by [excludes](#exclude) (the files that you do not want generated as static pages).
 
 ```js{}[nuxt.config.js]
 fallback: true

--- a/content/es/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/es/docs/5.configuration-glossary/11.configuration-generate.md
@@ -170,7 +170,7 @@ The path to the fallback HTML file. It should be set as the error page, so that 
 fallback: false;
 ```
 
-If working with statically generated pages then it is recommended to use a `404.html` for error pages and for those covered by [excludes](/docs/configuration-glossary/#exclude) (the files that you do not want generated as static pages).
+If working with statically generated pages then it is recommended to use a `404.html` for error pages and for those covered by [excludes](#exclude) (the files that you do not want generated as static pages).
 
 ```js{}[nuxt.config.js]
 fallback: true

--- a/content/fr/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/fr/docs/5.configuration-glossary/11.configuration-generate.md
@@ -173,7 +173,7 @@ Lorsque notre application est une SPA, il est plus idiomatique d'utiliser une `2
 fallback: false
 ```
 
-Lorsque l'on travaille avec des pages générées de manière statique, il est recommandé d'utiliser une `404.html` en tant que page d'erreur et pour celles qui concordent avec les entrées dans [excludes](https://nuxtjs.org/api/configuration-generate#exclude) (autrement dit, les fichiers que l'on ne veut pas voir être générés en tant que pages statiques).
+Lorsque l'on travaille avec des pages générées de manière statique, il est recommandé d'utiliser une `404.html` en tant que page d'erreur et pour celles qui concordent avec les entrées dans [excludes](#exclude) (autrement dit, les fichiers que l'on ne veut pas voir être générés en tant que pages statiques).
 
 ```js{}[nuxt.config.js]
 fallback: true

--- a/content/ja/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/ja/docs/5.configuration-glossary/11.configuration-generate.md
@@ -170,7 +170,7 @@ export default {
 fallback: false;
 ```
 
-静的に生成されたページを運用する場合、エラーページと [excludes](/docs/configuration-glossary/#exclude) でカバーされるページに `404.html` を使うことをおすすめします（静的ページとして生成してほしくない場合）。
+静的に生成されたページを運用する場合、エラーページと [excludes](#exclude) でカバーされるページに `404.html` を使うことをおすすめします（静的ページとして生成してほしくない場合）。
 
 ```js{}[nuxt.config.js]
 fallback: true

--- a/content/pt-br/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/pt-br/docs/5.configuration-glossary/11.configuration-generate.md
@@ -170,7 +170,7 @@ The path to the fallback HTML file. It should be set as the error page, so that 
 fallback: false;
 ```
 
-If working with statically generated pages then it is recommended to use a `404.html` for error pages and for those covered by [excludes](/docs/configuration-glossary/#exclude) (the files that you do not want generated as static pages).
+If working with statically generated pages then it is recommended to use a `404.html` for error pages and for those covered by [excludes](#exclude) (the files that you do not want generated as static pages).
 
 ```js{}[nuxt.config.js]
 fallback: true


### PR DESCRIPTION
Fixes broken markdown link in all locales, except PT since it will be fixed in #2044 