### PR TITLE
docs: fix vue-router link

### DIFF
--- a/content/en/docs/3.features/3.file-system-routing.md
+++ b/content/en/docs/3.features/3.file-system-routing.md
@@ -391,7 +391,7 @@ export default {
 The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered.
 
 ::alert{type="next"}
-To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+To learn more about it, see [vue-router scrollBehavior documentation](https://v3.router.vuejs.org/guide/advanced/scroll-behavior.html).
 ::
 
 Available since:v2.9.0:

--- a/content/en/docs/3.features/8.nuxt-components.md
+++ b/content/en/docs/3.features/8.nuxt-components.md
@@ -179,7 +179,7 @@ The `<NuxtLink>` component should be used for all internal links. That means for
 ```
 
 ::alert{type="info"}
-If you want to know more about `<RouterLink>`, feel free to read the [Vue Router documentation](https://router.vuejs.org/api/#router-link) for more information.
+If you want to know more about `<RouterLink>`, feel free to read the [Vue Router documentation](https://v3.router.vuejs.org/api/#router-link) for more information.
 ::
 
 ::alert{type="info"}
@@ -244,7 +244,7 @@ export default {
 ```
 
 ::alert{type="info"}
-This option is given directly to the `vue-router` linkActiveClass. See the [vue-router docs](https://router.vuejs.org/api/#active-class) for more info.
+This option is given directly to the `vue-router` linkActiveClass. See the [vue-router docs](https://v3.router.vuejs.org/api/#active-class) for more info.
 ::
 
 ## linkExactActiveClass
@@ -272,7 +272,7 @@ export default {
 ```
 
 ::alert{type="info"}
-This option is given directly to the `vue-router` linkExactActiveClass. See the [vue-router](https://router.vuejs.org/api/#active-class) [docs](https://router.vuejs.org/api/#exact-active-class) for more info
+This option is given directly to the `vue-router` linkExactActiveClass. See the [vue-router](https://v3.router.vuejs.org/api/#active-class) [docs](https://v3.router.vuejs.org/api/#exact-active-class) for more info
 ::
 
 ## linkPrefetchedClass

--- a/content/en/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/en/docs/5.configuration-glossary/25.configuration-router.md
@@ -7,7 +7,7 @@ category: configuration-glossary
 ---
 # The router property
 
-The router property lets you customize Nuxt router. ([vue-router](https://router.vuejs.org/)).
+The router property lets you customize Nuxt router. ([vue-router](https://v3.router.vuejs.org/)).
 
 ---
 

--- a/content/en/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/en/docs/5.configuration-glossary/25.configuration-router.md
@@ -7,7 +7,7 @@ category: configuration-glossary
 ---
 # The router property
 
-The router property lets you customize Nuxt router. ([vue-router](https://router.vuejs.org/en/)).
+The router property lets you customize Nuxt router. ([vue-router](https://router.vuejs.org/)).
 
 ---
 

--- a/content/en/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/en/docs/5.configuration-glossary/25.configuration-router.md
@@ -36,7 +36,7 @@ export default {
 When `base` is set, Nuxt will also add in the document header `<base href="{{ router.base }}"/>`.
 ::
 
-> This option is given directly to the vue-router [base](https://router.vuejs.org/api/#base).
+> This option is given directly to the vue-router [base](https://v3.router.vuejs.org/api/#base).
 
 ## routeNameSplitter
 
@@ -89,7 +89,7 @@ export default {
 }
 ```
 
-The schema of the route should respect the [vue-router](https://router.vuejs.org/en/) schema.
+The schema of the route should respect the [vue-router](https://v3.router.vuejs.org/) schema.
 
 ::alert{type="warning"}
 When adding routes that use Named Views, don't forget to add the corresponding `chunkNames` of named `components`.
@@ -123,7 +123,7 @@ Controls whether the router should fallback to hash mode when the browser does n
 
 Setting this to false essentially makes every router-link navigation a full page refresh in IE9. This is useful when the app is server-rendered and needs to work in IE9, because a hash mode URL does not work with SSR.
 
-> This option is given directly to the vue-router [fallback](https://router.vuejs.org/api/#fallback).
+> This option is given directly to the vue-router [fallback](https://v3.router.vuejs.org/api/#fallback).
 
 ## linkActiveClass
 
@@ -140,7 +140,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkActiveClass](https://router.vuejs.org/api/#linkactiveclass).
+> This option is given directly to the vue-router [linkActiveClass](https://v3.router.vuejs.org/api/#linkactiveclass).
 
 ## linkExactActiveClass
 
@@ -157,7 +157,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkExactActiveClass](https://router.vuejs.org/api/#linkexactactiveclass).
+> This option is given directly to the vue-router [linkExactActiveClass](https://v3.router.vuejs.org/api/#linkexactactiveclass).
 
 ## linkPrefetchedClass
 
@@ -216,7 +216,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [mode](https://router.vuejs.org/api/#mode).
+> This option is given directly to the vue-router [mode](https://v3.router.vuejs.org/api/#mode).
 
 ## parseQuery / stringifyQuery
 
@@ -224,7 +224,7 @@ export default {
 
 Provide custom query string parse / stringify functions. Overrides the default.
 
-> This option is given directly to the vue-router [parseQuery / stringifyQuery](https://router.vuejs.org/api/#parsequery-stringifyquery).
+> This option is given directly to the vue-router [parseQuery / stringifyQuery](https://v3.router.vuejs.org/api/#parsequery-stringifyquery).
 
 ## prefetchLinks
 
@@ -303,7 +303,7 @@ export default {
 
 - Type: `Function`
 
-The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered. To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered. To learn more about it, see [vue-router scrollBehavior documentation](https://v3.router.vuejs.org/guide/advanced/scroll-behavior.html).
 
 <div class="Alert Alert-blue">
 

--- a/content/en/docs/6.internals-glossary/1.context.md
+++ b/content/en/docs/6.internals-glossary/1.context.md
@@ -56,7 +56,7 @@ Vuex Store instance. **Available only if the [vuex store](/docs/directory-struct
 
 ### route
 
-`route` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`route` ([_Vue Router Route_](https://v3.router.vuejs.org/api/#the-route-object))
 
 Vue Router route instance.
 
@@ -152,7 +152,7 @@ These keys are available only on client-side.
 
 ### from
 
-`from` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`from` ([_Vue Router Route_](https://v3.router.vuejs.org/api/#the-route-object))
 
 The route navigated from.
 

--- a/content/en/examples/1.routing/2.active-link-classes.md
+++ b/content/en/examples/1.routing/2.active-link-classes.md
@@ -15,7 +15,7 @@ In this example:
 `layouts/default.vue` shows the styles for `nuxt-link-active` and `nuxt-link-exact-active`.
 
 ::alert{type="next"}
-Learn more about [vue routers](https://router.vuejs.org/api/#exact-active-class) active and exact active classes.
+Learn more about [vue routers](https://v3.router.vuejs.org/api/#exact-active-class) active and exact active classes.
 ::
 
 ::alert{type="next"}

--- a/content/es/docs/3.features/3.file-system-routing.md
+++ b/content/es/docs/3.features/3.file-system-routing.md
@@ -320,7 +320,7 @@ export default {
 ```
 
 ::alert{type="warning"}
-The schema of the route should respect the [vue-router](https://router.vuejs.org/en/) schema.
+The schema of the route should respect the [vue-router](https://v3.router.vuejs.org/) schema.
 ::
 
 ::alert{type="warning"}
@@ -391,7 +391,7 @@ export default {
 The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered.
 
 ::alert{type="next"}
-To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+To learn more about it, see [vue-router scrollBehavior documentation](https://v3.router.vuejs.org/guide/advanced/scroll-behavior.html).
 ::
 
 Available since:v2.9.0:

--- a/content/es/docs/3.features/8.nuxt-components.md
+++ b/content/es/docs/3.features/8.nuxt-components.md
@@ -179,7 +179,7 @@ The `<NuxtLink>` component should be used for all internal links. That means for
 ```
 
 ::alert{type="info"}
-If you want to know more about `<RouterLink>`, feel free to read the [Vue Router documentation](https://router.vuejs.org/api/#router-link) for more information.
+If you want to know more about `<RouterLink>`, feel free to read the [Vue Router documentation](https://v3.router.vuejs.org/api/#router-link) for more information.
 ::
 
 ::alert{type="info"}
@@ -244,7 +244,7 @@ export default {
 ```
 
 ::alert{type="info"}
-This option is given directly to the `vue-router` linkActiveClass. See the [vue-router docs](https://router.vuejs.org/api/#active-class) for more info.
+This option is given directly to the `vue-router` linkActiveClass. See the [vue-router docs](https://v3.router.vuejs.org/api/#active-class) for more info.
 ::
 
 ## linkExactActiveClass
@@ -272,7 +272,7 @@ export default {
 ```
 
 ::alert{type="info"}
-This option is given directly to the `vue-router` linkExactActiveClass. See the [vue-router](https://router.vuejs.org/api/#active-class) [docs](https://router.vuejs.org/api/#exact-active-class) for more info
+This option is given directly to the `vue-router` linkExactActiveClass. See the [vue-router](https://v3.router.vuejs.org/api/#active-class) [docs](https://v3.router.vuejs.org/api/#exact-active-class) for more info
 ::
 
 ## linkPrefetchedClass

--- a/content/es/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/es/docs/5.configuration-glossary/25.configuration-router.md
@@ -7,7 +7,7 @@ category: configuration-glossary
 ---
 # The router property
 
-The router property lets you customize Nuxt router. ([vue-router](https://router.vuejs.org/en/)).
+The router property lets you customize Nuxt router. ([vue-router](https://v3.router.vuejs.org/)).
 
 ---
 
@@ -36,7 +36,7 @@ export default {
 When `base` is set, Nuxt will also add in the document header `<base href="{{ router.base }}"/>`.
 ::
 
-> This option is given directly to the vue-router [base](https://router.vuejs.org/api/#base).
+> This option is given directly to the vue-router [base](https://v3.router.vuejs.org/api/#base).
 
 ## routeNameSplitter
 
@@ -89,7 +89,7 @@ export default {
 }
 ```
 
-The schema of the route should respect the [vue-router](https://router.vuejs.org/en/) schema.
+The schema of the route should respect the [vue-router](https://v3.router.vuejs.org/) schema.
 
 ::alert{type="warning"}
 When adding routes that use Named Views, don't forget to add the corresponding `chunkNames` of named `components`.
@@ -123,7 +123,7 @@ Controls whether the router should fallback to hash mode when the browser does n
 
 Setting this to false essentially makes every router-link navigation a full page refresh in IE9. This is useful when the app is server-rendered and needs to work in IE9, because a hash mode URL does not work with SSR.
 
-> This option is given directly to the vue-router [fallback](https://router.vuejs.org/api/#fallback).
+> This option is given directly to the vue-router [fallback](https://v3.router.vuejs.org/api/#fallback).
 
 ## linkActiveClass
 
@@ -140,7 +140,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkActiveClass](https://router.vuejs.org/api/#linkactiveclass).
+> This option is given directly to the vue-router [linkActiveClass](https://v3.router.vuejs.org/api/#linkactiveclass).
 
 ## linkExactActiveClass
 
@@ -157,7 +157,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkExactActiveClass](https://router.vuejs.org/api/#linkexactactiveclass).
+> This option is given directly to the vue-router [linkExactActiveClass](https://v3.router.vuejs.org/api/#linkexactactiveclass).
 
 ## linkPrefetchedClass
 
@@ -216,7 +216,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [mode](https://router.vuejs.org/api/#mode).
+> This option is given directly to the vue-router [mode](https://v3.router.vuejs.org/api/#mode).
 
 ## parseQuery / stringifyQuery
 
@@ -224,7 +224,7 @@ export default {
 
 Provide custom query string parse / stringify functions. Overrides the default.
 
-> This option is given directly to the vue-router [parseQuery / stringifyQuery](https://router.vuejs.org/api/#parsequery-stringifyquery).
+> This option is given directly to the vue-router [parseQuery / stringifyQuery](https://v3.router.vuejs.org/api/#parsequery-stringifyquery).
 
 ## prefetchLinks
 
@@ -303,7 +303,7 @@ export default {
 
 - Type: `Function`
 
-The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered. To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered. To learn more about it, see [vue-router scrollBehavior documentation](https://v3.router.vuejs.org/guide/advanced/scroll-behavior.html).
 
 <div class="Alert Alert-blue">
 

--- a/content/es/docs/6.internals-glossary/1.context.md
+++ b/content/es/docs/6.internals-glossary/1.context.md
@@ -56,7 +56,7 @@ Vuex Store instance. **Available only if the [vuex store](/docs/directory-struct
 
 ### route
 
-`route` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`route` ([_Vue Router Route_](https://v3.router.vuejs.org/api/#the-route-object))
 
 Vue Router route instance.
 
@@ -152,7 +152,7 @@ These keys are available only on client-side.
 
 ### from
 
-`from` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`from` ([_Vue Router Route_](https://v3.router.vuejs.org/api/#the-route-object))
 
 The route navigated from.
 

--- a/content/es/examples/1.routing/2.active-link-classes.md
+++ b/content/es/examples/1.routing/2.active-link-classes.md
@@ -15,7 +15,7 @@ In this example:
 `layouts/default.vue` shows the styles for `nuxt-link-active` and `nuxt-link-exact-active`.
 
 ::alert{type="next"}
-Learn more about [vue routers](https://router.vuejs.org/api/#exact-active-class) active and exact active classes.
+Learn more about [vue routers](https://v3.router.vuejs.org/api/#exact-active-class) active and exact active classes.
 ::
 
 ::alert{type="next"}

--- a/content/fr/docs/3.features/3.file-system-routing.md
+++ b/content/fr/docs/3.features/3.file-system-routing.md
@@ -336,7 +336,7 @@ export default {
 
 ::alert{type="info"}
 
-Les routes doivent respecter le schéma du [vue-router](https://router.vuejs.org/en/).
+Les routes doivent respecter le schéma du [vue-router](https://v3.router.vuejs.org/fr/).
 
 ::
 
@@ -419,7 +419,7 @@ L'option `scrollBehavior` nous laisse le choix pour définir un comportement per
 
 ::alert{type="next"}
 
-Pour plus d'informations, veuillez consulter [la documentation sur le scrollBehavior de vue-router](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+Pour plus d'informations, veuillez consulter [la documentation sur le scrollBehavior de vue-router](https://v3.router.vuejs.org/fr/guide/advanced/scroll-behavior.html).
 
 ::
 

--- a/content/fr/docs/3.features/8.nuxt-components.md
+++ b/content/fr/docs/3.features/8.nuxt-components.md
@@ -180,7 +180,7 @@ Le composant `<NuxtLink>` doit être utilisé pour tous les liens internes. Ce q
 
 ::alert{type="info"}
 
-Si nous voulons en savoir plus sur `RouterLink`, se référer à la [documentation du Routeur Vue](https://router.vuejs.org/api/#router-link).
+Si nous voulons en savoir plus sur `RouterLink`, se référer à la [documentation du Routeur Vue](https://v3.router.vuejs.org/fr/api/#router-link).
 
 ::
 
@@ -249,7 +249,7 @@ export default {
 
 ::alert{type="info"}
 
-Cette option est donnée directement à la propriété `linkActiveClass` du `vue-router`, plus d'informations [ici](https://router.vuejs.org/api/#active-class).
+Cette option est donnée directement à la propriété `linkActiveClass` du `vue-router`, plus d'informations [ici](https://v3.router.vuejs.org/fr/api/#active-class).
 
 ::
 

--- a/content/fr/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/fr/docs/5.configuration-glossary/25.configuration-router.md
@@ -8,7 +8,7 @@ category: configuration-glossary
 
 # La propriété router
 
-La propriété router permet de personnaliser le routeur de Nuxt ([vue-router](https://router.vuejs.org/en/)).
+La propriété router permet de personnaliser le routeur de Nuxt ([vue-router](https://v3.router.vuejs.org/fr/)).
 
 ---
 
@@ -35,7 +35,7 @@ export default {
 Lorsque `base` est défini, Nuxt va aussi ajouter `<base href="{{ router.base }}"/>` dans l'entête du document.
 ::
 
-> Cette option est donnée directement à [base](https://router.vuejs.org/api/#base) dans `vue-router`.
+> Cette option est donnée directement à [base](https://v3.router.vuejs.org/fr/api/#base) dans `vue-router`.
 
 ## routeNameSplitter
 
@@ -88,7 +88,7 @@ export default {
 }
 ```
 
-Le schéma de la route doit respecter le schéma de [vue-router](https://router.vuejs.org/en/).
+Le schéma de la route doit respecter le schéma de [vue-router](https://v3.router.vuejs.org/fr/).
 
 ::alert{type="warning"}
 Lorsque l'on ajoute des routes qui utilisent des Vues Nommées, il ne faut pas oublier d'ajouter les `chunkNames` qui correspondent aux `composants`.
@@ -122,7 +122,7 @@ Gère le comportement du router quand le navigateur ne supporte pas `history.pus
 
 Si on le passe à `false`, le router va faire un rafraîchissement à chaque navigation de `router-link` dans IE9. Ceci est essentiel quand l'application est render côté serveur et a besoin de marcher dans IE9 car le `hash` ne marche pas avec du rendu côté serveur (SSR).
 
-> Cette option est donnée directement à [fallback](https://router.vuejs.org/api/#fallback) dans `vue-router`.
+> Cette option est donnée directement à [fallback](https://v3.router.vuejs.org/fr/api/#fallback) dans `vue-router`.
 
 ## linkActiveClass
 
@@ -139,7 +139,7 @@ export default {
 }
 ```
 
-> Cette option est donnée directement à [linkactiveclass](https://router.vuejs.org/api/#linkactiveclass) dans `vue-router`.
+> Cette option est donnée directement à [linkactiveclass](https://v3.router.vuejs.org/fr/api/#linkactiveclass) dans `vue-router`.
 
 ## linkExactActiveClass
 
@@ -156,7 +156,7 @@ export default {
 }
 ```
 
-> Cette option est donnée directement à [linkexactactiveclass](https://router.vuejs.org/api/#linkexactactiveclass) dans `vue-router`.
+> Cette option est donnée directement à [linkexactactiveclass](https://v3.router.vuejs.org/fr/api/#linkexactactiveclass) dans `vue-router`.
 
 ## linkPrefetchedClass
 
@@ -215,7 +215,7 @@ export default {
 }
 ```
 
-> Cette option est donnée directement à [mode](https://router.vuejs.org/api/#mode) dans `vue-router`.
+> Cette option est donnée directement à [mode](https://v3.router.vuejs.org/fr/api/#mode) dans `vue-router`.
 
 ## parseQuery / stringifyQuery
 
@@ -223,7 +223,7 @@ export default {
 
 Fournit des fonctions de query string parse / stringify personnalisées. Écrase les valeurs par défaut.
 
-> Cette option est donnée directement aux [parseQuery / stringifyQuery](https://router.vuejs.org/api/#parsequery-stringifyquery) dans `vue-router`.
+> Cette option est donnée directement aux [parseQuery / stringifyQuery](https://v3.router.vuejs.org/fr/api/#parsequery-stringifyquery) dans `vue-router`.
 
 ## prefetchLinks
 
@@ -304,7 +304,7 @@ export default {
 
 L'option `scrollBehavior` permet de définir un comportement personnalisé pour la position du défilement de la page entre les routes. Cette méthode est appelée à chaque fois qu'une page est render.
 
-Pour en apprendre davantage, se référer à la documentation sur le [vue-router scrollBehavior](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+Pour en apprendre davantage, se référer à la documentation sur le [vue-router scrollBehavior](https://v3.router.vuejs.org/fr/guide/advanced/scroll-behavior.html).
 
 <div class="Alert Alert-blue">
 

--- a/content/fr/docs/6.internals-glossary/1.context.md
+++ b/content/fr/docs/6.internals-glossary/1.context.md
@@ -56,7 +56,7 @@ L'instance du Store Vuex. **Disponible uniquement si le [store vuex](/docs/direc
 
 ### route
 
-`route` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`route` ([_Vue Router Route_](https://v3.router.vuejs.org/fr/api/#the-route-object))
 
 L'instance du Routeur de Vue.
 
@@ -152,7 +152,7 @@ Ces paramètres ne sont disponibles que du côté client.
 
 ### from
 
-`from` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`from` ([_Vue Router Route_](https://v3.router.vuejs.org/fr/api/#the-route-object))
 
 La route d'où l'on vient.
 

--- a/content/fr/examples/1.routing/2.active-link-classes.md
+++ b/content/fr/examples/1.routing/2.active-link-classes.md
@@ -14,7 +14,7 @@ Dans cet exemple :
 `layouts/default.vue` montre les styles de `nuxt-link-active` et `nuxt-link-exact-active`.
 
 ::alert{type="next"}
-En savoir plus sur les classes `active` et `exact-active` de [vue-router](https://router.vuejs.org/api/#exact-active-class).
+En savoir plus sur les classes `active` et `exact-active` de [vue-router](https://v3.router.vuejs.org/ja/api/#exact-active-class).
 ::
 
 ::alert{type="next"}

--- a/content/ja/docs/3.features/3.file-system-routing.md
+++ b/content/ja/docs/3.features/3.file-system-routing.md
@@ -320,7 +320,7 @@ export default {
 ```
 
 ::alert{type="warning"}
-ルートのスキーマは [vue-router](https://router.vuejs.org/en/) のスキーマを尊重すべきです。
+ルートのスキーマは [vue-router](https://v3.router.vuejs.org/ja/) のスキーマを尊重すべきです。
 ::
 
 ::alert{type="warning"}
@@ -391,7 +391,7 @@ export default {
 `scrollBehavior` オプションを使って、ページ間遷移のスクロール位置について独自の振る舞いを定義することができます。このメソッドはページがレンダリングされるたびに毎回呼び出されます。
 
 ::alert{type="next"}
-詳細は [vue-vue-router のスクロールの振る舞いのドキュメント](https://router.vuejs.org/guide/advanced/scroll-behavior.html)を参照してください。
+詳細は [vue-vue-router のスクロールの振る舞いのドキュメント](https://v3.router.vuejs.org/ja/guide/advanced/scroll-behavior.html)を参照してください。
 ::
 
 v2.9.0 以降で利用可能：

--- a/content/ja/docs/3.features/8.nuxt-components.md
+++ b/content/ja/docs/3.features/8.nuxt-components.md
@@ -179,7 +179,7 @@ keep-alive そして keep-alive-props について詳細は、[Vue.js のドキ�
 ```
 
 ::alert{type="info"}
-`<RouterLink>` についてもっと知りたい場合は、[Vue Router のドキュメント](https://router.vuejs.org/api/#router-link)を読んで参考にしてください。
+`<RouterLink>` についてもっと知りたい場合は、[Vue Router のドキュメント](https://v3.router.vuejs.org/ja/api/#router-link)を読んで参考にしてください。
 ::
 
 ::alert{type="info"}
@@ -244,7 +244,7 @@ export default {
 ```
 
 ::alert{type="info"}
-このオプションは `vue-router` の `linkActiveClass` に直接設定されます。詳細については[Vue Router のドキュメント](https://router.vuejs.org/api/#active-class)を参照してください。
+このオプションは `vue-router` の `linkActiveClass` に直接設定されます。詳細については[Vue Router のドキュメント](https://v3.router.vuejs.org/ja/api/#active-class)を参照してください。
 ::
 
 ## linkExactActiveClass
@@ -272,7 +272,7 @@ export default {
 ```
 
 ::alert{type="info"}
-このオプションは `vue-router` の `linkExactActiveClass` に直接設定されます。詳細については[Vue Router のドキュメント](https://router.vuejs.org/api/#exact-active-class)を参照してください。
+このオプションは `vue-router` の `linkExactActiveClass` に直接設定されます。詳細については[Vue Router のドキュメント](https://v3.router.vuejs.org/ja/api/#exact-active-class)を参照してください。
 ::
 
 ## linkPrefetchedClass

--- a/content/ja/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/ja/docs/5.configuration-glossary/25.configuration-router.md
@@ -7,7 +7,7 @@ category: configuration-glossary
 ---
 # router プロパティ
 
-router プロパティを使って Nuxt ルーター ([vue-router](https://router.vuejs.org/en/))をカスタマイズできます。
+router プロパティを使って Nuxt ルーター ([vue-router](https://v3.router.vuejs.org/ja/))をカスタマイズできます。
 
 ---
 
@@ -36,7 +36,7 @@ export default {
 `base` が設定されている場合、Nuxt はドキュメントヘッダー `<base href="{{ router.base }}"/>` も追加します。
 ::
 
-> このオプションは直接 vue-router の [base](https://router.vuejs.org/api/#base) に渡されます。
+> このオプションは直接 vue-router の [base](https://v3.router.vuejs.org/ja/api/#base) に渡されます。
 
 ## routeNameSplitter
 
@@ -89,7 +89,7 @@ export default {
 }
 ```
 
-ルートのスキーマは [vue-router](https://router.vuejs.org/en/) スキーマを尊重してください。
+ルートのスキーマは [vue-router](https://v3.router.vuejs.org/ja/) スキーマを尊重してください。
 
 ::alert{type="warning"}
 名前付きビューを使うルートを追加する場合、対応する名前付き `components` の `chunkNames` の追加を忘れないでください。
@@ -124,7 +124,7 @@ Controls whether the router should fallback to hash mode when the browser does n
 
 これを false に設定すると、基本的にすべてのルーターリンクのナビゲーションが IE9 でフルページリフレッシュされるようになります。これは、アプリがサーバーレンダリングされており、ハッシュモードのURLが SSR で動作しないため、IE9 で動作させる必要がある場合に便利です。
 
-> このオプションは直接 vue-router の [fallback](https://router.vuejs.org/api/#fallback) に渡されます。
+> このオプションは直接 vue-router の [fallback](https://v3.router.vuejs.org/ja/api/#fallback) に渡されます。
 
 ## linkActiveClass
 
@@ -141,7 +141,7 @@ export default {
 }
 ```
 
-> このオプションは直接 vue-router の [linkActiveClass](https://router.vuejs.org/api/#linkactiveclass) に渡されます。
+> このオプションは直接 vue-router の [linkActiveClass](https://v3.router.vuejs.org/ja/api/#linkactiveclass) に渡されます。
 
 ## linkExactActiveClass
 
@@ -158,7 +158,7 @@ export default {
 }
 ```
 
-> このオプションは直接 vue-router の [linkExactActiveClass](https://router.vuejs.org/api/#linkexactactiveclass) に渡されます。
+> このオプションは直接 vue-router の [linkExactActiveClass](https://v3.router.vuejs.org/ja/api/#linkexactactiveclass) に渡されます。
 
 ## linkPrefetchedClass
 
@@ -217,7 +217,7 @@ export default {
 }
 ```
 
-> このオプションは直接 vue-router の [mode](https://router.vuejs.org/api/#mode) に渡されます。
+> このオプションは直接 vue-router の [mode](https://v3.router.vuejs.org/ja/api/#mode) に渡されます。
 
 ## parseQuery / stringifyQuery
 
@@ -225,7 +225,7 @@ export default {
 
 カスタムクエリ構文解析関数/文字列化関数を提供します。デフォルトを上書きします。
 
-> このオプションは直接 vue-router の [parseQuery / stringifyQuery](https://router.vuejs.org/api/#parsequery-stringifyquery) に渡されます。
+> このオプションは直接 vue-router の [parseQuery / stringifyQuery](https://v3.router.vuejs.org/ja/api/#parsequery-stringifyquery) に渡されます。
 
 ## prefetchLinks
 
@@ -304,7 +304,7 @@ export default {
 
 - 型: `Function`
 
-`scrollBehavior` オプションを使って、ページ間のスクロール位置についての独自の振る舞いを定義できます。このメソッドはページがレンダリングされるたびに毎回呼び出されます。詳細は [vue-router のスクロールの振る舞いのドキュメント](https://router.vuejs.org/guide/advanced/scroll-behavior.html)を参照してください。
+`scrollBehavior` オプションを使って、ページ間のスクロール位置についての独自の振る舞いを定義できます。このメソッドはページがレンダリングされるたびに毎回呼び出されます。詳細は [vue-router のスクロールの振る舞いのドキュメント](https://v3.router.vuejs.org/ja/guide/advanced/scroll-behavior.html)を参照してください。
 
 <div class="Alert Alert-blue">
 v2.9.0 以降、ファイルを使用してルーターの scrollBehavior を上書きすることができます。このファイルは `~/app/router.scrollBehavior.js` に配置する必要があります（注意: Windows ではファイル名の大文字と小文字が区別されます）。

--- a/content/ja/docs/6.internals-glossary/1.context.md
+++ b/content/ja/docs/6.internals-glossary/1.context.md
@@ -56,7 +56,7 @@ Vuex の Store インスタンス。**[Vuex ストア](/docs/directory-structure
 
 ### route
 
-`route` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`route` ([_Vue Router Route_](https://v3.router.vuejs.org/ja/api/#the-route-object))
 
 Vue Router の route インスタンス。
 
@@ -152,7 +152,7 @@ Node.js サーバーからのレスポンス。Nuxt がミドルウェアとし�
 
 ### from
 
-`from` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`from` ([_Vue Router Route_](https://v3.router.vuejs.org/ja/api/#the-route-object))
 
 遷移元の route。
 

--- a/content/ja/examples/1.routing/2.active-link-classes.md
+++ b/content/ja/examples/1.routing/2.active-link-classes.md
@@ -15,7 +15,7 @@ category: routing
 `layouts/default.vue` は `nuxt-link-active` と `nuxt-link-exact-active` に対するスタイルを表示します。
 
 ::alert{type="next"}
-より詳細は [Vue Router](https://router.vuejs.org/api/#exact-active-class) の active と exact active classes について学んでください。
+より詳細は [Vue Router](https://v3.router.vuejs.org/ja/api/#exact-active-class) の active と exact active classes について学んでください。
 ::
 
 ::alert{type="next"}

--- a/content/pt-br/docs/3.features/3.file-system-routing.md
+++ b/content/pt-br/docs/3.features/3.file-system-routing.md
@@ -320,7 +320,7 @@ export default {
 ```
 
 ::alert{type="warning"}
-O esquema de rotas deve respeitar o esquema do [vue-router (em inglês)](https://router.vuejs.org)
+O esquema de rotas deve respeitar o esquema do [vue-router (em inglês)](https://v3.router.vuejs.org)
 ::
 
 ::alert{type="warning"}
@@ -391,7 +391,7 @@ export default {
 A opção `scrollBehavior` permite você definir um comportamento personalizado para a posição do scroll entre as rotas. Essa método é chamado toda vez que a página é renderizada.
 
 ::alert{type="next"}
-Para aprender mais sobre isso, veja [documentação do vue-router scrollBehavior](https://router.vuejs.org/guide/advanced/scroll-behavior.html)
+Para aprender mais sobre isso, veja [documentação do vue-router scrollBehavior](https://v3.router.vuejs.org/guide/advanced/scroll-behavior.html)
 ::
 
 Disponível desde: v2.9.0;

--- a/content/pt-br/docs/3.features/8.nuxt-components.md
+++ b/content/pt-br/docs/3.features/8.nuxt-components.md
@@ -176,7 +176,7 @@ The `<NuxtLink>` component should be used for all internal links. That means for
 ```
 
 ::alert{type="info"}
-If you want to know more about `<RouterLink>`, feel free to read the [Vue Router documentation](https://router.vuejs.org/api/#router-link) for more information.
+If you want to know more about `<RouterLink>`, feel free to read the [Vue Router documentation](https://v3.router.vuejs.org/api/#router-link) for more information.
 ::
 
 ::alert{type="info"}
@@ -241,7 +241,7 @@ export default {
 ```
 
 ::alert{type="info"}
-This option is given directly to the `vue-router` linkActiveClass. See the [vue-router docs](https://router.vuejs.org/api/#active-class) for more info.
+This option is given directly to the `vue-router` linkActiveClass. See the [vue-router docs](https://v3.router.vuejs.org/api/#active-class) for more info.
 ::
 
 ## linkExactActiveClass
@@ -269,7 +269,7 @@ export default {
 ```
 
 ::alert{type="info"}
-This option is given directly to the `vue-router` linkExactActiveClass. See the [vue-router](https://router.vuejs.org/api/#active-class) [docs](https://router.vuejs.org/api/#exact-active-class) for more info
+This option is given directly to the `vue-router` linkExactActiveClass. See the [vue-router](https://v3.router.vuejs.org/api/#active-class) [docs](https://v3.router.vuejs.org/api/#exact-active-class) for more info
 ::
 
 ## linkPrefetchedClass

--- a/content/pt-br/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/pt-br/docs/5.configuration-glossary/25.configuration-router.md
@@ -7,7 +7,7 @@ category: configuration-glossary
 ---
 # The router property
 
-The router property lets you customize Nuxt router. ([vue-router](https://router.vuejs.org/en/)).
+The router property lets you customize Nuxt router. ([vue-router](https://v3.router.vuejs.org/)).
 
 ---
 
@@ -36,7 +36,7 @@ export default {
 When `base` is set, Nuxt will also add in the document header `<base href="{{ router.base }}"/>`.
 ::
 
-> This option is given directly to the vue-router [base](https://router.vuejs.org/api/#base).
+> This option is given directly to the vue-router [base](https://v3.router.vuejs.org/api/#base).
 
 ## routeNameSplitter
 
@@ -89,7 +89,7 @@ export default {
 }
 ```
 
-The schema of the route should respect the [vue-router](https://router.vuejs.org/en/) schema.
+The schema of the route should respect the [vue-router](https://v3.router.vuejs.org/) schema.
 
 ::alert{type="warning"}
 When adding routes that use Named Views, don't forget to add the corresponding `chunkNames` of named `components`.
@@ -123,7 +123,7 @@ Controls whether the router should fallback to hash mode when the browser does n
 
 Setting this to false essentially makes every router-link navigation a full page refresh in IE9. This is useful when the app is server-rendered and needs to work in IE9, because a hash mode URL does not work with SSR.
 
-> This option is given directly to the vue-router [fallback](https://router.vuejs.org/api/#fallback).
+> This option is given directly to the vue-router [fallback](https://v3.router.vuejs.org/api/#fallback).
 
 ## linkActiveClass
 
@@ -140,7 +140,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkActiveClass](https://router.vuejs.org/api/#linkactiveclass).
+> This option is given directly to the vue-router [linkActiveClass](https://v3.router.vuejs.org/api/#linkactiveclass).
 
 ## linkExactActiveClass
 
@@ -157,7 +157,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [linkExactActiveClass](https://router.vuejs.org/api/#linkexactactiveclass).
+> This option is given directly to the vue-router [linkExactActiveClass](https://v3.router.vuejs.org/api/#linkexactactiveclass).
 
 ## linkPrefetchedClass
 
@@ -216,7 +216,7 @@ export default {
 }
 ```
 
-> This option is given directly to the vue-router [mode](https://router.vuejs.org/api/#mode).
+> This option is given directly to the vue-router [mode](https://v3.router.vuejs.org/api/#mode).
 
 ## parseQuery / stringifyQuery
 
@@ -224,7 +224,7 @@ export default {
 
 Provide custom query string parse / stringify functions. Overrides the default.
 
-> This option is given directly to the vue-router [parseQuery / stringifyQuery](https://router.vuejs.org/api/#parsequery-stringifyquery).
+> This option is given directly to the vue-router [parseQuery / stringifyQuery](https://v3.router.vuejs.org/api/#parsequery-stringifyquery).
 
 ## prefetchLinks
 
@@ -303,7 +303,7 @@ export default {
 
 - Type: `Function`
 
-The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered. To learn more about it, see [vue-router scrollBehavior documentation](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+The `scrollBehavior` option lets you define a custom behavior for the scroll position between the routes. This method is called every time a page is rendered. To learn more about it, see [vue-router scrollBehavior documentation](https://v3.router.vuejs.org/guide/advanced/scroll-behavior.html).
 
 <div class="Alert Alert-blue">
 

--- a/content/pt-br/docs/6.internals-glossary/1.context.md
+++ b/content/pt-br/docs/6.internals-glossary/1.context.md
@@ -56,7 +56,7 @@ Vuex Store instance. **Available only if the [vuex store](/docs/directory-struct
 
 ### route
 
-`route` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`route` ([_Vue Router Route_](https://v3.router.vuejs.org/api/#the-route-object))
 
 Vue Router route instance.
 
@@ -152,7 +152,7 @@ These keys are available only on client-side.
 
 ### from
 
-`from` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`from` ([_Vue Router Route_](https://v3.router.vuejs.org/api/#the-route-object))
 
 The route navigated from.
 

--- a/content/pt-br/examples/1.routing/2.active-link-classes.md
+++ b/content/pt-br/examples/1.routing/2.active-link-classes.md
@@ -15,7 +15,7 @@ Neste exemplo:
 `layouts/default.vue` contém os estilos para `nuxt-link-active` e `nuxt-link-exact-active`.
 
 ::alert{type="next"}
-Aprenda mais sobre as classes active e exact active na documentação do [vue router](https://router.vuejs.org/api/#exact-active-class).
+Aprenda mais sobre as classes active e exact active na documentação do [vue router](https://v3.router.vuejs.org/api/#exact-active-class).
 ::
 
 ::alert{type="next"}

--- a/content/pt/docs/3.features/3.file-system-routing.md
+++ b/content/pt/docs/3.features/3.file-system-routing.md
@@ -320,7 +320,7 @@ export default {
 ```
 
 ::alert{type="warning"}
-O estrutura de rotas deve respeitar a estrutura do [vue-router](https://router.vuejs.org/en/).
+O estrutura de rotas deve respeitar a estrutura do [vue-router](https://v3.router.vuejs.org/).
 ::
 
 ::alert{type="warning"}
@@ -391,7 +391,7 @@ export default {
 A opção `scrollBehavior` permite você definir um comportamento personalizado para a posição da rolagem entre as rotas. Este método é chamado toda vez que a página é renderizada.
 
 ::alert{type="next"}
-Para aprender mais sobre ele, veja a [documentação do vue-router para scrollBehavior](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+Para aprender mais sobre ele, veja a [documentação do vue-router para scrollBehavior](https://v3.router.vuejs.org/guide/advanced/scroll-behavior.html).
 ::
 
 Disponível desde a versão 2.9.0:

--- a/content/pt/docs/3.features/8.nuxt-components.md
+++ b/content/pt/docs/3.features/8.nuxt-components.md
@@ -179,7 +179,7 @@ O componente `<NuxtLink>` deve ser usado para todas ligações internas. Isso si
 ```
 
 ::alert{type="info"}
-Se você quiser saber mais sobre `<RouterLink>`, sinta-se livre para ler a [documentação do Vue Router](https://router.vuejs.org/api/#router-link) para obter mais informações.
+Se você quiser saber mais sobre `<RouterLink>`, sinta-se livre para ler a [documentação do Vue Router](https://v3.router.vuejs.org/api/#router-link) para obter mais informações.
 ::
 
 ::alert{type="info"}
@@ -244,7 +244,7 @@ export default {
 ```
 
 ::alert{type="info"}
-Esta opção é dada diretamente ao linkActiveClass do `vue-router`. Veja a [documentação do vue-router](https://router.vuejs.org/api/#active-class) para obter mais informações.
+Esta opção é dada diretamente ao linkActiveClass do `vue-router`. Veja a [documentação do vue-router](https://v3.router.vuejs.org/api/#active-class) para obter mais informações.
 ::
 
 ## linkExactActiveClass (classe da ligação exata ativa)
@@ -272,7 +272,7 @@ export default {
 ```
 
 ::alert{type="info"}
-Esta opção é dada diretamente ao linkExactActiveClass do `vue-router`. Veja a [documentação do vue-router](https://router.vuejs.org/api/#active-class) para obter mais informações.
+Esta opção é dada diretamente ao linkExactActiveClass do `vue-router`. Veja a [documentação do vue-router](https://v3.router.vuejs.org/api/#active-class) para obter mais informações.
 ::
 
 ## linkPrefetchedClass (classe da ligação pré-requisitada)

--- a/content/pt/docs/5.configuration-glossary/25.configuration-router.md
+++ b/content/pt/docs/5.configuration-glossary/25.configuration-router.md
@@ -7,7 +7,7 @@ category: configuration-glossary
 ---
 # A propriedade router
 
-A propriedade router permite você personalizar o roteador do Nuxt. ([vue-router](https://router.vuejs.org/en/)).
+A propriedade router permite você personalizar o roteador do Nuxt. ([vue-router](https://v3.router.vuejs.org/)).
 
 ---
 
@@ -36,7 +36,7 @@ export default {
 Quando o `base` estiver definido, o Nuxt também adicionará dentro do cabeçalho do documento o `<base href="{{ router.base }}"/>`.
 ::
 
-> Esta opção é dada diretamente ao [`base`](https://router.vuejs.org/api/#base) do `vue-router`.
+> Esta opção é dada diretamente ao [`base`](https://v3.router.vuejs.org/api/#base) do `vue-router`.
 
 ## A propriedade routeNameSplitter
 
@@ -89,7 +89,7 @@ export default {
 }
 ```
 
-O estrutura da rota deve respeitar o estrutura do [`vue-router`](https://router.vuejs.org/en/).
+O estrutura da rota deve respeitar o estrutura do [`vue-router`](https://v3.router.vuejs.org/).
 
 ::alert{type="warning"}
 Quando estiver adicionando rotas que usam Apresentações Nomeadas, não esqueça de adicionar o `chunkNames` correspondente dos `components` nomeados.
@@ -123,7 +123,7 @@ Controla se a roteador deve recuar para o modo de `hash` quando o navegador não
 
 Definindo isto para `false` essencialmente faz um recarregamento completo da página em toda navegação do `router-link` no Internet Explorer 9. Isto é útil quando a aplicação é renderizada no servidor e precisa funcionar no Internet Explorer 9, porque o modo de `hash` da URL não funciona com a Renderização no Lado do Servidor.
 
-> Esta opção é dada diretamente ao [`fallback`](https://router.vuejs.org/api/#fallback) do `vue-router`.
+> Esta opção é dada diretamente ao [`fallback`](https://v3.router.vuejs.org/api/#fallback) do `vue-router`.
 
 ## A propriedade linkActiveClass
 
@@ -140,7 +140,7 @@ export default {
 }
 ```
 
-> Esta opção é dada diretamente ao [`linkActiveClass`](https://router.vuejs.org/api/#linkactiveclass) do `vue-router`.
+> Esta opção é dada diretamente ao [`linkActiveClass`](https://v3.router.vuejs.org/api/#linkactiveclass) do `vue-router`.
 
 ## A propriedade linkExactActiveClass
 
@@ -157,7 +157,7 @@ export default {
 }
 ```
 
-> Esta opção é dada diretamente ao [`linkExactActiveClass`](https://router.vuejs.org/api/#linkexactactiveclass) do `vue-router`.
+> Esta opção é dada diretamente ao [`linkExactActiveClass`](https://v3.router.vuejs.org/api/#linkexactactiveclass) do `vue-router`.
 
 ## A propriedade linkPrefetchedClass
 
@@ -216,7 +216,7 @@ export default {
 }
 ```
 
-> Esta opção é dada diretamente ao [`mode`](https://router.vuejs.org/api/#mode) do `vue-router`.
+> Esta opção é dada diretamente ao [`mode`](https://v3.router.vuejs.org/api/#mode) do `vue-router`.
 
 ## A propriedade parseQuery / stringifyQuery
 
@@ -224,7 +224,7 @@ export default {
 
 Fornece analise personalizada de sequência de caracteres de consulta / transforma funções em sequências de caracteres. Sobrescreve o valor padrão.
 
-> Esta opção é dada diretamente ao [`parseQuery` / `stringifyQuery`](https://router.vuejs.org/api/#parsequery-stringifyquery) do `vue-router`.
+> Esta opção é dada diretamente ao [`parseQuery` / `stringifyQuery`](https://v3.router.vuejs.org/api/#parsequery-stringifyquery) do `vue-router`.
 
 ## A propriedade prefetchLinks
 
@@ -303,7 +303,7 @@ export default {
 
 - Tipo: `Function`
 
-A opção `scrollBehavior` permite você definir um comportamento personalizado para a posição da rolagem entre as rotas. Este método é chamado toda vez que uma página é renderizada. Para saber mais sobre ele, consulte a [documentação do `scrollBehavior` do `vue-router`](https://router.vuejs.org/guide/advanced/scroll-behavior.html).
+A opção `scrollBehavior` permite você definir um comportamento personalizado para a posição da rolagem entre as rotas. Este método é chamado toda vez que uma página é renderizada. Para saber mais sobre ele, consulte a [documentação do `scrollBehavior` do `vue-router`](https://v3.router.vuejs.org/guide/advanced/scroll-behavior.html).
 
 <div class="Alert Alert-blue">
 

--- a/content/pt/docs/6.internals-glossary/1.context.md
+++ b/content/pt/docs/6.internals-glossary/1.context.md
@@ -56,7 +56,7 @@ Vuex Store instance. **Available only if the [vuex store](/docs/directory-struct
 
 ### route
 
-`route` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`route` ([_Vue Router Route_](https://v3.router.vuejs.org/api/#the-route-object))
 
 Vue Router route instance.
 
@@ -152,7 +152,7 @@ These keys are available only on client-side.
 
 ### from
 
-`from` ([_Vue Router Route_](https://router.vuejs.org/api/#the-route-object))
+`from` ([_Vue Router Route_](https://v3.router.vuejs.org/api/#the-route-object))
 
 The route navigated from.
 

--- a/content/pt/examples/1.routing/2.active-link-classes.md
+++ b/content/pt/examples/1.routing/2.active-link-classes.md
@@ -15,7 +15,7 @@ Neste exemplo:
 - O `layouts/default.vue` mostra os estilos para o `nuxt-link-active` e o `nuxt-link-exact-active`.
 
 ::alert{type="next"}
-Saiba mais sobre as classes `active` e `exact-active` do [roteador do vue](https://router.vuejs.org/api/#exact-active-class).
+Saiba mais sobre as classes `active` e `exact-active` do [roteador do vue](https://v3.router.vuejs.org/api/#exact-active-class).
 ::
 
 ::alert{type="next"}


### PR DESCRIPTION
vue-router's [/en/](https://router.vuejs.org/en/) leads to a non-existent page. Latest vue-router (4.x) is built for Vue 3, so they should link to 3.x docs.