### PR TITLE
docs: Remove "this" from VUE SFC template code

### DIFF
--- a/content/en/docs/4.directory-structure/9.pages.md
+++ b/content/en/docs/4.directory-structure/9.pages.md
@@ -43,7 +43,7 @@ If you've defined a file named `_slug.vue` in your pages folder, you can access 
 
 ```html{}[pages/_slug.vue]
 <template>
-  <h1>{{ this.slug }}</h1>
+  <h1>{{ slug }}</h1>
 </template>
 
 <script>
@@ -60,7 +60,7 @@ If you've defined a file named `_slug.vue` inside a folder called `_book` you ca
 
 ```html{}[pages/_book/_slug.vue]
 <template>
-  <h1>{{ this.book }} / {{ this.slug }}</h1>
+  <h1>{{ book }} / {{ slug }}</h1>
 </template>
 
 <script>


### PR DESCRIPTION
Remove incorrect use of "this" in SFC templates.