### PR TITLE
docs: fix typo actions parameter

### DIFF
--- a/content/en/docs/4.directory-structure/12.store.md
+++ b/content/en/docs/4.directory-structure/12.store.md
@@ -48,10 +48,10 @@ export const mutations = {
 }
 
 export const actions = {
-  async fetchCounter(context) {
+  async fetchCounter({ state }) {
     // make request
     const res = { data: 10 };
-    context.state.counter = res.data;
+    state.counter = res.data;
     return res.data;
   }
 }
@@ -192,10 +192,10 @@ And the corresponding actions can be in the file  `store/actions.js`
 
 ```js{}[store/actions.js]
 export default {
-  async fetchCounter(context) {
+  async fetchCounter({ state }) {
     // make request
     const res = { data: 10 };
-    context.state.counter = res.data;
+    state.counter = res.data;
     return res.data;
   }
 }

--- a/content/en/docs/4.directory-structure/12.store.md
+++ b/content/en/docs/4.directory-structure/12.store.md
@@ -51,7 +51,7 @@ export const actions = {
   async fetchCounter(context) {
     // make request
     const res = { data: 10 };
-    state.counter = res.data;
+    context.state.counter = res.data;
     return res.data;
   }
 }
@@ -195,7 +195,7 @@ export default {
   async fetchCounter(context) {
     // make request
     const res = { data: 10 };
-    state.counter = res.data;
+    context.state.counter = res.data;
     return res.data;
   }
 }

--- a/content/en/docs/4.directory-structure/12.store.md
+++ b/content/en/docs/4.directory-structure/12.store.md
@@ -48,7 +48,7 @@ export const mutations = {
 }
 
 export const actions = {
-  async fetchCounter(state) {
+  async fetchCounter(context) {
     // make request
     const res = { data: 10 };
     state.counter = res.data;
@@ -192,7 +192,7 @@ And the corresponding actions can be in the file  `store/actions.js`
 
 ```js{}[store/actions.js]
 export default {
-  async fetchCounter(state) {
+  async fetchCounter(context) {
     // make request
     const res = { data: 10 };
     state.counter = res.data;


### PR DESCRIPTION
current docs provide an example of the store actions having a `state` parameter whereas it's supposed to be `context`