### PR TITLE
docs: mention putting `dist/` in `.gitgnore`

### DIFF
--- a/content/en/docs/1.get-started/4.commands.md
+++ b/content/en/docs/1.get-started/4.commands.md
@@ -138,6 +138,10 @@ npm run generate
 
 Nuxt will create a `dist/` directory with everything inside ready to be deployed on a static hosting service.
 
+::alert{type="info"}
+We recommend putting `dist/` in `.npmignore` or `.gitignore`.
+::
+
 As of Nuxt v2.13 there is a crawler installed that will now crawl your link tags and generate your routes when using the command `nuxt generate` based on those links.
 
 


### PR DESCRIPTION
For coherence on the page, I mentioned putting `dist/` in `.gitignore` as this was not mentioned as it does for putting `.nuxt` in `.gitignore`

Under the following sentence in the docs, it is mentioned to ignore `.nuxt`

> Nuxt will create a .nuxt directory with everything inside ready to be deployed on your server hosting.

> We recommend putting .nuxt in .npmignore or .gitignore.

However under the same sentence for `.dist` the ignore step is not mentioned.

> Nuxt will create a dist/ directory with everything inside ready to be deployed on a static hosting service.

This causes a significant confusion from a learners point of view and incoherence in the docs.