### PR TITLE
Removal of dist/ directory from .gignore mentioned

### DIFF
--- a/content/en/docs/1.get-started/4.commands.md
+++ b/content/en/docs/1.get-started/4.commands.md
@@ -136,7 +136,7 @@ npm run generate
 ```
 ::
 
-Nuxt will create a `dist/` directory with everything inside ready to be deployed on a static hosting service.
+Nuxt will create a `dist/` directory with everything inside ready to be deployed on a static hosting service. Finally make sure to remove the `dist/` directory from your `.gitignore` file.
 
 As of Nuxt v2.13 there is a crawler installed that will now crawl your link tags and generate your routes when using the command `nuxt generate` based on those links.
 


### PR DESCRIPTION
A necessary step of removing dist/ folder from .gignore file is required for static deploment. This was not mentioned before, thus I added it.