### PR TITLE
docs: fix typo getter

### DIFF
--- a/content/en/docs/4.directory-structure/12.store.md
+++ b/content/en/docs/4.directory-structure/12.store.md
@@ -35,7 +35,7 @@ export const state = () => ({
   counter: 0
 })
 
-export const getter = {
+export const getters = {
   getCounter(state) {
     return state.counter
   }


### PR DESCRIPTION
current store directory documentation exports const getter instead of getters
I don't think that's intended as it will cause issues accessing it / mapping it through map helpers