### PR TITLE
Replace top banner with Nuxt Nation banner

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -45,7 +45,7 @@ export default withDocus({
     ],
     script: [
       {
-        src: 'https://masteringnuxt.com/banners/main.js',
+        src: 'https://nuxtnation.com/banners/main.js',
         async: true
       }
     ],


### PR DESCRIPTION
This PR replaces the current "Mastering Nuxt" top banner with the "Join Nuxt Nation" banner.

It opens https://nuxtnation.com in a new tab. If closed it does not open again (key saved in Local Storage).

![Screenshot 2022-11-03 at 17-23-44 The Intuitive Vue Framework](https://user-images.githubusercontent.com/3766839/199826763-1cececa6-3575-4f8b-bb88-db04defeb0e5.png)


[More screenshots](https://imgur.com/a/6rA4RJn)