### PR TITLE
Update 5.meta-tags-seo.md

### DIFF
--- a/content/en/docs/3.features/5.meta-tags-seo.md
+++ b/content/en/docs/3.features/5.meta-tags-seo.md
@@ -67,7 +67,7 @@ export default {
 ```
 
 ::alert{type="info"}
-Use `head` as an object to set a title and description only for the home page
+This example will use `head` as an object to set a title and description only for the home page
 ::
 
 ```html{}[pages/index.vue]
@@ -98,7 +98,7 @@ Use `head` as an object to set a title and description only for the home page
 ```
 
 ::alert{type="info"}
-Use `head` as a function to set a title and description only for the home page. By using a function you have access to data and computed properties
+This example will use `head` as a function to set a title and description only for the home page. By using a function you have access to data and computed properties
 ::
 
 Nuxt uses [vue-meta](https://vue-meta.nuxtjs.org/) to update the document head and meta attributes of your application.


### PR DESCRIPTION
It's not clear because people can think "Use this this object / function for homepage" is the rule that  should be used always