### PR TITLE
docs: recommend volar instead of vetur

### DIFF
--- a/content/en/docs/1.get-started/1.installation.md
+++ b/content/en/docs/1.get-started/1.installation.md
@@ -24,7 +24,7 @@ You can play with Nuxt online directly on CodeSandbox or StackBlitz:
 ## Prerequisites
 
 - [node](https://nodejs.org) - _We recommend you have the latest LTS version installed_.
-- A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) extension or [WebStorm](https://www.jetbrains.com/webstorm/).
+- A text editor, we recommend [VS Code](https://code.visualstudio.com/) with the [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) extension or [WebStorm](https://www.jetbrains.com/webstorm/).
 - A terminal, we recommend using VS Code's [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal) or [WebStorm terminal](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
 ## Using create-nuxt-app


### PR DESCRIPTION
Recently `Volar` is recommended by the Vue developers as the must have vs-code extension.