### PR TITLE
docs: Added a line about `srcDir` for .nuxtignore

### DIFF
--- a/content/en/docs/5.configuration-glossary/15.configuration-ignore.md
+++ b/content/en/docs/5.configuration-glossary/15.configuration-ignore.md
@@ -15,7 +15,7 @@ Define the ignore files for your Nuxt application
 
 You can use a `.nuxtignore` file to let Nuxt ignore `layout`, `page`, `store` and `middleware` files in your project’s root directory (`rootDir`) during the build phase. The `.nuxtignore` file is subject to the same specification as `.gitignore` and `.eslintignore` files, in which each line is a glob pattern indicating which files should be ignored.
 
-(NOTE: if you specified a different `srcDir` in nuxt.config, your `.nuxtignore` file will need to be moved there for it to work properly)
+NOTE: if you specified a different `srcDir` in `nuxt.config`, your `.nuxtignore` file will need to be moved there for it to work properly
 
 For example:
 

--- a/content/en/docs/5.configuration-glossary/15.configuration-ignore.md
+++ b/content/en/docs/5.configuration-glossary/15.configuration-ignore.md
@@ -15,7 +15,7 @@ Define the ignore files for your Nuxt application
 
 You can use a `.nuxtignore` file to let Nuxt ignore `layout`, `page`, `store` and `middleware` files in your project’s root directory (`rootDir`) during the build phase. The `.nuxtignore` file is subject to the same specification as `.gitignore` and `.eslintignore` files, in which each line is a glob pattern indicating which files should be ignored.
 
-(NOTE: if you specified a different `srcDir` in nuxt.config, your .nuxtignore file will need to be moved there for it to work properly)
+(NOTE: if you specified a different `srcDir` in nuxt.config, your `.nuxtignore` file will need to be moved there for it to work properly)
 
 For example:
 

--- a/content/en/docs/5.configuration-glossary/15.configuration-ignore.md
+++ b/content/en/docs/5.configuration-glossary/15.configuration-ignore.md
@@ -15,6 +15,8 @@ Define the ignore files for your Nuxt application
 
 You can use a `.nuxtignore` file to let Nuxt ignore `layout`, `page`, `store` and `middleware` files in your project’s root directory (`rootDir`) during the build phase. The `.nuxtignore` file is subject to the same specification as `.gitignore` and `.eslintignore` files, in which each line is a glob pattern indicating which files should be ignored.
 
+(NOTE: if you specified a different `srcDir` in nuxt.config, your .nuxtignore file will need to be moved there for it to work properly)
+
 For example:
 
 ```


### PR DESCRIPTION
PR to help address https://github.com/nuxt/nuxt.js/issues/6459

Some projects may want to have their srcDir different from the default and still be able to .nuxtignore files during development. A one-liner in the docs may help devs put the .nuxtignore file in the correct location.