### PR TITLE
docs: update links to Vue 2 docs

### DIFF
--- a/content/en/docs/3.features/10.transitions.md
+++ b/content/en/docs/3.features/10.transitions.md
@@ -73,7 +73,7 @@ Nuxt will use these settings to set the component as follows:
 
 The `transition` object can have many properties such as name, mode, css, duration and many more. Please see the vue docs for more info.
 
-You can also define methods in the page `transition` property, for more information on the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) see the vue docs.
+You can also define methods in the page `transition` property, for more information on the [JavaScript hooks](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) see the vue docs.
 
 ```js
 export default {

--- a/content/en/docs/3.features/4.data-fetching.md
+++ b/content/en/docs/3.features/4.data-fetching.md
@@ -150,7 +150,7 @@ You can use `keep-alive` directive in `<nuxt/>` and `<nuxt-child/>` compon
 </template>
 ```
 
-You can also specify the [props](https://vuejs.org/v2/api/#keep-alive) passed to `<keep-alive>` by passing a prop `keep-alive-props` to the `<nuxt>`  component.
+You can also specify the [props](https://v2.vuejs.org/v2/api/#keep-alive) passed to `<keep-alive>` by passing a prop `keep-alive-props` to the `<nuxt>`  component.
 
 ```html{}[layouts/default.vue]
 <nuxt keep-alive :keep-alive-props="{ max: 10 }" />

--- a/content/en/docs/3.features/6.configuration.md
+++ b/content/en/docs/3.features/6.configuration.md
@@ -195,7 +195,7 @@ export default {
 
 Aliasing `createElement` to `h` is a common convention you’ll see in the Vue ecosystem but is actually optional for JSX since it [automatically injects](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` in any method and getter (not functions or arrow functions) declared in ES2015 syntax that has JSX so you can drop the (h) parameter.
 
-You can learn more about how to use it in the [JSX section](https://vuejs.org/v2/guide/render-function.html#JSX) of the Vue.js documentation.
+You can learn more about how to use it in the [JSX section](https://v2.vuejs.org/v2/guide/render-function.html#JSX) of the Vue.js documentation.
 
 ## Ignoring files
 

--- a/content/en/docs/3.features/8.nuxt-components.md
+++ b/content/en/docs/3.features/8.nuxt-components.md
@@ -105,7 +105,7 @@ To display the `child.vue` component, you have to insert the `<NuxtChild>` co
 Both, the `<Nuxt>` component and the `<NuxtChild/>` component, accept `keep-alive` and `keep-alive-props.`
 
 ::alert{type="info"}
-To learn more about keep-alive and keep-alive-props see the [vue docs](https://vuejs.org/v2/api/#keep-alive)
+To learn more about keep-alive and keep-alive-props see the [vue docs](https://v2.vuejs.org/v2/api/#keep-alive)
 ::
 
 ```html{}[layouts/default.vue]

--- a/content/en/docs/3.features/9.component-discovery.md
+++ b/content/en/docs/3.features/9.component-discovery.md
@@ -90,7 +90,7 @@ And now in your template you can use `FooButton` instead of `BaseFooButton`.
 ```
 
 ::alert{type="info"}
-Consider naming your components and directories following the [Vue Style Guide](https://vuejs.org/v2/style-guide/).
+Consider naming your components and directories following the [Vue Style Guide](https://v2.vuejs.org/v2/style-guide/).
 ::
 
 ## Dynamic Imports

--- a/content/en/docs/4.directory-structure/10.plugins.md
+++ b/content/en/docs/4.directory-structure/10.plugins.md
@@ -184,7 +184,7 @@ Sometimes you want to make functions or values available across your app. You ca
 Nuxt provides you with an `inject(key, value)` method to do this easily. Inject is given as the second parameter when exporting a function. The `$` will be prepended automatically to the key.
 
 ::alert{type="info"}
-It is important to know that in any Vue [instance lifecycle](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), only  `beforeCreate` and `created` hooks are called both, from client-side and server-side. All other hooks are called only from the client-side.
+It is important to know that in any Vue [instance lifecycle](https://v2.vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), only  `beforeCreate` and `created` hooks are called both, from client-side and server-side. All other hooks are called only from the client-side.
 ::
 
 ```js{}[plugins/hello.js]

--- a/content/en/docs/5.configuration-glossary/34.configuration-vue-config.md
+++ b/content/en/docs/5.configuration-glossary/34.configuration-vue-config.md
@@ -38,4 +38,4 @@ Vue.config.silent // !isDev [default value]
 Vue.config.performance // isDev [default value]
 ```
 
-To learn more about the `Vue.config` API, check out the [official Vue documentation](https://vuejs.org/v2/api/#Global-Config)
+To learn more about the `Vue.config` API, check out the [official Vue documentation](https://v2.vuejs.org/v2/api/#Global-Config)

--- a/content/en/docs/7.components-glossary/7.transition.md
+++ b/content/en/docs/7.components-glossary/7.transition.md
@@ -7,7 +7,7 @@ category: components-glossary
 ---
 # The page transition property
 
-Nuxt uses the [`<transition>`](https://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages.
+Nuxt uses the [`<transition>`](https://v2.vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages.
 
 ---
 
@@ -66,18 +66,18 @@ The `transition` object can have the following properties:
 | key                | Type      | Default    | definition                                                                                                                                                                                                                 |
 | ------------------ | --------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`             | `String`  | `"page"`   | The transition name applied on all the route transitions.                                                                                                                                                                  |
-| `mode`             | `String`  | `"out-in"` | The transition mode applied on all routes, see [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Transition-Modes).                                                                                       |
+| `mode`             | `String`  | `"out-in"` | The transition mode applied on all routes, see [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Transition-Modes).                                                                                       |
 | `css`              | `Boolean` | `true`     | Whether to apply CSS transition classes. Defaults to `true`. If set to `false`, will only trigger JavaScript hooks registered via component events.                                                                        |
-| `duration`         | `Integer` | n/a        | The duration (in milliseconds) applied on the transition, see [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).                                                           |
+| `duration`         | `Integer` | n/a        | The duration (in milliseconds) applied on the transition, see [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).                                                           |
 | `type`             | `String`  | n/a        | Specify the type of transition events to wait for to determine transition end timing. Available values are `"transition"` and `"animation"`. By default, it will automatically detect the type that has a longer duration. |
-| `enterClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
-| `enterToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
-| `enterActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
-| `leaveClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
-| `leaveToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
-| `leaveActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
+| `enterClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
+| `enterToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
+| `enterActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
+| `leaveClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
+| `leaveToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
+| `leaveActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
 
-You can also define methods in the page `transition` property, these are for the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
+You can also define methods in the page `transition` property, these are for the [JavaScript hooks](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
 
 - `beforeEnter(el)`
 - `enter(el, done)`

--- a/content/es/docs/3.features/10.transitions.md
+++ b/content/es/docs/3.features/10.transitions.md
@@ -73,7 +73,7 @@ Nuxt will use these settings to set the component as follows:
 
 The `transition` object can have many properties such as name, mode, css, duration and many more. Please see the vue docs for more info.
 
-You can also define methods in the page `transition` property, for more information on the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) see the vue docs.
+You can also define methods in the page `transition` property, for more information on the [JavaScript hooks](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) see the vue docs.
 
 ```js
 export default {

--- a/content/es/docs/3.features/4.data-fetching.md
+++ b/content/es/docs/3.features/4.data-fetching.md
@@ -150,7 +150,7 @@ You can use `keep-alive` directive in `<nuxt/>` and `<nuxt-child/>` compon
 </template>
 ```
 
-You can also specify the [props](https://vuejs.org/v2/api/#keep-alive) passed to `<keep-alive>` by passing a prop `keep-alive-props` to the `<nuxt>`  component.
+You can also specify the [props](https://v2.vuejs.org/v2/api/#keep-alive) passed to `<keep-alive>` by passing a prop `keep-alive-props` to the `<nuxt>`  component.
 
 ```html{}[layouts/default.vue]
 <nuxt keep-alive :keep-alive-props="{ max: 10 }" />

--- a/content/es/docs/3.features/6.configuration.md
+++ b/content/es/docs/3.features/6.configuration.md
@@ -195,7 +195,7 @@ export default {
 
 Aliasing `createElement` to `h` is a common convention you’ll see in the Vue ecosystem but is actually optional for JSX since it [automatically injects](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` in any method and getter (not functions or arrow functions) declared in ES2015 syntax that has JSX so you can drop the (h) parameter.
 
-You can learn more about how to use it in the [JSX section](https://vuejs.org/v2/guide/render-function.html#JSX) of the Vue.js documentation.
+You can learn more about how to use it in the [JSX section](https://v2.vuejs.org/v2/guide/render-function.html#JSX) of the Vue.js documentation.
 
 ## Ignoring files
 

--- a/content/es/docs/3.features/8.nuxt-components.md
+++ b/content/es/docs/3.features/8.nuxt-components.md
@@ -105,7 +105,7 @@ To display the `child.vue` component, you have to insert the `<NuxtChild>` co
 Both, the `<Nuxt>` component and the `<NuxtChild/>` component, accept `keep-alive` and `keep-alive-props.`
 
 ::alert{type="info"}
-To learn more about keep-alive and keep-alive-props see the [vue docs](https://vuejs.org/v2/api/#keep-alive)
+To learn more about keep-alive and keep-alive-props see the [vue docs](https://v2.vuejs.org/v2/api/#keep-alive)
 ::
 
 ```html{}[layouts/default.vue]

--- a/content/es/docs/3.features/9.component-discovery.md
+++ b/content/es/docs/3.features/9.component-discovery.md
@@ -90,7 +90,7 @@ And now in your template you can use `FooButton` instead of `BaseFooButton`.
 ```
 
 ::alert{type="info"}
-Consider naming your components and directories following the [Vue Style Guide](https://vuejs.org/v2/style-guide/).
+Consider naming your components and directories following the [Vue Style Guide](https://v2.vuejs.org/v2/style-guide/).
 ::
 
 ## Dynamic Imports

--- a/content/es/docs/4.directory-structure/10.plugins.md
+++ b/content/es/docs/4.directory-structure/10.plugins.md
@@ -184,7 +184,7 @@ Sometimes you want to make functions or values available across your app. You ca
 Nuxt provides you with an `inject(key, value)` method to do this easily. Inject is given as the second parameter when exporting a function. The `$` will be prepended automatically to the key.
 
 ::alert{type="info"}
-It is important to know that in any Vue [instance lifecycle](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), only  `beforeCreate` and `created` hooks are called both, from client-side and server-side. All other hooks are called only from the client-side.
+It is important to know that in any Vue [instance lifecycle](https://v2.vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), only  `beforeCreate` and `created` hooks are called both, from client-side and server-side. All other hooks are called only from the client-side.
 ::
 
 ```js{}[plugins/hello.js]

--- a/content/es/docs/5.configuration-glossary/34.configuration-vue-config.md
+++ b/content/es/docs/5.configuration-glossary/34.configuration-vue-config.md
@@ -38,4 +38,4 @@ Vue.config.silent // !isDev [default value]
 Vue.config.performance // isDev [default value]
 ```
 
-To learn more about the `Vue.config` API, check out the [official Vue documentation](https://vuejs.org/v2/api/#Global-Config)
+To learn more about the `Vue.config` API, check out the [official Vue documentation](https://v2.vuejs.org/v2/api/#Global-Config)

--- a/content/es/docs/7.components-glossary/7.transition.md
+++ b/content/es/docs/7.components-glossary/7.transition.md
@@ -7,7 +7,7 @@ category: components-glossary
 ---
 # The page transition property
 
-Nuxt uses the [`<transition>`](https://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages.
+Nuxt uses the [`<transition>`](https://v2.vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages.
 
 ---
 
@@ -66,18 +66,18 @@ The `transition` object can have the following properties:
 | key                | Type      | Default    | definition                                                                                                                                                                                                                 |
 | ------------------ | --------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`             | `String`  | `"page"`   | The transition name applied on all the route transitions.                                                                                                                                                                  |
-| `mode`             | `String`  | `"out-in"` | The transition mode applied on all routes, see [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Transition-Modes).                                                                                       |
+| `mode`             | `String`  | `"out-in"` | The transition mode applied on all routes, see [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Transition-Modes).                                                                                       |
 | `css`              | `Boolean` | `true`     | Whether to apply CSS transition classes. Defaults to `true`. If set to `false`, will only trigger JavaScript hooks registered via component events.                                                                        |
-| `duration`         | `Integer` | n/a        | The duration (in milliseconds) applied on the transition, see [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).                                                           |
+| `duration`         | `Integer` | n/a        | The duration (in milliseconds) applied on the transition, see [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).                                                           |
 | `type`             | `String`  | n/a        | Specify the type of transition events to wait for to determine transition end timing. Available values are `"transition"` and `"animation"`. By default, it will automatically detect the type that has a longer duration. |
-| `enterClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
-| `enterToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
-| `enterActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
-| `leaveClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
-| `leaveToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
-| `leaveActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
+| `enterClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
+| `enterToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
+| `enterActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
+| `leaveClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
+| `leaveToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
+| `leaveActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
 
-You can also define methods in the page `transition` property, these are for the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
+You can also define methods in the page `transition` property, these are for the [JavaScript hooks](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
 
 - `beforeEnter(el)`
 - `enter(el, done)`

--- a/content/fr/docs/3.features/11.transitions.md
+++ b/content/fr/docs/3.features/11.transitions.md
@@ -73,7 +73,7 @@ Nuxt va utiliser ces paramètres pour configurer le composant comme suit:
 <transition name="test" mode="out-in"></transition>
 ```
 
-L'objet `transition` peut avoir des propriétés telles que le nom, le mode, le CSS, la durée et encore tout plein d'autres ! La [documentation de Vue](https://vuejs.org/v2/guide/transitions.html) a plus d'informations sur ce sujet. On peut aussi définir des méthodes dans la propriété `transition` de la page.
+L'objet `transition` peut avoir des propriétés telles que le nom, le mode, le CSS, la durée et encore tout plein d'autres ! La [documentation de Vue](https://v2.vuejs.org/v2/guide/transitions.html) a plus d'informations sur ce sujet. On peut aussi définir des méthodes dans la propriété `transition` de la page.
 
 ```js
 export default {

--- a/content/fr/docs/3.features/4.data-fetching.md
+++ b/content/fr/docs/3.features/4.data-fetching.md
@@ -146,7 +146,7 @@ Nous pouvons utiliser la directive `keep-alive` dans les composants `<nuxt/>` et
 </template>
 ```
 
-Nous pouvons aussi spécifier les [props](https://vuejs.org/v2/api/#keep-alive) passées à `<keep-alive>` en passant la prop `keep-alive-props` au composant `<nuxt>`.
+Nous pouvons aussi spécifier les [props](https://v2.vuejs.org/v2/api/#keep-alive) passées à `<keep-alive>` en passant la prop `keep-alive-props` au composant `<nuxt>`.
 
 ```html{}[layouts/default.vue]
 <nuxt keep-alive :keep-alive-props="{ max: 10 }" />

--- a/content/fr/docs/3.features/6.configuration.md
+++ b/content/fr/docs/3.features/6.configuration.md
@@ -104,7 +104,7 @@ export default {
 
 Abréger `createElement` par `h` est une convention commune que nous pouvons voir dans l'écosystème Vue mais c'est en fait optionnel pour du JSX car ce dernier [injecte automatiquement](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` dans n'importe quelle méthode et getter (pas les fonctions ni les fonctions fléchées) à condition qu'ils soient définis dans la syntaxe ES2015. Si c'est le cas, nous pouvons omettre le paramètre `h` dans le cas où nous utilisons du JSX.
 
-Nous pouvons en apprendre davantage sur le fonction du JSX dans cette [section](https://vuejs.org/v2/guide/render-function.html#JSX) de la documentation de Vue.
+Nous pouvons en apprendre davantage sur le fonction du JSX dans cette [section](https://v2.vuejs.org/v2/guide/render-function.html#JSX) de la documentation de Vue.
 
 ## Ignorer des fichiers
 

--- a/content/fr/docs/3.features/8.nuxt-components.md
+++ b/content/fr/docs/3.features/8.nuxt-components.md
@@ -106,7 +106,7 @@ Les composants `<Nuxt>` et `<NuxtChild/>` acceptent tous les deux `keep-alive`�
 
 ::alert{type="info"}
 
-Pour en apprendre davantage sur `keep-alive` et `keep-alive-props`, se référer à la [documentation de Vue](https://vuejs.org/v2/api/#keep-alive).
+Pour en apprendre davantage sur `keep-alive` et `keep-alive-props`, se référer à la [documentation de Vue](https://v2.vuejs.org/v2/api/#keep-alive).
 
 ::
 

--- a/content/fr/docs/4.directory-structure/10.plugins.md
+++ b/content/fr/docs/4.directory-structure/10.plugins.md
@@ -176,7 +176,7 @@ Parfois, on souhaiterait rendre des fonctions ou des variables accessibles dans 
 Nuxt nous fournit une méthode `inject(cle, valeur)` pour faire cela facilement. Le second paramètre donné à `inject` est la fonction que l'on souhaite exporter. Le `$` sera automatiquement préfixé à notre clé.
 
 ::alert{type="info"}
-Il est important de savoir que dans tout [lifecycle](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram) d'une instance Vue, seulement les hooks `beforeCreate` et `created` seront appellés du côté client et serveur. Les hooks restants seront appellés seulement du côté client.
+Il est important de savoir que dans tout [lifecycle](https://v2.vuejs.org/v2/guide/instance.html#Lifecycle-Diagram) d'une instance Vue, seulement les hooks `beforeCreate` et `created` seront appellés du côté client et serveur. Les hooks restants seront appellés seulement du côté client.
 ::
 
 ```js{}[plugins/hello.js]

--- a/content/fr/docs/5.configuration-glossary/34.configuration-vue-config.md
+++ b/content/fr/docs/5.configuration-glossary/34.configuration-vue-config.md
@@ -39,4 +39,4 @@ Vue.config.silent // !isDev [valeur par défaut]
 Vue.config.performance // isDev [valeur par défaut]
 ```
 
-Pour en savoir plus sur l'API `Vue.config`, consultez la [documentation officielle de Vue](https://vuejs.org/v2/api/#Global-Config)
+Pour en savoir plus sur l'API `Vue.config`, consultez la [documentation officielle de Vue](https://v2.vuejs.org/v2/api/#Global-Config)

--- a/content/fr/docs/7.components-glossary/8.transition.md
+++ b/content/fr/docs/7.components-glossary/8.transition.md
@@ -6,7 +6,7 @@ category: components-glossary
 ---
 # La propriété transition
 
-Nuxt utilise le composant [`<transition>`](https://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) pour nous permettre de créer et appliquer de superbes transitions/animations lors de la navigation entre les pages.
+Nuxt utilise le composant [`<transition>`](https://v2.vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) pour nous permettre de créer et appliquer de superbes transitions/animations lors de la navigation entre les pages.
 
 ---
 
@@ -67,18 +67,18 @@ L'objet `transition` peut avoir les propriétés suivantes:
 | Propriété          | Type      | Par défaut | Définition                                                                                                                                                                                                                  |
 | ------------------ | --------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`             | `String`  | `"page"`   | Le nom de la transition appliquée à toutes les transitions de routes.                                                                                                                                                       |
-| `mode`             | `String`  | `"out-in"` | Le mode qui s'applique aux transitions sur toutes les routes, se référer à la [documentation de Vue.js](https://vuejs.org/v2/guide/transitions.html#Transition-Modes).                                                      |
+| `mode`             | `String`  | `"out-in"` | Le mode qui s'applique aux transitions sur toutes les routes, se référer à la [documentation de Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Transition-Modes).                                                      |
 | `css`              | `Boolean` | `true`     | Définit l'application ou non des classes CSS sur les transitions. Si définit à `false`, seulement les hooks JavaScript définis par des événements seront exécutés.                                                          |
-| `duration`         | `Integer` | non défini | La durée (en millisecondes) appliquée à la transition, voir la [documentation de Vue.js](https://vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).                                                        |
+| `duration`         | `Integer` | non défini | La durée (en millisecondes) appliquée à la transition, voir la [documentation de Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).                                                        |
 | `type`             | `String`  | non défini | Spécifie le type des événements de transition à attendre pour déterminer la fin d'une transition. Les valeurs disponibles sont `"transition"` et `"animation"`. Par défaut, le type qui a la plus longue durée sera choisi. |
-| `enterClass`       | `String`  | non défini | Le state du départ d'une classe de transition. Voir la [documentation de Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                    |
-| `enterToClass`     | `String`  | non défini | Le state de fin d'une classe de transition. Voir la [documentation de Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                       |
-| `enterActiveClass` | `String`  | non défini | La classe appliquée pendant l'intégralité de la durée de la transition. Voir la [documentation de Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                           |
-| `leaveClass`       | `String`  | non défini | Le state du départ d'une classe de transition. Voir la [documentation de Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                    |
-| `leaveToClass`     | `String`  | non défini | Le state de fin d'une classe de transition. Voir la [documentation de Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                       |
-| `leaveActiveClass` | `String`  | non défini | La classe appliquée pendant l'intégralité de la durée de la transition. Voir la [documentation de Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                           |
+| `enterClass`       | `String`  | non défini | Le state du départ d'une classe de transition. Voir la [documentation de Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                    |
+| `enterToClass`     | `String`  | non défini | Le state de fin d'une classe de transition. Voir la [documentation de Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                       |
+| `enterActiveClass` | `String`  | non défini | La classe appliquée pendant l'intégralité de la durée de la transition. Voir la [documentation de Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                           |
+| `leaveClass`       | `String`  | non défini | Le state du départ d'une classe de transition. Voir la [documentation de Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                    |
+| `leaveToClass`     | `String`  | non défini | Le state de fin d'une classe de transition. Voir la [documentation de Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                       |
+| `leaveActiveClass` | `String`  | non défini | La classe appliquée pendant l'intégralité de la durée de la transition. Voir la [documentation de Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                           |
 
-On peut aussi définir des méthodes dans la propriété `transition` de la page, celles-ci sont pour des [hooks JavaScript](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
+On peut aussi définir des méthodes dans la propriété `transition` de la page, celles-ci sont pour des [hooks JavaScript](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
 
 - `beforeEnter(élément)`
 - `enter(élément, terminé)`

--- a/content/ja/docs/3.features/10.transitions.md
+++ b/content/ja/docs/3.features/10.transitions.md
@@ -73,7 +73,7 @@ export default {
 
 `transition` オブジェクトは name、mode、css、duration などの多くのプロパティを持つことができます。詳細は vue のドキュメントを参照してください。
 
-ページ内の transition プロパティで関数を定義することもできます。 詳細は vue のドキュメントの [JavaScript フック](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks)を参照してください。
+ページ内の transition プロパティで関数を定義することもできます。 詳細は vue のドキュメントの [JavaScript フック](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks)を参照してください。
 
 ```js
 export default {

--- a/content/ja/docs/3.features/4.data-fetching.md
+++ b/content/ja/docs/3.features/4.data-fetching.md
@@ -148,7 +148,7 @@ export default {
 </template>
 ```
 
-また、`<nuxt>` コンポーネントへ `keep-alive-props` プロパティを渡すことで、`<keep-alive>` に渡す [props](https://vuejs.org/v2/api/#keep-alive) を指定することもできます。
+また、`<nuxt>` コンポーネントへ `keep-alive-props` プロパティを渡すことで、`<keep-alive>` に渡す [props](https://v2.vuejs.org/v2/api/#keep-alive) を指定することもできます。
 
 ```html{}[layouts/default.vue]
 <nuxt keep-alive :keep-alive-props="{ max: 10 }" />

--- a/content/ja/docs/3.features/6.configuration.md
+++ b/content/ja/docs/3.features/6.configuration.md
@@ -195,7 +195,7 @@ export default {
 
 `createElement` を `h` にエイリアスすることは、Vue のエコシステムで見られる共通の慣例です。しかしその慣例は JSX では任意です。なぜなら ES2015 の構文で宣言された（関数またはアロー関数ではない）JSX で書かれた任意のメソッドやゲッターには `const h = this.$createElement` が[自動的に注入](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection)されるためです。よって `(h)` パラメータは削除することができます。
 
-JSX の使い方をより深く理解するには Vue.js ドキュメントの [JSX セクション](https://vuejs.org/v2/guide/render-function.html#JSX)を参照してください。
+JSX の使い方をより深く理解するには Vue.js ドキュメントの [JSX セクション](https://v2.vuejs.org/v2/guide/render-function.html#JSX)を参照してください。
 
 ## ファイルの無視
 

--- a/content/ja/docs/3.features/8.nuxt-components.md
+++ b/content/ja/docs/3.features/8.nuxt-components.md
@@ -105,7 +105,7 @@ export default {
 `<Nuxt>` コンポーネント、そして `<NuxtChild>` コンポーネント両方は、`keep-alive` そして `keep-alive-props` を受け付けます。
 
 ::alert{type="info"}
-keep-alive そして keep-alive-props について詳細は、[Vue.js のドキュメント](https://vuejs.org/v2/api/#keep-alive)を参照してください。
+keep-alive そして keep-alive-props について詳細は、[Vue.js のドキュメント](https://v2.vuejs.org/v2/api/#keep-alive)を参照してください。
 ::
 
 ```html{}[layouts/default.vue]

--- a/content/ja/docs/3.features/9.component-discovery.md
+++ b/content/ja/docs/3.features/9.component-discovery.md
@@ -90,7 +90,7 @@ components: {
 ```
 
 ::alert{type="info"}
-コンポーネントやディレクトリの名前は、[Vue.js のスタイルガイド](https://vuejs.org/v2/style-guide/)を検討してください。
+コンポーネントやディレクトリの名前は、[Vue.js のスタイルガイド](https://v2.vuejs.org/v2/style-guide/)を検討してください。
 ::
 
 ## 動的インポート

--- a/content/ja/docs/4.directory-structure/10.plugins.md
+++ b/content/ja/docs/4.directory-structure/10.plugins.md
@@ -184,7 +184,7 @@ export default {
 Nuxt はこれを簡単に行うための `inject（key、value` メソッドを提供します。関数をエクスポートするとき、2 番目のパラメーターとして Inject が指定されます。`$` は、キーの先頭に自動的に追加されます。
 
 ::alert{type="info"}
-Vue[インスタンスのライフサイクル](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram)では、`beforeCreate` フックと `created` フックのみがクライアント、サーバーサイド両方から呼び出されることを把握しておくことが重要です。他のすべてのフックはクライアントサイドからのみ呼び出されます。
+Vue[インスタンスのライフサイクル](https://v2.vuejs.org/v2/guide/instance.html#Lifecycle-Diagram)では、`beforeCreate` フックと `created` フックのみがクライアント、サーバーサイド両方から呼び出されることを把握しておくことが重要です。他のすべてのフックはクライアントサイドからのみ呼び出されます。
 ::
 
 ```js{}[plugins/hello.js]

--- a/content/ja/docs/5.configuration-glossary/34.configuration-vue-config.md
+++ b/content/ja/docs/5.configuration-glossary/34.configuration-vue-config.md
@@ -38,4 +38,4 @@ Vue.config.silent // !isDev [デフォルト値]
 Vue.config.performance // isDev [デフォルト値]
 ```
 
-`Vue.config` API の詳細については[公式の Vue のドキュメント](https://vuejs.org/v2/api/#Global-Config)を参照してください。
+`Vue.config` API の詳細については[公式の Vue のドキュメント](https://v2.vuejs.org/v2/api/#Global-Config)を参照してください。

--- a/content/ja/docs/7.components-glossary/7.transition.md
+++ b/content/ja/docs/7.components-glossary/7.transition.md
@@ -7,7 +7,7 @@ category: components-glossary
 ---
 # page transition プロパティ
 
-Nuxt では [`<transition>`](https://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) コンポーネントを使って、ページ間を遷移する際のトランジション/アニメーションの作成することができます。
+Nuxt では [`<transition>`](https://v2.vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) コンポーネントを使って、ページ間を遷移する際のトランジション/アニメーションの作成することができます。
 
 ---
 
@@ -66,18 +66,18 @@ Nuxt はこれらの設定を使ってコンポーネントを以下のように
 | キー                | 型        | デフォルト   | 定義 |
 | ------------------ | --------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`             | `String`  | `"page"`   | すべてのルートトランジションに適用されるトランジション名です。 |
-| `mode`             | `String`  | `"out-in"` | すべてのルートに適用されるトランジションモードです。詳細は [Vue.js のドキュメント](https://vuejs.org/v2/guide/transitions.html#Transition-Modes)を参照してください。|
+| `mode`             | `String`  | `"out-in"` | すべてのルートに適用されるトランジションモードです。詳細は [Vue.js のドキュメント](https://v2.vuejs.org/v2/guide/transitions.html#Transition-Modes)を参照してください。|
 | `css`              | `Boolean` | `true`     | CSS トランジションクラスを適用するかどうかを設定します。デフォルトは `true` です、もし `false` に設定した場合コンポーネントのイベント経由で登録された JavaScript フックのみがトリガーとなります。|
-| `duration`         | `Integer` | n/a        | トランジションが適用される時間（ミリ秒）です。[Vue.js のドキュメント](https://vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations)を参照してください。 |
+| `duration`         | `Integer` | n/a        | トランジションが適用される時間（ミリ秒）です。[Vue.js のドキュメント](https://v2.vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations)を参照してください。 |
 | `type`             | `String`  | n/a        | トランジション終了のタイミングを判定するために待ち受けるトランジションのイベントタイプを指定します。指定可能な値は `"transition"` または `"animation"` です。デフォルトではより期間の長いほうのタイプが自動的に検出されます。|
-| `enterClass`       | `String`  | n/a        | トランジションクラスの開始状態です。[Vue.js のドキュメント](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
-| `enterToClass`     | `String`  | n/a        | トランジションの終了状態です。[Vue.js のドキュメント](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
-| `enterActiveClass` | `String`  | n/a        | トランジション中に適用されるクラスです。[Vue.js のドキュメント](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
-| `leaveClass`       | `String`  | n/a        | トランジションクラスの開始状態です。[Vue.js のドキュメント](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。 |
-| `leaveToClass`     | `String`  | n/a        | トランジションの終了状態です。[Vue.js のドキュメント](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
-| `leaveActiveClass` | `String`  | n/a        | トランジション中に適用されるクラスです。[Vue.js のドキュメント](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
+| `enterClass`       | `String`  | n/a        | トランジションクラスの開始状態です。[Vue.js のドキュメント](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
+| `enterToClass`     | `String`  | n/a        | トランジションの終了状態です。[Vue.js のドキュメント](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
+| `enterActiveClass` | `String`  | n/a        | トランジション中に適用されるクラスです。[Vue.js のドキュメント](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
+| `leaveClass`       | `String`  | n/a        | トランジションクラスの開始状態です。[Vue.js のドキュメント](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。 |
+| `leaveToClass`     | `String`  | n/a        | トランジションの終了状態です。[Vue.js のドキュメント](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
+| `leaveActiveClass` | `String`  | n/a        | トランジション中に適用されるクラスです。[Vue.js のドキュメント](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes)を参照してください。|
 
-page `transition` プロパティでメソッドを定義することもできます。これらは [JavaScript フック用](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks)です：
+page `transition` プロパティでメソッドを定義することもできます。これらは [JavaScript フック用](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks)です：
 
 - `beforeEnter(el)`
 - `enter(el, done)`

--- a/content/pt-br/docs/3.features/10.transitions.md
+++ b/content/pt-br/docs/3.features/10.transitions.md
@@ -73,7 +73,7 @@ Nuxt will use these settings to set the component as follows:
 
 The `transition` object can have many properties such as name, mode, css, duration and many more. Please see the vue docs for more info.
 
-You can also define methods in the page `transition` property, for more information on the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) see the vue docs.
+You can also define methods in the page `transition` property, for more information on the [JavaScript hooks](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) see the vue docs.
 
 ```js
 export default {

--- a/content/pt-br/docs/3.features/4.data-fetching.md
+++ b/content/pt-br/docs/3.features/4.data-fetching.md
@@ -152,7 +152,7 @@ Você pode utilizar a diretiva `keep-alive` nos componentes `<nuxt />` e `<nuxt-
 </template>
 ```
 
-Você também pode especificar as [propriedades](https://vuejs.org/v2/api/#keep-alive) passados ​​para `<keep-alive>` passando uma propriedade `keep-alive-props` para o componente `<nuxt>`.
+Você também pode especificar as [propriedades](https://v2.vuejs.org/v2/api/#keep-alive) passados ​​para `<keep-alive>` passando uma propriedade `keep-alive-props` para o componente `<nuxt>`.
 
 ```html{}[layouts/default.vue]
 <nuxt keep-alive :keep-alive-props="{ max: 10 }" />

--- a/content/pt-br/docs/3.features/6.configuration.md
+++ b/content/pt-br/docs/3.features/6.configuration.md
@@ -195,7 +195,7 @@ export default {
 
 Aliasing `createElement` to `h` is a common convention you’ll see in the Vue ecosystem but is actually optional for JSX since it [automatically injects](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElement` in any method and getter (not functions or arrow functions) declared in ES2015 syntax that has JSX so you can drop the (h) parameter.
 
-You can learn more about how to use it in the [JSX section](https://vuejs.org/v2/guide/render-function.html#JSX) of the Vue.js documentation.
+You can learn more about how to use it in the [JSX section](https://v2.vuejs.org/v2/guide/render-function.html#JSX) of the Vue.js documentation.
 
 ## Ignoring files
 

--- a/content/pt-br/docs/3.features/8.nuxt-components.md
+++ b/content/pt-br/docs/3.features/8.nuxt-components.md
@@ -104,7 +104,7 @@ To display the `child.vue` component, you have to insert the `<NuxtChild>` co
 Both, the `<Nuxt>` component and the `<NuxtChild/>` component, accept `keep-alive` and `keep-alive-props.`
 
 ::alert{type="info"}
-To learn more about keep-alive and keep-alive-props see the [vue docs](https://vuejs.org/v2/api/#keep-alive)
+To learn more about keep-alive and keep-alive-props see the [vue docs](https://v2.vuejs.org/v2/api/#keep-alive)
 ::
 
 ```html{}[layouts/default.vue]

--- a/content/pt-br/docs/3.features/9.component-discovery.md
+++ b/content/pt-br/docs/3.features/9.component-discovery.md
@@ -90,7 +90,7 @@ And now in your template you can use `FooButton` instead of `BaseFooButton`.
 ```
 
 ::alert{type="info"}
-Consider naming your components and directories following the [Vue Style Guide](https://vuejs.org/v2/style-guide/).
+Consider naming your components and directories following the [Vue Style Guide](https://v2.vuejs.org/v2/style-guide/).
 ::
 
 ## Dynamic Imports

--- a/content/pt-br/docs/4.directory-structure/10.plugins.md
+++ b/content/pt-br/docs/4.directory-structure/10.plugins.md
@@ -184,7 +184,7 @@ Sometimes you want to make functions or values available across your app. You ca
 Nuxt provides you with an `inject(key, value)` method to do this easily. Inject is given as the second parameter when exporting a function. The `$` will be prepended automatically to the key.
 
 ::alert{type="info"}
-It is important to know that in any Vue [instance lifecycle](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), only  `beforeCreate` and `created` hooks are called both, from client-side and server-side. All other hooks are called only from the client-side.
+It is important to know that in any Vue [instance lifecycle](https://v2.vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), only  `beforeCreate` and `created` hooks are called both, from client-side and server-side. All other hooks are called only from the client-side.
 ::
 
 ```js{}[plugins/hello.js]

--- a/content/pt-br/docs/5.configuration-glossary/34.configuration-vue-config.md
+++ b/content/pt-br/docs/5.configuration-glossary/34.configuration-vue-config.md
@@ -38,4 +38,4 @@ Vue.config.silent // !isDev [default value]
 Vue.config.performance // isDev [default value]
 ```
 
-To learn more about the `Vue.config` API, check out the [official Vue documentation](https://vuejs.org/v2/api/#Global-Config)
+To learn more about the `Vue.config` API, check out the [official Vue documentation](https://v2.vuejs.org/v2/api/#Global-Config)

--- a/content/pt-br/docs/7.components-glossary/7.transition.md
+++ b/content/pt-br/docs/7.components-glossary/7.transition.md
@@ -7,7 +7,7 @@ category: components-glossary
 ---
 # The page transition property
 
-Nuxt uses the [`<transition>`](https://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages.
+Nuxt uses the [`<transition>`](https://v2.vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) component to let you create amazing transitions/animations between your pages.
 
 ---
 
@@ -66,18 +66,18 @@ The `transition` object can have the following properties:
 | key                | Type      | Default    | definition                                                                                                                                                                                                                 |
 | ------------------ | --------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`             | `String`  | `"page"`   | The transition name applied on all the route transitions.                                                                                                                                                                  |
-| `mode`             | `String`  | `"out-in"` | The transition mode applied on all routes, see [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Transition-Modes).                                                                                       |
+| `mode`             | `String`  | `"out-in"` | The transition mode applied on all routes, see [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Transition-Modes).                                                                                       |
 | `css`              | `Boolean` | `true`     | Whether to apply CSS transition classes. Defaults to `true`. If set to `false`, will only trigger JavaScript hooks registered via component events.                                                                        |
-| `duration`         | `Integer` | n/a        | The duration (in milliseconds) applied on the transition, see [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).                                                           |
+| `duration`         | `Integer` | n/a        | The duration (in milliseconds) applied on the transition, see [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).                                                           |
 | `type`             | `String`  | n/a        | Specify the type of transition events to wait for to determine transition end timing. Available values are `"transition"` and `"animation"`. By default, it will automatically detect the type that has a longer duration. |
-| `enterClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
-| `enterToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
-| `enterActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
-| `leaveClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
-| `leaveToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
-| `leaveActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
+| `enterClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
+| `enterToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
+| `enterActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
+| `leaveClass`       | `String`  | n/a        | The starting state of the transition class. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                             |
+| `leaveToClass`     | `String`  | n/a        | The ending state for the transition. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                    |
+| `leaveActiveClass` | `String`  | n/a        | The class applied across the entire transition duration. See [Vue.js documentation](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                |
 
-You can also define methods in the page `transition` property, these are for the [JavaScript hooks](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
+You can also define methods in the page `transition` property, these are for the [JavaScript hooks](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
 
 - `beforeEnter(el)`
 - `enter(el, done)`

--- a/content/pt/docs/3.features/10.transitions.md
+++ b/content/pt/docs/3.features/10.transitions.md
@@ -73,7 +73,7 @@ O Nuxt usará essas configurações para definir o componente da seguinte forma:
 
 O objeto `transition`  pode ter várias propriedades tais como name, mode, css, duration e muitas mais. Consulte a documentação do vue para ter informações mais detalhadas.
 
-Você também pode definir métodos dentro da propriedade `transition` , para saber mais sobre consulte os [Gatilhos de JavaScript](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) na documentação do vue.
+Você também pode definir métodos dentro da propriedade `transition` , para saber mais sobre consulte os [Gatilhos de JavaScript](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks) na documentação do vue.
 
 ```js
 export default {

--- a/content/pt/docs/3.features/4.data-fetching.md
+++ b/content/pt/docs/3.features/4.data-fetching.md
@@ -151,7 +151,7 @@ Você pode usar a diretiva `keep-alive` dentro do componente `<nuxt/>` e `<nuxt-
 </template>
 ```
 
-Você pode também especificar as [props](https://vuejs.org/v2/api/#keep-alive) passadas para o `<keep-alive>` ao passar uma propriedade `keep-alive-props` para o componente `<nuxt>` :
+Você pode também especificar as [props](https://v2.vuejs.org/v2/api/#keep-alive) passadas para o `<keep-alive>` ao passar uma propriedade `keep-alive-props` para o componente `<nuxt>` :
 
 ```html{}[layouts/default.vue]
 <nuxt keep-alive :keep-alive-props="{ max: 10 }" />

--- a/content/pt/docs/3.features/6.configuration.md
+++ b/content/pt/docs/3.features/6.configuration.md
@@ -195,7 +195,7 @@ export default {
 
 Apelidar de `createElement` para `h` é uma convenção comum que você verá dentro do ecossistema porém é atualmente opcional para o JSX desde qye ele [injete automaticamente](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `const h = this.$createElemet` dentro de qualquer método e recebedor (getter) (não em funções ou funções em seta) declarado dentro da sintaxe ES2015 que tem o JSX assim você pode eliminar o parâmetro (h).
 
-Você pode aprender mais sobre como usar ele dentro da [secção JSX](https://vuejs.org/v2/guide/render-function.html#JSX) da documentação do Vue.js.
+Você pode aprender mais sobre como usar ele dentro da [secção JSX](https://v2.vuejs.org/v2/guide/render-function.html#JSX) da documentação do Vue.js.
 
 ## Ignorando Ficheiros
 

--- a/content/pt/docs/3.features/8.nuxt-components.md
+++ b/content/pt/docs/3.features/8.nuxt-components.md
@@ -105,7 +105,7 @@ Para exibir o componente `child.vue` , você tem de inserir o componente `<Nu
 Ambos, o componente `<Nuxt>` e o componente `<NuxtChild/>` , aceitam `keep-alive` e `keep-alive-props`.
 
 ::alert{type="info"}
-Para aprender mais sobre o keep-alive e keep-alive-props consulte a [documentação do vue](https://vuejs.org/v2/api/#keep-alive)
+Para aprender mais sobre o keep-alive e keep-alive-props consulte a [documentação do vue](https://v2.vuejs.org/v2/api/#keep-alive)
 ::
 
 ```html{}[layouts/default.vue]

--- a/content/pt/docs/3.features/9.component-discovery.md
+++ b/content/pt/docs/3.features/9.component-discovery.md
@@ -90,7 +90,7 @@ E agora dentro do seu modelo você pode usar `FooButton` ao invés de `BaseFooBu
 ```
 
 ::alert{type="info"}
-Considere nomear o seu componentes e diretórios seguindo o [Guia de Estilo do Vue](https://vuejs.org/v2/style-guide/).
+Considere nomear o seu componentes e diretórios seguindo o [Guia de Estilo do Vue](https://v2.vuejs.org/v2/style-guide/).
 ::
 
 ## Importação Dinâmica

--- a/content/pt/docs/4.directory-structure/10.plugins.md
+++ b/content/pt/docs/4.directory-structure/10.plugins.md
@@ -184,7 +184,7 @@ Algumas vezes você deseja tornar as funções ou valores disponíveis ao longo 
 O Nuxt fornece a você uma maneira de fazer isso facilmente com um método `inject(key, value)`. O inject é dado como segundo parâmetro quando exportamos uma função. O `$` será pré-adicionado automaticamente a chave.
 
 ::alert{type="info"}
-É importante saber que de todo [ciclo de vida da instância do Vue](https://vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), apenas os gatilhos `beforeCreate` e `created` são chamados ambos, no lado do cliente e no lado do servidor. Todos os outros gatilhos são apenas chamado no lado do cliente.
+É importante saber que de todo [ciclo de vida da instância do Vue](https://v2.vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), apenas os gatilhos `beforeCreate` e `created` são chamados ambos, no lado do cliente e no lado do servidor. Todos os outros gatilhos são apenas chamado no lado do cliente.
 ::
 
 ```js{}[plugins/hello.js]

--- a/content/pt/docs/5.configuration-glossary/34.configuration-vue-config.md
+++ b/content/pt/docs/5.configuration-glossary/34.configuration-vue-config.md
@@ -38,4 +38,4 @@ Vue.config.silent // !isDev [valor padrão]
 Vue.config.performance // isDev [valor padrão]
 ```
 
-Para saber mais sobre a API do `Vue.config`, consulte a [documentação oficial do Vue](https://vuejs.org/v2/api/#Global-Config)
+Para saber mais sobre a API do `Vue.config`, consulte a [documentação oficial do Vue](https://v2.vuejs.org/v2/api/#Global-Config)

--- a/content/pt/docs/7.components-glossary/7.transition.md
+++ b/content/pt/docs/7.components-glossary/7.transition.md
@@ -8,7 +8,7 @@ category: components-glossary
 # A propriedade transition da página
 
 
-O Nuxt usa o componente [`<transition>`](https://vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) para permitir você criar transições ou animações incríveis entre suas páginas.
+O Nuxt usa o componente [`<transition>`](https://v2.vuejs.org/v2/guide/transitions.html#Transitioning-Single-Elements-Components) para permitir você criar transições ou animações incríveis entre suas páginas.
 
 ---
 
@@ -67,18 +67,18 @@ O objeto `transition` pode ter ass seguintes propriedades:
 | key                | Type      | Default    | definition                                                       |
 | ------------------ | --------- | ---------- | ---------------------------------------------------------------- |
 | `name`             | `String`  | `"page"`   | O nome da transição aplicado sobre todas transições de rotas.    |
-| `mode`             | `String`  | `"out-in"` | O modo de transição aplicado sobre todas rotas, consulte a [documentação do Vue.js](https://vuejs.org/v2/guide/transitions.html#Transition-Modes)                                    |
+| `mode`             | `String`  | `"out-in"` | O modo de transição aplicado sobre todas rotas, consulte a [documentação do Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Transition-Modes)                                    |
 | `css`              | `Boolean` | `true`     | Se aplicar a classes de transição de CSS. Padroniza para `true`. Se definir para `false`, apenas acionará gatilhos de JavaScript registado através dos eventos de componente.     |
-| `duration`         | `Integer` | n/a        | A duração (em milissegundos) aplicado sobre a transição, consulte a [documentação do Vue.js](https://vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).           |
+| `duration`         | `Integer` | n/a        | A duração (em milissegundos) aplicado sobre a transição, consulte a [documentação do Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Explicit-Transition-Durations).           |
 | `type`             | `String`  | n/a        | Especifica o tipo dos eventos de transição, para esperar determinar o tempo final da transição. Os valores disponíveis são `'transition'` e `'animation'`. Por padrão, ele detetará automaticamente o tipo que tiver duração mais longa.                                                    |
-| `enterClass`       | `String`  | n/a        | O estado de inicial da classe de transição (classe ou transição de entrada). Consulte a [documentação do Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                  |
-| `enterToClass`     | `String`  | n/a        | O estado final para a transição (estado final da classe ou transição de entrada). Consulte a [documentação do Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                 |
-| `enterActiveClass` | `String`  | n/a        | A classe aplicada em toda duração da transição (depois de adicionar a classe `enterClass` e antes de adicionar a classe `enterToClass`). Consulte a [documentação do Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                         |
-| `leaveClass`       | `String`  | n/a        | O estado inicial da transição (classe ou transição de saída). Consulte a [documentação do Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).      |
-| `leaveToClass`     | `String`  | n/a        | O estado final da transição (classe ou transição de saída). Consulte a [documentação do Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).      |
-| `leaveActiveClass` | `String`  | n/a        | A classe aplicada em toda duração da transição (depois de adicionar a classe `leaveClass` e antes de adicionar a classe `leaveToClass`). Consulte a [documentação do Vue.js](https://vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                         |
+| `enterClass`       | `String`  | n/a        | O estado de inicial da classe de transição (classe ou transição de entrada). Consulte a [documentação do Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                  |
+| `enterToClass`     | `String`  | n/a        | O estado final para a transição (estado final da classe ou transição de entrada). Consulte a [documentação do Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                                                                 |
+| `enterActiveClass` | `String`  | n/a        | A classe aplicada em toda duração da transição (depois de adicionar a classe `enterClass` e antes de adicionar a classe `enterToClass`). Consulte a [documentação do Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                         |
+| `leaveClass`       | `String`  | n/a        | O estado inicial da transição (classe ou transição de saída). Consulte a [documentação do Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).      |
+| `leaveToClass`     | `String`  | n/a        | O estado final da transição (classe ou transição de saída). Consulte a [documentação do Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).      |
+| `leaveActiveClass` | `String`  | n/a        | A classe aplicada em toda duração da transição (depois de adicionar a classe `leaveClass` e antes de adicionar a classe `leaveToClass`). Consulte a [documentação do Vue.js](https://v2.vuejs.org/v2/guide/transitions.html#Custom-Transition-Classes).                                         |
 
-Você pode também definir métodos dentro da propriedade `transition` da página, esses são para os [gatilhos de JavaScript](https://vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
+Você pode também definir métodos dentro da propriedade `transition` da página, esses são para os [gatilhos de JavaScript](https://v2.vuejs.org/v2/guide/transitions.html#JavaScript-Hooks):
 
 - `beforeEnter(el)`
 - `enter(el, done)`


### PR DESCRIPTION
Vue 2 docs now reside at `v2.vuejs.org/v2` instead of `vuejs.org/v2`. Omitting the subdomain redirects to the according Vue 3 pages.

This PR adjusts all links to the Vue 2 docs accordingly.