### PR TITLE
fix: remove `beta` label from banner in `pt-PT` lang

### DIFF
--- a/i18n/pt-PT.js
+++ b/i18n/pt-PT.js
@@ -1,7 +1,7 @@
 export default {
   banner: {
     here: 'https://nuxt.com/v3',
-    format: '{nuxt} beta já está disponível! Descobre mais sobre isso {here}'
+    format: '{nuxt} já está disponível! Descobre mais sobre isso {here}'
   },
   cookies: {
     message: 'Nós usamos Cookies para análise do utilizador e fazer melhorias na página!',


### PR DESCRIPTION
Recently has been pushed to production the banners updates of new stable version (PR #2161), but from pt-PT lang ins't removed the `beta` label.