### PR TITLE
Add extra flag to prevent loading audiofile as eseModule

### DIFF
--- a/content/en/docs/3.features/6.configuration.md
+++ b/content/en/docs/3.features/6.configuration.md
@@ -343,7 +343,8 @@ export default {
         test: /\.(ogg|mp3|wav|mpe?g)$/i,
         loader: 'file-loader',
         options: {
-          name: '[path][name].[ext]'
+          name: '[path][name].[ext]',
+          esModule: false,
         }
       })
     }
@@ -371,7 +372,8 @@ export default {
         test: /\.(ogg|mp3|wav|mpe?g)$/i,
         loader: 'file-loader',
         options: {
-          name: '[path][name].[ext]'
+          name: '[path][name].[ext]',
+          esModule: false,
         }
       })
     }


### PR DESCRIPTION
According to the following bug some people have:

https://stackoverflow.com/questions/69304022/unable-to-play-an-audio-file-in-nuxt-js-app