### PR TITLE
chore: Add Mastering Nuxt top banner script

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,6 +43,12 @@ export default withDocus({
         content: 'https://nuxtjs.org/preview.png'
       }
     ],
+    script: [
+      {
+        src: 'https://masteringnuxt.com/banners/main.js',
+        async: true
+      }
+    ],
     bodyAttrs: {
       class: ['min-w-xs']
     }


### PR DESCRIPTION
This PR adds the following script to the nuxtjs.org website:

```
https://masteringnuxt.com/banners/main.js
```

This external script does the following:

- Adds a fixed top `<a>` to the body and renders the banner inside
- Adds a `<style>` tag to properly style it
- Adds the `.has-bb-banner` class to the body, plus a class name derived of the host. In this case, `.nuxtjs_org`
- Adds custom CSS to push down the fixed elements of the page (in this case, the navbar and sidebars) when the `.has-bb-banner` class is present in the body tag. This custom CSS depends on the host name. For nuxtjs.org, it is:

```
body.has-bb-banner.nuxtjs_org .d-header {
  top: 72px;
}

body.has-bb-banner.nuxtjs_org .top-header {
  top: calc(var(--header-height) + 72px);
}
```

The banner opens Mastering Nuxt's site in a new tab. The banner is closeable and will not reappear if a user has closed it (key stored in localStorage).

[Click here to see banner screenshots](https://imgur.com/a/npEhO8L).

Let me know if you have comments or questions. Thanks!






