### PR TITLE
fix: nuxt ^3.2.3 print usage when no args

### DIFF
--- a/content/en/docs/1.get-started/1.installation.md
+++ b/content/en/docs/1.get-started/1.installation.md
@@ -95,7 +95,7 @@ Fill the content of your `package.json` with:
 {
   "name": "my-app",
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt dev",
     "build": "nuxt build",
     "generate": "nuxt generate",
     "start": "nuxt start"


### PR DESCRIPTION
fix: nuxt ^3.2.3 print usage when no args

> While `nuxt dev` works for `yarn dev`...
>
> `nuxt start` doesn't _(for `yarn start`)_ as it report a missing **nitro.json** file:
>
> ```plain
> yarn run v1.22.19
> $ nuxt start
> Nuxi 3.2.3
> 
>  ERROR  Cannot find nitro.json. Did you run nuxi build first? Search path:
>  [
>   '/home/salathiel/apps/umoya-tech/tools-care/tools-care-web/.output/nitro.json',
>   '/home/salathiel/apps/umoya-tech/tools-care/tools-care-web/nitro.json'
> ]