### PR TITLE
docs(pt): translate `tutorials/moving-from-nuxtjs-dotenv-to-runtime-config.md`

### DIFF
--- a/content/pt/tutorials/4.moving-from-nuxtjs-dotenv-to-runtime-config.md
+++ b/content/pt/tutorials/4.moving-from-nuxtjs-dotenv-to-runtime-config.md
@@ -1,14 +1,14 @@
 ---
 template: post
-title: 'Moving from @nuxtjs/dotenv to runtime config'
-description: 'In our frontend applications, we often use APIs and third-party integrations which require us to use configuration data which is usually provided by environment variables. These variables should not be exposed to the frontend as the browser environment is accessible by all visitors.'
+title: 'Movendo de @nuxtjs/dotenv para configuração de tempo de execução'
+description: 'Em nossas aplicações de frontend, utilizamos APIs com frequência e integrações de terceiros que requerem que nós utilizemos dados de configuração que normalmente são fornecidas pelas variáveis de ambiente. Estas variáveis não devem ser expostas ao frontend visto que o ambiente do navegador é acessível por todos os visitantes.'
 imgUrl: blog/moving-from-nuxtjs-dotenv-to-runtime-config/main.jpeg
 imgCredits: Norris Niman
 imgCreditsUrl: https://unsplash.com/@norrisniman
 date: 2020-06-15
 authors:
   - name: "Debbie O'Brien"
-    avatarUrl: https://pbs.twimg.com/profile_images/1537114604278530048/FMrBa87o_400x400.jpg
+    avatarUrl: https://pbs.twimg.com/profile_images/1252900852156772352/JLIVJ-TC_400x400.jpg
     link: https://twitter.com/debs_obrien
 tags:
   - Nuxt
@@ -16,47 +16,47 @@ tags:
 category: Tutorial
 ---
 
-It's time to migrate from @nuxtjs/dotenv module to use our new runtime config which has been released as of Nuxt v2.13.
+É hora de migrar do módulo `@nuxtjs/dotenv` para utilizar nossa nova configuração de tempo de execução que foi lançada com a versão 2.13 da Nuxt.
 
