### PR TITLE
docs: fix typo in "getters" file name

### DIFF
--- a/content/en/docs/4.directory-structure/12.store.md
+++ b/content/en/docs/4.directory-structure/12.store.md
@@ -168,9 +168,9 @@ export default () => ({
 })
 ```
 
-And the corresponding getters can be in the file  `store/getter.js`
+And the corresponding getters can be in the file  `store/getters.js`
 
-```js{}[store/getter.js]
+```js{}[store/getters.js]
 export default {
   getCounter(state) {
     return state.counter


### PR DESCRIPTION
fix typo. It should be "getters" instead of "getter"