### PR TITLE
docs: update postcss config to use postcssOptions

### DIFF
--- a/content/en/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/en/docs/5.configuration-glossary/2.configuration-build.md
@@ -473,23 +473,25 @@ export default {
 
 > Customize [PostCSS Loader](https://github.com/postcss/postcss-loader#usage) plugins.
 
-- Type: `Array` (legacy, will override defaults), `Object` (recommended), `Function` or `Boolean`
+- Type: `Array` (legacy, will override defaults), `Object` (recommended),  or `Boolean`
 
-  **Note:** Nuxt has applied [PostCSS Preset Env](https://github.com/csstools/postcss-preset-env). By default it enables [Stage 2 features](https://cssdb.org/) and [Autoprefixer](https://github.com/postcss/autoprefixer), you can use `build.postcss.preset` to configure it.
+  **Note:** Nuxt has applied [PostCSS Preset Env](https://github.com/csstools/postcss-plugins/plugin-packs/postcss-preset-env). By default it enables [Stage 2 features](https://cssdb.org/#stage-2-allowable) and you can use `build.postcss.postcssOptions.preset` to configure it.
 
 - Default:
 
   ```js{}[nuxt.config.js]
   {
-    plugins: {
-      'postcss-import': {},
-      'postcss-url': {},
-      'postcss-preset-env': this.preset,
-      'cssnano': { preset: 'default' } // disabled in dev mode
-    },
-    order: 'presetEnvAndCssnanoLast',
-    preset: {
-      stage: 2
+    postcssOptions: {
+      plugins: {
+        'postcss-import': {},
+        'postcss-url': {},
+        'postcss-preset-env': this.preset,
+        'cssnano': { preset: 'default' } // disabled in dev mode
+      },
+      order: 'presetEnvAndCssnanoLast',
+      preset: {
+        stage: 2
+      }
     }
   }
   ```
@@ -500,17 +502,19 @@ Your custom plugin settings will be merged with the default plugins (unless you 
 export default {
   build: {
     postcss: {
-      plugins: {
-        // Disable `postcss-url`
-        'postcss-url': false,
-        // Add some plugins
-        'postcss-nested': {},
-        'postcss-responsive-type': {},
-        'postcss-hexrgba': {}
-      },
-      preset: {
-        autoprefixer: {
-          grid: true
+      postcssOptions: {
+        plugins: {
+          // Disable `postcss-url`
+          'postcss-url': false,
+          // Add some plugins
+          'postcss-nested': {},
+          'postcss-responsive-type': {},
+          'postcss-hexrgba': {}
+        },
+        preset: {
+          autoprefixer: {
+            grid: true
+          }
         }
       }
     }
@@ -518,7 +522,7 @@ export default {
 }
 ```
 
-If the postcss configuration is an `Object`, `order` can be used for defining the plugin order:
+If the postcss configuration is an `Object`, `postcssOptions.order` can be used for defining the plugin order:
 
 - Type: `Array` (ordered plugin names), `String` (order preset name), `Function`
 - Default: `cssnanoLast` (put `cssnano` in last)
@@ -527,12 +531,14 @@ If the postcss configuration is an `Object`, `order` can be used for defining th
 export default {
   build: {
     postcss: {
-      // preset name
-      order: 'cssnanoLast',
-      // ordered plugin names
-      order: ['postcss-import', 'postcss-preset-env', 'cssnano']
-      // Function to calculate plugin order
-      order: (names, presets) => presets.cssnanoLast(names)
+      postcssOptions: {
+        // preset name
+        order: 'cssnanoLast',
+        // ordered plugin names
+        order: ['postcss-import', 'postcss-preset-env', 'cssnano']
+        // Function to calculate plugin order
+        order: (names, presets) => presets.cssnanoLast(names)
+      }
     }
   }
 }
@@ -551,10 +557,12 @@ export default {
   // ...
   build: {
     postcss: {
-      plugins: {
-        tailwindcss: join(__dirname, 'tailwind.config.js'),
-        'postcss-pxtorem': {
-          propList: ['*', '!border*']
+      postcssOptions: {
+        plugins: {
+          tailwindcss: join(__dirname, 'tailwind.config.js'),
+          'postcss-pxtorem': {
+            propList: ['*', '!border*']
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

The `postcss` config object has been updated to use an inner `postcssOptions` in Nuxt 2.16. This PR updates the docs to move the postcss configuration to `postcssOptions`. It also updates the link to `postcss` GitHub repository.

## Linked Issue
https://github.com/nuxt/nuxt/issues/19482