### PR TITLE
Fix error in docs -> `nuxt` should be `nuxt dev`

### DIFF
--- a/content/en/docs/1.get-started/1.installation.md
+++ b/content/en/docs/1.get-started/1.installation.md
@@ -95,7 +95,7 @@ Fill the content of your `package.json` with:
 {
   "name": "my-app",
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "start": "nuxt start"


### PR DESCRIPTION
`nuxt` will just print documentation, it should be `nuxt dev`.