### PR TITLE
fix: changed branch for stackblitz's link

### DIFF
--- a/content/es/docs/1.get-started/1.installation.md
+++ b/content/es/docs/1.get-started/1.installation.md
@@ -19,7 +19,7 @@ Here, you will find information on setting up and running a Nuxt project in 4 st
 You can play with Nuxt online directly on CodeSandbox or StackBlitz:
 
 :app-button[Play on CodeSandbox]{href=https://codesandbox.io/s/github/nuxt/codesandbox-nuxt/tree/master/ size="small" externalIcon}
-:app-button[Play on StackBlitz]{href=https://stackblitz.com/github/nuxt/starter/tree/stackblitz size="small" externalIcon .mt-1}
+:app-button[Play on StackBlitz]{href=https://stackblitz.com/github/nuxt/starter/tree/v2-stackblitz size="small" externalIcon .mt-1}
 
 ## Prerequisites
 

--- a/content/fr/docs/1.get-started/1.installation.md
+++ b/content/fr/docs/1.get-started/1.installation.md
@@ -20,7 +20,7 @@ Découvrez ci-dessous comment créer un projet Nuxt fonctionnel en 4 étapes.
 Vous pouvez essayer Nuxt en ligne sur CodeSandbox ou StackBlitz:
 
 :app-button[Play on CodeSandbox]{href=https://codesandbox.io/s/github/nuxt/codesandbox-nuxt/tree/master/ size="small" externalIcon}
-:app-button[Play on StackBlitz]{href=https://stackblitz.com/github/nuxt/starter/tree/stackblitz size="small" externalIcon .mt-1}
+:app-button[Play on StackBlitz]{href=https://stackblitz.com/github/nuxt/starter/tree/v2-stackblitz size="small" externalIcon .mt-1}
 
 ## Prérequis
 


### PR DESCRIPTION
I noticed that the french translation's branch for the stackblitz example was wrong.