### PR TITLE
docs: replace Nuxt 3 `Beta` label with `RC`

### DIFF
--- a/components/theme/app/AsideBottom.vue
+++ b/components/theme/app/AsideBottom.vue
@@ -37,7 +37,7 @@
       </AppLink>
       <AppLink href="https://v3.nuxtjs.org" class="flex items-center group nuxt-text-highlight-hover mt-4">
         <IconNuxt class="w-5 h-5 mr-2 text-primary" />
-        <span>{{ $t('common.version') }}: v3.x (Beta)</span>
+        <span>{{ $t('common.version') }}: v3.x (RC)</span>
       </AppLink>
     </div>
   </div>


### PR DESCRIPTION
This small commit changes Nuxt 3 status on page to remove ambiguity for new users and encourage them to try Nuxt 3