### PR TITLE
Update 11.configuration-generate.md - change "Ficheiro" to "Arquivo"

### DIFF
--- a/content/pt/docs/5.configuration-glossary/11.configuration-generate.md
+++ b/content/pt/docs/5.configuration-glossary/11.configuration-generate.md
@@ -95,7 +95,7 @@ O nome do diretório criado quando estiver construindo aplicações web com uso 
 
 Configura a permissão de inspeção para [vue-devtools](https://github.com/vuejs/vue-devtools).
 
-Se você já ativou através do ficheiro `nuxt.config.js` ou outra forma, a ferramenta de desenvolvimento ativa independentemente da bandeira.
+Se você já ativou através do arquivo `nuxt.config.js` ou outra forma, a ferramenta de desenvolvimento ativa independentemente da bandeira.
 
 ## A propriedade exclude
 
@@ -114,7 +114,7 @@ Considere este exemplos de estrutura:
 -----| index.vue
 ```
 
-Por padrão, a execução do comando `nuxt generate` criará um ficheiro para cada rota.
+Por padrão, a execução do comando `nuxt generate` criará um arquivo para cada rota.
 
 ```bash
 -| dist/
@@ -164,25 +164,25 @@ export default {
 }
 ```
 
-O caminho para o ficheiro HTML alternativo. Ele deve ser definido como a página de erro, assim também as rotas desconhecidas serão renderizadas através do Nuxt. Se for definida ou não para um valor de falsidade, o nome de um ficheiro HTML alternativo será `200.html`. Se for definido para `true`, o nome de ficheiro será `404.html`. Se você fornecer uma sequência de caracteres como um valor, ela será usada no lugar.
+O caminho para o arquivo HTML alternativo. Ele deve ser definido como a página de erro, assim também as rotas desconhecidas serão renderizadas através do Nuxt. Se for definida ou não para um valor de falsidade, o nome de um arquivo HTML alternativo será `200.html`. Se for definido para `true`, o nome de arquivo será `404.html`. Se você fornecer uma sequência de caracteres como um valor, ela será usada no lugar.
 
 ```{}[nuxt.config.js]
 fallback: false;
 ```
 
-Se estiver trabalhando com páginas estaticamente geradas então é recomendado usar um ficheiro `404.html` para páginas de erros e para aqueles cobertos pelo [excludes](#a-propriedade-exclude) (os ficheiros que você não quer que sejam gerados como páginas estáticas).
+Se estiver trabalhando com páginas estaticamente geradas então é recomendado usar um arquivo `404.html` para páginas de erros e para aqueles cobertos pelo [excludes](#a-propriedade-exclude) (os arquivos que você não quer que sejam gerados como páginas estáticas).
 
 ```js{}[nuxt.config.js]
 fallback: true
 ```
 
-Contudo, o Nuxt permite você configurar qualquer página que você quiser, assim se você não quiser usar o ficheiro `200.html` ou `404.html`, você pode adicionar uma sequência de caracteres e depois você apenas tem de certificar-se de redirecionar para aquela página no lugar.
+Contudo, o Nuxt permite você configurar qualquer página que você quiser, assim se você não quiser usar o arquivos `200.html` ou `404.html`, você pode adicionar uma sequência de caracteres e depois você apenas tem de certificar-se de redirecionar para aquela página no lugar.
 
 ```js{}[nuxt.config.js]
 fallback: 'fallbackPage.html'
 ```
 
-_Nota: Vários serviços (por exemplo, Netlify) detetam um `404.html` automaticamente. Se você configura o seu servidor web por conta própria, consulte a sua documentação para saber como definir uma página de erro (e defina ela para o ficheiro `404.html`)_
+_Nota: Vários serviços (por exemplo, Netlify) detetam um `404.html` automaticamente. Se você configura o seu servidor web por conta própria, consulte a sua documentação para saber como definir uma página de erro (e defina ela para o arquivo `404.html`)_
 
 ## A propriedade interval
 
@@ -332,7 +332,7 @@ async asyncData ({ params, error, payload }) {
 - Tipo: `Boolean`
 - Valor padrão: `true`
 
-Por padrão, quando estiver executando o comando `nuxt generate`, o Nuxt criará um diretório para cada rota e servir um ficheiro `index.html`.
+Por padrão, quando estiver executando o comando `nuxt generate`, o Nuxt criará um diretório para cada rota e servir um arquivo `index.html`.
 
 Exemplo:
 
@@ -346,7 +346,7 @@ Exemplo:
 -------| index.html
 ```
 
-Quando definida para `false`, os ficheiros HTML são gerados de acordo com o caminho da rota:
+Quando definida para `false`, os arquivos HTML são gerados de acordo com o caminho da rota:
 
 ```js{}[nuxt.config.js]
 export default {


### PR DESCRIPTION
Here in Brazil, we use the word "Arquivo" instead of "Ficheiro", I am requesting to change the word to the Brazilian Portuguese standard.