-- [What are environment variables](#what-are-environment-variables)
-- [Misconceptions](#misconceptions)
-- [Why we need webpack](#why-we-need-webpack)
-- [How environment variables work](#how-environment-variables-work)
-- [Introducing the Nuxt runtime config](#introducing-the-nuxtjs-runtime-config)
-  - [The new runtime config values are:](#the-new-runtime-config-values-are)
-- [Migrating to the Nuxt runtime config from @nuxtjs/dotenv](#migrating-to-the-nuxtjs-runtime-config-from-nuxtjsdotenv)
-- [Migrating to the Nuxt runtime config from the env property](#migrating-to-the-nuxtjs-runtime-config-from-the-env-property)
-- [The env property vs runtime config](#the-env-property-vs-runtime-config)
-- [Using your config values](#using-your-config-values)
-- [Migrating your config values in your script tags](#migrating-your-config-values-in-your-script-tags)
-- [Migrating your config values in your templates](#migrating-your-config-values-in-your-templates)
-- [Expand/Interpolation Support](#expandinterpolation-support)
-- [Best Practices:](#best-practices)
-- [What to do next](#what-to-do-next)
+- [O que são variáveis de ambiente](#o-que-são-variáveis-de-ambiente)
+- [Equívocos](#equívocos)
+- [Porquê que nós precisamos do Webpack](#porquê-que-nós-precisamos-do-webpack)
+- [Como as variáveis de ambiente funcionam](#como-as-variáveis-de-ambiente-funcionam)
+- [Introduzindo a configuração de tempo de execução da Nuxt](#introduzindo-a-configuração-de-tempo-de-execução-da-nuxt)
+  - [Os novos valores de configuração de tempo de execução são:](#os-novos-valores-de-configuração-de-tempo-de-execução-são)
+- [Migrando de `@nuxtjs/dotenv` para a configuração de tempo de execução da Nuxt](#migrando-de-nuxtjsdotenv-para-a-configuração-de-tempo-de-execução-da-nuxt)
+- [Migrando da propriedade `env` para a configuração de tempo de execução da Nuxt](#migrando-da-propriedade-env-para-a-configuração-de-tempo-de-execução-da-nuxt)
+- [A propriedade `env` contra a configuração de tempo de execução](#a-propriedade-env-contra-a-configuração-de-tempo-de-execução)
+- [Utilizando os teus valores de configuração](#utilizando-os-teus-valores-de-configuração)
+- [Migrando os teus valores de configuração nos teus marcadores de `script`](#migrando-os-teus-valores-de-configuração-nos-teus-marcadores-de-script)
+- [Migrando os teus valores de configuração nos teus modelos de marcação](#migrando-os-teus-valores-de-configuração-nos-teus-modelos-de-marcação)
+- [Suporte a Expansão e Interpolação](#suporte-a-expansão-e-interpolação)
+- [Boas Práticas:](#boas-práticas)
+- [O que fazer a seguir](#o-que-fazer-a-seguir)
 
-## What are environment variables
+## O que são variáveis de ambiente
 
-In our frontend applications, we often use APIs and third-party integrations which require us to use configuration data which is usually provided by environment variables. These variables should not be exposed to the frontend as the browser environment is accessible by all visitors. Instead, we can store sensitive information, like keys and secrets, in password-protected CI tools or deployment pipelines. However, when we are developing applications locally we might not have access to deployment pipelines and therefore need somewhere to store these environment variables.
+Em nossas aplicações de frontend, utilizamos APIs com frequência e integrações de terceiros que requerem que nós utilizemos dados de configuração que normalmente são fornecidas pelas variáveis de ambiente. Estas variáveis não devem ser expostas ao frontend visto que o ambiente do navegador é acessível por todos os visitantes. Ao invés disto, nós podemos guardar informação sensível, como chames e segredos, em ferramentas de integração continua protegidas por senha ou condutas de desdobramento. No entanto, quando estamos desenvolvendo aplicações localmente podemos não ter acesso às condutas de desdobramento e portanto precisamos de algum lugar para guardar estas variáveis de ambiente.
 
-## Misconceptions
+## Equívocos
 
-It is very easy to think that your secret keys are safe by placing them somewhere other than your source code such as a `.env` file, which makes it very easy to expose your secret keys to client-side bundles. Adding your `.env` file to `.gitignore` means this file is not pushed to your version control and therefore not available for people to see which is important if your repo is public. However, the .env file is not encrypted, and therefore placing secrets in environment variables doesn't really provide us with an increase in security and really it just keeps sensitive data out of plain sight. A `.env` option can easily mislead developers to expose secret keys to client-side bundles so always make sure this file is added to your .gitignore.
+É muito fácil pensar que as tuas chaves secretas estão seguras ao colocá-las em algum lugar diferente o teu código-fonte tal como em um ficheiro `.env`, que fica muito fácil expor as tuas chaves secretas para pacotes no lado do cliente. Adicionar o teu ficheiro `.env` ao `.gitignore` significa que este ficheiro não será empurrado para teu controlo de versão e portanto não estará disponível para as pessoas olharem o que é importante se o teu repositório for público. No entanto, o ficheiro `.env` não é encriptado, e portanto colocar segredos em variáveis de ambiente na realidade não nos fornece um aumento em segurança e de fato ela só mantêm os dados sensíveis fora da vista. Uma opção de `.env` pode facilmente iludir programadores a exporem chaves secretas para pacotes no lado do cliente então sempre garanta que este ficheiro é adicionado ao teu ficheiro `.gitignore`.
 
-## Why we need webpack
+## Porquê que nós precisamos do Webpack
 
-Isomorphic applications, otherwise known as universal applications, need to share code between both the server and the client. Babel is used to compile our modern ES6 JavaScript code down to ES5 JavaScript so that it can work across all platforms. Node.js which is an asynchronous event-driven JavaScript runtime that can be used in computers and servers outside of a browser environment, uses the module system.
+Aplicações isomorfas, de outro modo conhecidas como aplicações universais, precisam partilhar código entre ambos o servidor e o cliente. Babel é utilizada para compilar o nosso código JavaScript ES6 moderno para JavaScript ES5 assim ele pode funcionar em todas plataformas. Node.js que é um tempo de execução de JavaScript orientado a evento assíncrono que pode ser utilizado em computadores e servidores fora de um ambiente de navegador, utilize o sistema de módulo.
 
-Using modules in Node.js is done using require, e.g. require('lodash'). However, browser support for modules is still incomplete and therefore we need bundling tools such as webpack to transpile these modules into code that the browsers can read. Webpack basically makes client-side development more "Node-like" with the same module system semantics. This means that a require statement or an ES6 import statement will resolve the same way. And as our applications are not only JavaScript but also HTML, CSS and images we can require these using webpack's loaders.
+A utilização de módulos na Node.js é feita utilizando `require`, por exemplo `require('lodash')`. No entanto, o suporte do navegador para módulos continua incompleto e portanto precisamos ferramentas de empacotamento tais como Webpack para traduzir estes módulos para um código que os navegadores possam ler. Webpack basicamente torna o desenvolvimento no lado do cliente mais "parecida com a Node" com os mesmas semânticas do sistema de módulo. Isto significa que uma declaração `require` ou declaração `import` de ES6 resolverá da mesma maneira. E visto que as nossas aplicações não são apenas JavaScript mas também HTML, CSS e imagens que podemos exigir estas utilizando os carregadores da Webpack.
 
-## How environment variables work
+## Como as variáveis de ambiente funcionam
 
-At runtime, Node.js automatically loads environment variables into `process.env` so that they are available to use in your application. The reference to the environment variable is replaced with the correct value. For example, if you had an `API_SECRET` key with the value of `'my-secret'` then in your application where you had used `process.env.API_SECRET` this would be replaced with the value of my-secret.
+No tempo de execução, a Node.js carrega as variáveis de ambiente automaticamente para `process.env` assim elas estão disponíveis para utilizar na tua aplicação. A referência às variáveis de ambiente são substituídas com o valor correto. Por exemplo, se tiveres uma chave `API_SECRET` com o valor de `'my-secret'` então na tua aplicação onde tiveres utilizado `process.env.API_SECRET` esta seria substituída com o valor de `'my-secret'`.
 
-Values are read during build time and persisted in the webpack bundle. Therefore if we change our `API_SECRET` we will need to rebuild our application so that it can read the new value.
+Os valores são lidos durante o tempo de construção e persistidos no pacote da Webpack. Portanto se mudarmos a nossa `API_SECRET` precisaremos reconstruir a nossa aplicação assim ela poderá ler o novo valor.
 
-## Introducing the Nuxt runtime config
+## Introduzindo a configuração de tempo de execução da Nuxt
 
-With Nuxt 2.13+ we have runtime config and built-in dotenv support providing better security and faster development! Two new options are added to your `nuxt.config.js` file which will allow passing runtime configuration which is then accessible using `$config` from the context. Despite the `env` option, runtime config is added to the Nuxt payload so there is no need to rebuild in order to update the runtime configuration when working in development or with Server-side rendering or single-page applications. Although for static sites you will still need to regenerate your site to see these changes.
+Nas versões da Nuxt acima 2.13 temos configuração de tempo de execução e suporte ao `dotenv` embutido fornecendo uma segurança melhor e desenvolvimento mais rápido! Duas novas opções são adicionadas ao ficheiro `nuxt.config.js` que permitirão a passagem da configuração de tempo de execução que está então acessível ao utilizar `$config` do contexto. Apesar da opção `env`, a configuração de tempo de execução é adicionada à carga (payload, em Inglês) da Nuxt assim não existe necessidade de reconstruir para atualizar a configuração de tempo de execução quando estiveres trabalhado em desenvolvimento ou com a interpretação no lado do servidor ou aplicações de página única. Ainda que para os sítios estáticos continuarás a precisar gerar novamente o teu sítio para ver estas mudanças.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -65,27 +65,27 @@ export default {
 }
 ```
 
-### The new runtime config values are:
+### Os novos valores de configuração de tempo de execução são:
 
-- `publicRuntimeConfig` should hold all env variables that are public as these will be exposed on the frontend. This could include a reference to your public URL for example.
-- `privateRuntimeConfig` should hold all env variables that are private and that should not be exposed on the frontend. This could include a reference to your API secret tokens for example.
+- `publicRuntimeConfig` deve segurar todas as variáveis de ambiente que são públicas visto que estas serão expostas no frontend. Este poderia incluir por exemplo uma referência à tua URL pública.
+- `privateRuntimeConfig` deve segurar todas as variáveis de ambiente que são privadas e que não devem ser expostas no frontend. Este poderia incluir por exemplo uma referência aos teus códigos secretos de API.
 
 ::alert{type="warning"}
-privateRuntimeConfig always overrides publicRuntimeConfig on server-side. `$config` in server mode is { ...public, ...private } but for client mode only { ...public }
+`privateRuntimeConfig` sempre sobrepõe o `publicRuntimeConfig` no lado do servidor. `$config` no modo de servidor é `{ ...public, ...private }` mas para modo de cliente é apenas `{ ...public }`.
 ::
 
-## Migrating to the Nuxt runtime config from @nuxtjs/dotenv
+## Migrando de `@nuxtjs/dotenv` para a configuração de tempo de execução da Nuxt
 
-If you have the `@nuxtjs/dotenv` module installed then you can remove this module by uninstalling it and removing it from the modules section of your nuxt.config file. You can then migrate to the Nuxt runtime config by adding the new properties to your nuxt.config.js file. And then you can add your variables from your `.env` files into your public and private runtime config properties so that Nuxt has access to these variables at runtime.
+Se tiveres o módulo `@nuxtjs/dotenv` instalado então podes remover este módulo desinstalando-o e removendo-o da secção de módulos do teu ficheiro `nuxt.config.js`. Tu podes então migrar para configuração de tempo de execução da Nuxt adicionando as novas propriedades ao teu ficheiro `nuxt.config.js`. E então podes adicionar as tuas variáveis dos teus ficheiros `.env` as tuas propriedades de configuração de tempo de execução pública e privada assim a Nuxt consegue o acesso à estas variáveis em tempo de execução.
 
-If your `.env` file looks something like this:
+Se o teu ficheiro `.env` se parecer com algo como:
 
 ```{}[.env]
 BASE_URL=https://nuxtjs.org
 API_SECRET=1234
 ```
 
-Then migrating it to the new runtime config would look something like:
+Então migrando-a para a nova configuração de tempo de execução se pareceria com algo como:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -98,7 +98,7 @@ export default {
 }
 ```
 
-This can be simplified even further by using a default value instead of having to maintain the value in both the runtime config and the `.env` file when using non-sensitive values.
+Isto pode ser ainda mais simplificado utilizando um valor padrão no lugar de ter que manter o valor em ambas configuração de tempo de execução e ficheiro `.env` quando estiveres utilizando valores não sensíveis.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -108,7 +108,7 @@ export default {
 }
 ```
 
-Also this can be a better replacement for `.env.example` and the default values can point to staging keys/configs.
+Além disto pode ser uma substituição melhor para o `.env.example` e os valores padrão podem apontar para chaves e configurações de encenação.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -118,11 +118,11 @@ export default {
 }
 ```
 
-## Migrating to the Nuxt runtime config from the env property
+## Migrando da propriedade `env` para a configuração de tempo de execução da Nuxt
 
-If you have your env variables stored in your nuxt.config then you can migrate these to use the new runtime configs by adding them to your nuxt.config file.
+Se tiveres as tuas variáveis de ambiente guardadas no teu ficheiro `nuxt.config.js` então podes migrar estas para utilizares as novas configurações de tempo de execução adicionando-as ao teu ficheiro `nuxt.config.js`.
 
-If your env variables in your nuxt.config look like this:
+Se as tuas variáveis de ambiente no teu `nuxt.config.js` se parecerem com algo como:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -133,7 +133,7 @@ export default {
 }
 ```
 
-Then migrating it to the new runtime config would look something like:
+Então migrando-a para a nova configuração de tempo de execução se pareceria com algo como:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -147,16 +147,16 @@ export default {
 ```
 
 ::alert{type="warning"}
-Remember secret keys should not be placed in your nuxt.config file so if you do have them in your env variables then you should remove them. You can create a .env file if needed or else your secret keys can be stored just in your hosting environment.
+Lembra-te de que as chaves secretas não devem ser colocadas no teu ficheiro `nuxt.config.js` assim se as tiveres nas tuas variáveis de ambiente então deves removê-las. Tu podes criar um ficheiro `.env` se necessário ou então as tuas chaves secretas podem ser apenas guardadas no teu ambiente de hospedagem.
 ::
 
-## The env property vs runtime config
+## A propriedade `env` contra a configuração de tempo de execução
 
-You can still use the env property and it is still useful for env variables that are required at build time rather than runtime such as NODE_ENV=staging or VERSION=1.2.3. However for runtime env variables the runtime config is preferred as using the env property can be as dangerous as using the dotenv module when used incorrectly.
+Tu podes continuar a utilizar a propriedade `env` e ela ainda é útil para variáveis de ambiente que são exigidas no momento da construção mais do que no tempo de execução tal como `NODE_ENV=staging` ou `VERSION=1.2.3`. No entanto, para variáveis de ambiente de tempo de execução a configuração de tempo de execução é preferida visto que utilizar a propriedade `env` pode ser tão perigoso quanto utilizar o módulo `dotenv` incorretamente.
 
-## Using your config values
+## Utilizando os teus valores de configuração
 
-Once you have stored your values in the public or private runtime config in your `nuxt.config` file you can then access these values anywhere by using the context in your pages, store, components and plugins by using `this.$config` or `context.$config` instead.
+Uma vez que tens guardado os teus valores em uma configuração de tempo de execução pública ou privada no teu ficheiro `nuxt.config.js` podes então acessar estes valores em qualquer lugar utilizando o contexto nas tuas páginas (pages), memória (store), componentes e extensões (plugins) utilizando `this.$config` ou `context.$config`. 
 
 ```html{}[pages/index.vue]
 <script>
@@ -167,7 +167,7 @@ Once you have stored your values in the public or private runtime config in your
 </script>
 ```
 
-And inside your templates you can access it directly using `{{ $config.* }}`
+E dentro do teus modelos de marcação (templates) podes acessá-lo diretamente utilizando `{{ $config.* }}`
 
 ```html{}[pages/index.vue]
 <template>
@@ -175,49 +175,49 @@ And inside your templates you can access it directly using `{{ $config.* }}`
 </template>
 ```
 
-## Migrating your config values in your script tags
+## Migrando os teus valores de configuração nos teus marcadores de `script`
 
-If you are already using the env variable in your script tags such as in async data
+Se já estiveres utilizando a variável de ambiente (env) nos teus marcadores de `script` tal como em dados assíncronos (async data)
 
 ```js
 async asyncData ({ env }) {
 ```
 
-then you can just replace env for \$config when passing into the context. Here we also pass in the key from the config that we want to access. In this case baseURL.
+então podes só substituir `env` por `$config` quando estiveres passando o contexto. Cá também passamos a chave da configuração que queremos acessar. Neste caso `baseURL`.
 
 ```js
 async asyncData ({ $config: { baseURL } }) {
 ```
 
-Then instead of using env.apiUrl
+Então ao invés de utilizar `env.apiURL`
 
 ```js
 const posts = await fetch(`${env.baseURL}/posts`)
 ```
 
-you can use baseURL direct in your code as we have already passed this in into the config option above and therefore we don't have to reference \$config in our fetch.
+podes utilizar `baseURL` direto no teu código visto que já passamos este para a opção de configuração acima e portanto não temos que referenciar `$config` na nossa requisição.
 
 ```js
 const posts = await fetch(`${baseURL}/posts`)
 ```
 
-## Migrating your config values in your templates
+## Migrando os teus valores de configuração nos teus modelos de marcação
 
-If you have code that is using the env variables you can migrate to using the \$config option. For example if in your code you had
+Se tiveres código que está utilizando as variáveis de ambiente podes migrar para utilizar a opção `$config`. Por exemplo se no teu código tinhas
 
 ```html
 <p>{{process.env.baseURL}}</p>
 ```
 
-You can change this by using \$config instead
+Podes mudar isto para utilizar `$config` no lugar
 
 ```html
 <p>{{$config.baseURL}}</p>
 ```
 
-## Expand/Interpolation Support
+## Suporte a Expansão e Interpolação
 
-Expand for run time config happens only if there is already a key.
+A expansão para configuração de tempo de execução só acontece se já houver uma chave.
 
 ```bash{}[.env]
 API_SECRET=1234
@@ -231,7 +231,7 @@ export default {
 }
 ```
 
-Interpolation allows nesting env vars.
+A interpolação permite o encaixamento de variáveis de ambiente.
 
 ```bash{}[.env]
 BASE_URL=/api
@@ -247,41 +247,41 @@ export default {
 ```
 
 ::alert{type="info"}
-It is also possible to use a function for publicRuntimeConfig and privateRuntimeConfig but not recommended.
+Também é possível utilizar uma função `publicRuntimeConfig` e `privateRuntimeConfig` mas não é recomendado.
 ::
 
-## Best Practices:
+## Boas Práticas:
 
 ::list{type="danger"}
-- Don’t commit sensitive values or secret keys to git
+- Não consolidar valores sensíveis ou chaves secretas no Git
 ::
 
 ::list{type="danger"}
-- Don't store secret keys or sensitive values in your nuxt.config or `.env` unless is gitignored
+- Não guardar chaves secretas ou valores sensíveis no teu `nuxt.config.js` ou `.env` a menos que este ficheiro esteja sendo ignorado com o `.gitignore`
 ::
 
 ::list{type="success"}
-- Use default values for runtimeConfig such as process.env.baseURL || 'https://nuxtjs.org'
+- Utilize valores padrão para `runtimeConfig` tais como `process.env.baseURL || 'https://nuxtjs.org'`
 ::
 
 ::list{type="success"}
-- Store secret keys correctly using your hosting platform such as on Heroku or Netlify etc
+- Guarde corretamente as chaves secretas utilizando a tua plataforma de hospedagem tal como Heroku ou Netlify etc
 ::
 
 ::list{type="success"}
-- Follow JS naming convention (secretKey rather than SECRET_KEY) for runtimeConfig
+- Siga a convenção de nomenclatura de JS (`secretKey` no lugar de `SECRET_KEY`) para o `runtimeConfig`
 ::
 
 ::list{type="success"}
-- Prefer using runtimeConfig rather than `env` option
+- Prefira a utilização de `runtimeConfig` no lugar da opção `env`
 ::
 
-## What to do next
+## O que fazer a seguir
 
 ::alert{type="next"}
-To learn more about going full static checkout [this article](/announcements/going-full-static).
+Para aprender mais a respeito de ir completamente estática consulte [este artigo](/announcements/going-full-static).
 ::
 
 ::alert{type="next"}
-[Subscribe to the newsletter](#subscribe-to-newsletter) to not miss the upcoming articles and resources.
+[Subscreva-te no boletim informativo](#subscribe-to-newsletter) para não perder os futuros artigos e recursos.
 ::

--- a/content/pt/tutorials/4.moving-from-nuxtjs-dotenv-to-runtime-config.md
+++ b/content/pt/tutorials/4.moving-from-nuxtjs-dotenv-to-runtime-config.md
@@ -8,7 +8,7 @@ imgCreditsUrl: https://unsplash.com/@norrisniman
 date: 2020-06-15
 authors:
   - name: "Debbie O'Brien"
-    avatarUrl: https://pbs.twimg.com/profile_images/1252900852156772352/JLIVJ-TC_400x400.jpg
+    avatarUrl: https://pbs.twimg.com/profile_images/1537114604278530048/FMrBa87o_400x400.jpg
     link: https://twitter.com/debs_obrien
 tags:
   - Nuxt


### PR DESCRIPTION
In this repository, I am sending the translation for the
`tutorials/moving-from-nuxtjs-dotenv-to-runtime-config.md`.

I intend to translate all tutorials, so this probably will not be
the last update for the Portuguese folder.

I am waiting for your reviews @smarroufin and @ChristopheCVB.