### PR TITLE
fixup: Fix nuxt dev command in guides.

### DIFF
--- a/content/en/deployments/github-pages.md
+++ b/content/en/deployments/github-pages.md
@@ -79,7 +79,7 @@ Add a `deploy` command to your `package.json` with the branch as `gh-pages` for 
 
 ```js
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "generate": "nuxt generate",
   "start": "nuxt start",
   "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup"

--- a/content/en/docs/1.get-started/1.installation.md
+++ b/content/en/docs/1.get-started/1.installation.md
@@ -95,7 +95,7 @@ Fill the content of your `package.json` with:
 {
   "name": "my-app",
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "start": "nuxt start"

--- a/content/en/docs/1.get-started/4.commands.md
+++ b/content/en/docs/1.get-started/4.commands.md
@@ -16,7 +16,7 @@ You should have these commands in your `package.json`:
 
 ```json
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "build": "nuxt build",
   "start": "nuxt start",
   "generate": "nuxt generate"

--- a/content/es/deployments/github-pages.md
+++ b/content/es/deployments/github-pages.md
@@ -79,7 +79,7 @@ Add a `deploy` command to your `package.json` with the branch as `gh-pages` for 
 
 ```js
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "generate": "nuxt generate",
   "start": "nuxt start",
   "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup"

--- a/content/es/docs/1.get-started/1.installation.md
+++ b/content/es/docs/1.get-started/1.installation.md
@@ -95,7 +95,7 @@ Fill the content of your `package.json` with:
 {
   "name": "my-app",
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "start": "nuxt start"

--- a/content/es/docs/1.get-started/4.commands.md
+++ b/content/es/docs/1.get-started/4.commands.md
@@ -16,7 +16,7 @@ You should have these commands in your `package.json`:
 
 ```json
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "build": "nuxt build",
   "start": "nuxt start",
   "generate": "nuxt generate"

--- a/content/fr/deployments/github-pages.md
+++ b/content/fr/deployments/github-pages.md
@@ -79,7 +79,7 @@ Add a `deploy` command to your `package.json` with the branch as `gh-pages` for 
 
 ```js
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "generate": "nuxt generate",
   "start": "nuxt start",
   "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup"

--- a/content/fr/docs/1.get-started/1.installation.md
+++ b/content/fr/docs/1.get-started/1.installation.md
@@ -106,7 +106,7 @@ Ouvrir le fichier `package.json` avec notre éditeur préféré et ajouter ce co
 {
   "name": "my-app",
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "start": "nuxt start"

--- a/content/fr/docs/1.get-started/4.commands.md
+++ b/content/fr/docs/1.get-started/4.commands.md
@@ -13,7 +13,7 @@ Vous devriez mettre ces commandes dans `package.json`:
 
 ```json
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "build": "nuxt build",
   "start": "nuxt start",
   "generate": "nuxt generate"

--- a/content/ja/deployments/github-pages.md
+++ b/content/ja/deployments/github-pages.md
@@ -69,7 +69,7 @@ npm install push-dir --save-dev
 
 ```js
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "generate": "nuxt generate",
   "start": "nuxt start",
   "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup"

--- a/content/ja/docs/1.get-started/1.installation.md
+++ b/content/ja/docs/1.get-started/1.installation.md
@@ -106,7 +106,7 @@ touch package.json
 {
   "name": "my-app",
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "start": "nuxt start"

--- a/content/ja/docs/1.get-started/4.commands.md
+++ b/content/ja/docs/1.get-started/4.commands.md
@@ -22,7 +22,7 @@ src: https://www.youtube.com/watch?v=hYdXzIGDlYA
 
 ```json
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "build": "nuxt build",
   "start": "nuxt start",
   "generate": "nuxt generate"

--- a/content/pt-br/deployments/github-pages.md
+++ b/content/pt-br/deployments/github-pages.md
@@ -82,7 +82,7 @@ Add a `deploy` command to your `package.json` with the branch as `gh-pages` for 
 
 ```js
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "generate": "nuxt generate",
   "start": "nuxt start",
   "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup"

--- a/content/pt-br/docs/1.get-started/1.installation.md
+++ b/content/pt-br/docs/1.get-started/1.installation.md
@@ -103,7 +103,7 @@ Preencha o conteúdo do seu `package.json` com:
 {
   "name": "my-app",
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "start": "nuxt start"

--- a/content/pt-br/docs/1.get-started/4.commands.md
+++ b/content/pt-br/docs/1.get-started/4.commands.md
@@ -17,7 +17,7 @@ Você deve ter esses comandos no seu `package.json`:
 
 ```json
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "build": "nuxt build",
   "start": "nuxt start",
   "generate": "nuxt generate"

--- a/content/pt/deployments/github-pages.md
+++ b/content/pt/deployments/github-pages.md
@@ -79,7 +79,7 @@ Adicione o comando `deploy` ao seu `package.json` com o ramo como `gh-pages` par
 
 ```js
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "generate": "nuxt generate",
   "start": "nuxt start",
   "deploy": "push-dir --dir=dist --branch=gh-pages --cleanup"

--- a/content/pt/docs/1.get-started/1.installation.md
+++ b/content/pt/docs/1.get-started/1.installation.md
@@ -102,7 +102,7 @@ Preencha o conteúdo do seu `package.json` com :
 {
   "name": "my-app",
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "start": "nuxt start"

--- a/content/pt/docs/1.get-started/4.commands.md
+++ b/content/pt/docs/1.get-started/4.commands.md
@@ -17,7 +17,7 @@ Você deve ter esses comandos no seu `package.json`:
 
 ```json
 "scripts": {
-  "dev": "nuxt",
+  "dev": "nuxt dev",
   "build": "nuxt build",
   "start": "nuxt start",
   "generate": "nuxt generate"


### PR DESCRIPTION
`nuxt` alone seems to be invalid but paired as `nuxt dev` it seems to work as expected

```
┬─[fixed@fixed-cs:/u/m/p/f/web]─[12:29:26 AM]─[G:feature/website-bath|✚23]
╰─>$ yarn nuxt
yarn run v1.22.19
warning package.json: No license field
$ /usr/mounts/programming/fixed.codes/web/node_modules/.bin/nuxt
Nuxi 3.0.0                                                                                    00:29:35
Usage: npx nuxi dev|build|build-module|cleanup|clean|preview|start|analyze|generate|prepare|typecheck|usage|info|init|create|upgrade|test|add|new [args]

Use npx nuxi [command] --help to see help for each command                                    00:29:35

Done in 0.08s.
```