### PR TITLE
Add new Mastering Nuxt top banner

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -45,7 +45,7 @@ export default withDocus({
     ],
     script: [
       {
-        src: 'https://masteringnuxt.com/banners/main.js',
+        src: 'https://masteringnuxt.com/banner.js?affiliate=nuxt&type=top',
         async: true
       }
     ],


### PR DESCRIPTION
This PR is similar to https://github.com/nuxt/nuxtjs.org/pull/2159

It adds an external script that renders the top banner of Mastering Nuxt at the top of the site. When clicked, it opens the Mastering Nuxt website in a new tab.

To quickly preview the banner on your website, you can follow these steps:

- Go to nuxtjs.org
- Open the developer toolbar
- Run the following:

```
const script = document.createElement('script');
script.type = 'text/javascript';
script.src = 'https://masteringnuxt.com/banner.js?affiliate=nuxt&type=top';    
document.head.appendChild(script);
```

That will add the script to the head and give you a live preview of how it will look when this PR gets merged.

Here's an screencast of the banner in action: https://imgur.com/a/B89zOiL

Let me know if you have comments or questions.