### PR TITLE
chore(i18n): enable portuguese language

### DIFF
--- a/i18n/pt-PT.js
+++ b/i18n/pt-PT.js
@@ -1,7 +1,4 @@
-import pt from '~docus-i18n/pt-PT'
-
 export default {
-  ...pt,
   banner: {
     here: 'v3.nuxtjs.org',
     format: '{nuxt} beta já está disponível! Descobre mais sobre isso {here}'

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -170,6 +170,12 @@ export default withDocus({
         iso: 'ja-JP',
         file: 'ja-JP.js',
         name: '日本語'
+      },
+      {
+        code: 'pt',
+        iso: 'pt-PT',
+        file: 'pt-PT.js',
+        name: 'Português'
       }
     ]
   },


### PR DESCRIPTION
Enables Portuguese in i18n config, allowing users to browse Portuguese pages.
PT translation is almost complete (>90%) thanks to a massive contribution from @nazarepiedady and reviews from @ChristopheCVB.
Having the language enabled will help translators as well as reviewers for deploy previews.