### PR TITLE
docs: add alert, add missing coma, change sentence (in docs/features/loading)

### DIFF
--- a/content/en/docs/3.features/7.loading.md
+++ b/content/en/docs/3.features/7.loading.md
@@ -12,9 +12,9 @@ Out of the box, Nuxt gives you its own loading progress bar component that's sho
 
 ## Customizing the Progress Bar
 
-Among other properties, the color, size, duration and direction of the progress bar can be customized to suit your application's needs. This is done by updating the `loading` property of the `nuxt.config.js` with the corresponding properties.
+Among other properties, the color, size, duration and direction of the progress bar can be customized to suit your application's needs. This is done by updating the `loading` property of the `nuxt.config.js` with the corresponding properties.
 
-For example, to set a blue progress bar with a height of 5px, we update the `nuxt.config.js` to the following:
+For example, to set a blue progress bar with a height of 5px, we update the `nuxt.config.js` to the following:
 
 ```js
 export default {
@@ -25,12 +25,14 @@ export default {
 }
 ```
 
+::alert{type="info"} If you do not see the loading bar when you move between routes, the time to load the page is short enough for the users to ignore. If you want the loading bar to appear even if the time is short, try `throttle: 0`. ::
+
 List of properties to customize the progress bar.
 
 | Key         | Type    | Default | Description                                                                                                                       |     |
 | ----------- | ------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- | --- |
 | color       | String  | 'black' | CSS color of the progress bar                                                                                                     |     |
-| failedColor | String  | 'red'   | CSS color of the progress bar when an error appended while rendering the route (if data or fetch sent back an error for example). |     |
+| failedColor | String  | 'red'   | CSS color of the progress bar when an error appended while rendering the route (if data or fetch sent back an error, for example). |     |
 | height      | String  | '2px'   | Height of the progress bar (used in the style property of the progress bar)                                                       |     |
 | throttle    | Number  | 200     | In ms, wait for the specified time before displaying the progress bar. Useful for preventing the bar from flashing.               |     |
 | duration    | Number  | 5000    | In ms, the maximum duration of the progress bar, Nuxt assumes that the route will be rendered before 5 seconds.                |     |
@@ -40,7 +42,7 @@ List of properties to customize the progress bar.
 
 ## Disable the Progress Bar
 
-If you don't want to display the progress bar between the routes add `loading: false` in your `nuxt.config.js` file:
+If you don't want to display the progress bar between the routes, add `loading: false` in your `nuxt.config.js` file:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -64,9 +66,9 @@ The loading property gives you the option to disable the default loading progres
 
 ## Programmatically starting the loading bar
 
-The loading bar can also be programmatically started in your components by calling `this.$nuxt.$loading.start()` to start the loading bar and `this.$nuxt.$loading.finish()` to finish it.
+The loading bar can also be programmatically started in your components by calling `this.$nuxt.$loading.start()` to start the loading bar and `this.$nuxt.$loading.finish()` to finish it.
 
