### PR TITLE
Change components directory path order

### DIFF
--- a/content/en/docs/4.directory-structure/3.components.md
+++ b/content/en/docs/4.directory-structure/3.components.md
@@ -139,8 +139,8 @@ If we want to use it as `<CustomButton />` while keeping the directory structure
 ```bash{}[nuxt.config.js]
 components: {
   dirs: [
-    '~/components',
-    '~/components/base/foo'
+    '~/components/base/foo',
+    '~/components'
   ]
 }
 ```


### PR DESCRIPTION
Order is important. Root components path (~/components) must be placed last for this config to work. I've ran into this problem with my project, had to change my folders and paths many times until I read the config docs (https://v3.nuxtjs.org/api/configuration/nuxt.config#components) and saw that the root components path must be placed last.