### PR TITLE
docs: lowercase `app.html`

### DIFF
--- a/content/en/docs/2.concepts/1.views.md
+++ b/content/en/docs/2.concepts/1.views.md
@@ -131,9 +131,11 @@ You can customize the error page by adding a `layouts/error.vue` file:
 </script>
 ```
 
-## Document: App.html
+## Document: app.html
 
 The app template is used to create the actual HTML frame of your document for your Nuxt application which injects the content as well as variables for the head and body. This file is created automatically for you and in general rarely needs to be modified. You can customize the HTML app template used by Nuxt to include scripts or conditional CSS classes by creating an `app.html` file in the source directory of your project which by default is the root directory.
+
+`app.html` must be lowercase to be recognized on all file systems.
 
 The default template used by Nuxt is:
 

--- a/content/en/docs/2.concepts/1.views.md
+++ b/content/en/docs/2.concepts/1.views.md
@@ -135,8 +135,6 @@ You can customize the error page by adding a `layouts/error.vue` file:
 
 The app template is used to create the actual HTML frame of your document for your Nuxt application which injects the content as well as variables for the head and body. This file is created automatically for you and in general rarely needs to be modified. You can customize the HTML app template used by Nuxt to include scripts or conditional CSS classes by creating an `app.html` file in the source directory of your project which by default is the root directory.
 
-`app.html` must be lowercase to be recognized on all file systems.
-
 The default template used by Nuxt is:
 
 ```html{}[app.html]


### PR DESCRIPTION
On macOS uppercase is not an issue, but when building with github actions for instance, it is. So better to remove the misleading uppercase altogether.