### PR TITLE
docs: Update google-appengine.md due to recent breaking changes in GCL

### DIFF
--- a/content/en/deployments/google-appengine.md
+++ b/content/en/deployments/google-appengine.md
@@ -49,6 +49,19 @@ env_variables:
   HOST: '0.0.0.0'
 ```
 
+inside your package.json file include `"gcp-build":""` script 
+
+```
+"scripts": {
+    "prepare": "husky install",
+    "generate": "nuxt generate",
+    "build": "nuxt generate",
+    "dev": "nuxt dev",
+    "start": "nuxt start"
+    "gcp-build":""
+  },
+```
+
 or for flexible environment the minimal configuration is:
 
 ```yaml


### PR DESCRIPTION
https://cloud.google.com/appengine/docs/standard/nodejs/release-notes since the 11 of April, you need to include `"gcp-build":""` script in your package.json if you building the app locally before deploying to GCP. Google Cloud changed its default behavior on building the repo.

If you don't include the script server returns 404 as it is unable to serve compiled files from your build dir.