-During your page component's mounting process, the `$loading` property may not be immediately available to access. To work around this, if you want to start the loader in the `mounted` method, make sure to wrap your `$loading` method calls inside `this.$nextTick` as shown below.
+The `$loading` property may not be immediately available to be used during your page component's mounting process. To work around this, if you want to start the loader in the `mounted` method, make sure to wrap your `$loading` method calls inside `this.$nextTick` as shown below.
 
 ```js
 export default {
@@ -83,9 +85,9 @@ export default {
 
 Unfortunately, it is not possible for the Loading component to know in advance how long loading a new page will take. Therefore, it is not possible to accurately animate the progress bar to 100% of the loading time.
 
-Nuxt's loading component partially solves this by letting you set the `duration`, this should be set to an estimate of how long the loading process will take. Unless you use a custom loading component, the progress bar will always move from 0% to 100% in `duration` time (regardless of actual progression). When the loading takes longer than `duration` time, the progress bar will stay at 100% until the loading finishes.
+Nuxt's loading component partially solves this by letting you set the `duration`, this should be set to an estimate of how long the loading process will take. Unless you use a custom loading component, the progress bar will always move from 0% to 100% in `duration` time (regardless of actual progression). When the loading takes longer than `duration` time, the progress bar will stay at 100% until the loading finishes.
 
-You can change the default behavior by setting `continuous` to true, then after reaching 100% the progress bar will start shrinking back to 0% again in `duration` time. When the loading is still not finished after reaching 0% it will start growing from 0% to 100% again, this repeats until the loading finishes.
+You can change the default behavior by setting `continuous` to true. Then after reaching 100%, the progress bar will start shrinking back to 0% again in `duration` time. When the loading is still not finished after reaching 0%, it will grow from 0% to 100% again. The process repeats until the loading finishes.
 
 ```js
 export default {
@@ -101,7 +103,7 @@ _Example of a continuous progress bar:_
 
 ## Using a Custom Loading Component
 
-You can also create your own component that Nuxt will call instead of the default loading progress bar component. To do so, you need to give a path to your component in the `loading` option. Then, your component will be called directly by Nuxt.
+You can also create your own component that Nuxt will call instead of the default loading progress bar component. To do so, you need to give a path to your component in the `loading` option. Then, your component will be called directly by Nuxt.
 
 Your component has to expose some of these methods:
 
@@ -112,7 +114,7 @@ Your component has to expose some of these methods:
 | fail(error)   | Optional | Called when a route couldn't be loaded (failed to fetch data for example).               |
 | increase(num) | Optional | Called during loading the route component, num is an Integer < 100.                      |
 
-You can create your custom component in `components/LoadingBar.vue`:
+You can create your custom component in `components/LoadingBar.vue`:
 
 ```html{}[components/LoadingBar.vue]
 <template>
@@ -153,7 +155,7 @@ You can create your custom component in `components/LoadingBar.vue`:
 </style>
 ```
 
-Then, you update your `nuxt.config.js` to tell Nuxt to use your component:
+Then, you update your `nuxt.config.js` to tell Nuxt to use your component:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -177,7 +179,7 @@ export default {
 
 ## Built-in indicators
 
-These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com/spinkit) project. You can check out its demo page to preview the spinners. In order to use one of these spinners all you have to do is add its name to the name property. No need to import or install anything. Here is a list of built in indicators you can use.
+These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com/spinkit) project. You can check out its demo page to preview the spinners. In order to use one of these spinners all you have to do is add its name to the name property. No need to import or install anything. Here is a list of built in indicators you can use.
 
 - circle
 - cube-grid
@@ -191,10 +193,10 @@ These indicators are imported from the awesome [SpinKit](http://tobiasahlin.com
 - three-bounce
 - wandering-cubes
 
-Built-in indicators support `color` and `background` options.
+Built-in indicators support `color` and `background` options.
 
 ## Custom indicators
 
 If you need your own special indicator, a String value or Name key can also be a path to an HTML template of indicator source code! All of the options are passed to the template, too.
 
-Nuxt's built-in [source code](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) is also available if you need a base!
+Nuxt's built-in [source code](https://github.com/nuxt/nuxt.js/tree/dev/packages/vue-app/template/views/loading) is also available if you need a base!

--- a/content/en/docs/3.features/7.loading.md
+++ b/content/en/docs/3.features/7.loading.md
@@ -25,7 +25,9 @@ export default {
 }
 ```
 
-::alert{type="info"} If you do not see the loading bar when you move between routes, the time to load the page is short enough for the users to ignore. If you want the loading bar to appear even if the time is short, try `throttle: 0`. ::
+::alert{type="info"}
+If you do not see the loading bar when you move between routes, the time to load the page is short enough for the users to ignore. If you want the loading bar to appear even if the time is short, try `throttle: 0`.
+::
 
 List of properties to customize the progress bar.
 


### PR DESCRIPTION
Alert: I have experienced a case where the loading bars did not appear between routes. I wnated beginners, such as myself, to know what is happening.
Missing Coma: A few sentences were hard to understand due to missing coma.
Sentence: A few sentences were hard to understand due to the structure.+