### PR TITLE
docs: fix typo in example description

### DIFF
--- a/content/en/examples/2.data-fetching/1.async-data.md
+++ b/content/en/examples/2.data-fetching/1.async-data.md
@@ -12,7 +12,7 @@ In this example we use asyncData to fetch our data from our API.
 
 In this example:
 
-`pages/index.vue` and `pages/posts/_id` use the `asyncData` hook and the `$http` module to fetch our list of mountains from our API.
+`pages/index.vue` and `pages/mountains/_slug` use the `asyncData` hook and the `$http` module to fetch our list of mountains from our API.
 
 ::alert{type="next"}
 Learn more about the [http module](https://http.nuxtjs.org/).


### PR DESCRIPTION
This PR fixes minor typo for asyncData hook readme as per the code sandbox example linked - https://codesandbox.io/s/github/nuxtlabs/examples/tree/master/data-fetching/async-data-hook?from-embed