### PR TITLE
Add Mastering Nuxt Black Friday banner

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -45,7 +45,7 @@ export default withDocus({
     ],
     script: [
       {
-        src: 'https://nuxtnation.com/banners/main.js',
+        src: 'https://masteringnuxt.com/banners/main.js',
         async: true
       }
     ],


### PR DESCRIPTION
This PR is similar to https://github.com/nuxt/nuxtjs.org/pull/2146

It replaces the top banner of Nuxt Nation with the top banner of Mastering Nuxt, for the Black Friday promo.

[Banner Screenshots](https://imgur.com/a/vaBBkYM)

